### PR TITLE
feat: Integration of ClickHouse storage

### DIFF
--- a/docarray/array/clickhouse.py
+++ b/docarray/array/clickhouse.py
@@ -1,0 +1,19 @@
+from .document import DocumentArray
+from .storage.clickhouse import StorageMixins, ClickHouseConfig
+
+__all__ = ['DocumentArrayClickHouse', 'ClickHouseConfig']
+
+
+class DocumentArrayClickHouse(StorageMixins, DocumentArray):
+    """This is a :class:`DocumentArray` that uses ClickHouse as
+    vector search engine and storage.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        """``__new__`` method for :class:`DocumentArrayClickHouse`
+
+        :param *args: list of args to instantiate the object
+        :param **kwargs: dict of args to instantiate the object
+        :return: the instantiated :class:`DocumentArrayClickHouse` object
+        """
+        return super().__new__(cls)

--- a/docarray/array/document.py
+++ b/docarray/array/document.py
@@ -10,10 +10,12 @@ if TYPE_CHECKING:
     from .annlite import DocumentArrayAnnlite
     from .weaviate import DocumentArrayWeaviate
     from .elastic import DocumentArrayElastic
+    from .clickhouse import DocumentArrayClickHouse
     from .storage.sqlite import SqliteConfig
     from .storage.annlite import AnnliteConfig
     from .storage.weaviate import WeaviateConfig
     from .storage.elastic import ElasticConfig
+    from .storage.clickhouse import ClickHouseConfig
 
 
 class DocumentArray(AllMixins, BaseDocumentArray):
@@ -64,6 +66,16 @@ class DocumentArray(AllMixins, BaseDocumentArray):
         """Create a Elastic-powered DocumentArray object."""
         ...
 
+    @overload
+    def __new__(
+        cls,
+        _docs: Optional['DocumentArraySourceType'] = None,
+        storage: str = 'clickhouse',
+        config: Optional[Union['ClickHouseConfig', Dict]] = None,
+    ) -> 'DocumentArrayClickHouse':
+        """Create a ClickHouse-powered DocumentArray object."""
+        ...
+
     def __enter__(self):
         return self
 
@@ -100,6 +112,10 @@ class DocumentArray(AllMixins, BaseDocumentArray):
                 from .elastic import DocumentArrayElastic
 
                 instance = super().__new__(DocumentArrayElastic)
+            elif storage == 'clickhouse':
+                from .clickhouse import DocumentArrayClickHouse
+
+                instance = super().__new__(DocumentArrayClickHouse)
 
             else:
                 raise ValueError(f'storage=`{storage}` is not supported.')

--- a/docarray/array/storage/clickhouse/__init__.py
+++ b/docarray/array/storage/clickhouse/__init__.py
@@ -1,0 +1,12 @@
+from abc import ABC
+
+from .backend import BackendMixin, ClickHouseConfig
+from .find import FindMixin  
+from .getsetdel import GetSetDelMixin
+from .seqlike import SequenceLikeMixin
+
+__all__ = ['StorageMixins', 'ClickHouseConfig']
+
+
+class StorageMixins(FindMixin, BackendMixin, GetSetDelMixin, SequenceLikeMixin, ABC):
+    ...

--- a/docarray/array/storage/clickhouse/__init__.py
+++ b/docarray/array/storage/clickhouse/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from .backend import BackendMixin, ClickHouseConfig
-from .find import FindMixin  
+from .find import FindMixin
 from .getsetdel import GetSetDelMixin
 from .seqlike import SequenceLikeMixin
 

--- a/docarray/array/storage/clickhouse/backend.py
+++ b/docarray/array/storage/clickhouse/backend.py
@@ -9,11 +9,9 @@ from typing import (
     Iterable,
     Mapping,
 )
+
 if TYPE_CHECKING:
-    from ....typing import (
-        DocumentArraySourceType,
-        ArrayType
-    )
+    from ....typing import DocumentArraySourceType, ArrayType
 import numpy as np
 
 import clickhouse_driver
@@ -27,8 +25,7 @@ from ....helper import random_identity, dataclass_from_dict
 def _sanitize_table_name(table_name: str) -> str:
     ret = ''.join(c for c in table_name if c.isalnum() or c == '_')
     if ret != table_name:
-        warnings.warn(
-            f'The table name is changed to {ret} due to illegal characters')
+        warnings.warn(f'The table name is changed to {ret} due to illegal characters')
     return ret
 
 
@@ -79,7 +76,7 @@ class BackendMixin(BaseBackendMixin):
         config.table_name = self._table_name
         self.n_dim = config.n_dim
         initialize_table(
-            self._table_name, self.__class__.__name__, self.schema_version,  self._client
+            self._table_name, self.__class__.__name__, self.schema_version, self._client
         )
         self._config = config
 
@@ -87,17 +84,22 @@ class BackendMixin(BaseBackendMixin):
 
         if _docs is None:
             return
-        
+
         self.clear()
-        
-        if isinstance(_docs, Iterable):   
+
+        if isinstance(_docs, Iterable):
             self.extend(_docs)
         elif isinstance(_docs, Document):
             self.append(_docs)
 
     def build_cur(self, config):
-        conn = connect(host=config.host, user=config.user,
-                       password=config.password, port=config.port, database=config.database)
+        conn = connect(
+            host=config.host,
+            user=config.user,
+            password=config.password,
+            port=config.port,
+            database=config.database,
+        )
         cursor = conn.cursor()
         return cursor
 

--- a/docarray/array/storage/clickhouse/backend.py
+++ b/docarray/array/storage/clickhouse/backend.py
@@ -12,8 +12,8 @@ from typing import (
 if TYPE_CHECKING:
     from ....typing import (
         DocumentArraySourceType,
+        ArrayType
     )
-    from ....typing import DocumentArraySourceType, ArrayType
 import numpy as np
 
 import clickhouse_driver
@@ -22,9 +22,6 @@ from clickhouse_driver import connect
 from .helper import initialize_table
 from ..base.backend import BaseBackendMixin
 from ....helper import random_identity, dataclass_from_dict
-
-if TYPE_CHECKING:
-    from ....typing import DocumentArraySourceType
 
 
 def _sanitize_table_name(table_name: str) -> str:
@@ -91,13 +88,12 @@ class BackendMixin(BaseBackendMixin):
         if _docs is None:
             return
         
-        if isinstance(_docs, Iterable):
-            self.clear()
+        self.clear()
+        
+        if isinstance(_docs, Iterable):   
             self.extend(_docs)
-        else:
-            self.clear()
-            if isinstance(_docs, Document):
-                self.append(_docs)
+        elif isinstance(_docs, Document):
+            self.append(_docs)
 
     def build_cur(self, config):
         conn = connect(host=config.host, user=config.user,

--- a/docarray/array/storage/clickhouse/backend.py
+++ b/docarray/array/storage/clickhouse/backend.py
@@ -1,0 +1,135 @@
+import warnings
+from dataclasses import dataclass, field
+from typing import (
+    Dict,
+    Optional,
+    TYPE_CHECKING,
+    Union,
+    List,
+    Iterable,
+    Mapping,
+)
+if TYPE_CHECKING:
+    from ....typing import (
+        DocumentArraySourceType,
+    )
+    from ....typing import DocumentArraySourceType, ArrayType
+import numpy as np
+
+import clickhouse_driver
+from clickhouse_driver import connect
+
+from .helper import initialize_table
+from ..base.backend import BaseBackendMixin
+from ....helper import random_identity, dataclass_from_dict
+
+if TYPE_CHECKING:
+    from ....typing import DocumentArraySourceType
+
+
+def _sanitize_table_name(table_name: str) -> str:
+    ret = ''.join(c for c in table_name if c.isalnum() or c == '_')
+    if ret != table_name:
+        warnings.warn(
+            f'The table name is changed to {ret} due to illegal characters')
+    return ret
+
+
+@dataclass
+class ClickHouseConfig:
+    n_dim: int = 768  # dims
+    host: Union[
+        str, List[Union[str, Mapping[str, Union[str, int]]]], None
+    ] = 'localhost'
+    user: str = 'default'
+    password: str = ''
+    port: int = 9000
+    database: str = ''
+    table_name: Optional[str] = None
+    serialize_config: Dict = field(default_factory=dict)
+    conn_config: Dict = field(default_factory=dict)
+
+
+class BackendMixin(BaseBackendMixin):
+    """Provide necessary functions to enable this storage backend."""
+
+    schema_version = '0'
+
+    def _init_storage(
+        self,
+        _docs: Optional['DocumentArraySourceType'] = None,
+        config: Optional[Union[ClickHouseConfig, Dict]] = None,
+        **kwargs,
+    ):
+        if not config:
+            config = ClickHouseConfig()
+
+        if isinstance(config, dict):
+            config = dataclass_from_dict(ClickHouseConfig, config)
+
+        from docarray import Document
+
+        _conn_kwargs = dict()
+        _conn_kwargs.update(config.conn_config)
+        self._client = self.build_cur(config)
+
+        self._table_name = (
+            _sanitize_table_name(self.__class__.__name__ + random_identity())
+            if config.table_name is None
+            else _sanitize_table_name(config.table_name)
+        )
+        self._persist = bool(config.table_name)
+        config.table_name = self._table_name
+        self.n_dim = config.n_dim
+        initialize_table(
+            self._table_name, self.__class__.__name__, self.schema_version,  self._client
+        )
+        self._config = config
+
+        super()._init_storage()
+
+        if _docs is None:
+            return
+        
+        if isinstance(_docs, Iterable):
+            self.clear()
+            self.extend(_docs)
+        else:
+            self.clear()
+            if isinstance(_docs, Document):
+                self.append(_docs)
+
+    def build_cur(self, config):
+        conn = connect(host=config.host, user=config.user,
+                       password=config.password, port=config.port, database=config.database)
+        cursor = conn.cursor()
+        return cursor
+
+    def __getstate__(self):
+        d = dict(self.__dict__)
+        del d['_client']
+        return d
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        _conn_kwargs = dict()
+        _conn_kwargs.update(state['_config'].conn_config)
+        self._client = self.build_cur(state['_config'])
+
+    def _map_embedding(self, embedding: 'ArrayType') -> List[float]:
+        from ....math.helper import EPSILON
+
+        if embedding is None:
+            embedding = np.zeros(self.n_dim) + EPSILON
+        else:
+            from ....math.ndarray import to_numpy_array
+
+            embedding = to_numpy_array(embedding)
+
+            if embedding.ndim > 1:
+                embedding = np.asarray(embedding).squeeze()
+
+        if np.all(embedding == 0):
+            embedding = embedding + EPSILON
+
+        return embedding.tolist()

--- a/docarray/array/storage/clickhouse/find.py
+++ b/docarray/array/storage/clickhouse/find.py
@@ -1,0 +1,84 @@
+from typing import (
+    TYPE_CHECKING,
+    TypeVar,
+    Sequence,
+    List,
+    Optional,
+    Dict,
+)
+
+import numpy as np
+
+from .... import Document, DocumentArray
+from ....math import ndarray
+from ....math.helper import EPSILON
+from ....score import NamedScore
+from ....array.mixins.find import FindMixin as BaseFindMixin
+
+if TYPE_CHECKING:
+    import tensorflow
+    import torch
+
+    CLickHouseArrayType = TypeVar(
+        'CLickHouseArrayType',
+        np.ndarray,
+        tensorflow.Tensor,
+        torch.Tensor,
+        Sequence[float],
+    )
+
+
+class FindMixin(BaseFindMixin):
+    def _find_similar_vectors(self, query: 'CLickHouseArrayType', limit=10):
+        is_all_zero = np.all(query == 0)
+        if is_all_zero:
+            query = query + EPSILON
+
+        query = query.tolist()
+
+        resp = self._fetchall(
+            f"""
+                SELECT
+                    serialized_value,
+                    embedding,
+                    L2Distance({query}, embedding)  AS dist 
+                FROM {self._table_name}
+                ORDER BY dist ASC LIMIT {limit}
+            """
+        )
+
+        da = DocumentArray()
+        for result in resp:
+            doc = Document.from_base64(result[0])
+            doc.embedding = result[1]
+            doc.scores['score'] = NamedScore(value=result[2])
+            da.append(doc)
+
+        return da
+
+    def _find(
+        self,
+        query: 'CLickHouseArrayType',
+        limit: int = 10,
+        filter: Optional[Dict] = None,
+        **kwargs,
+    ) -> List['DocumentArray']:
+        """Returns approximate nearest neighbors given a batch of input queries.
+
+        :param query: input supported to be stored in ClickHouse. This includes any from the list '[np.ndarray, tensorflow.Tensor, torch.Tensor, Sequence[float]]'
+        :param limit: number of retrieved items
+        :param filter: filter query used for pre-filtering
+
+        :return: DocumentArray containing the closest documents to the query if it is a single query, otherwise a list of DocumentArrays containing
+           the closest Document objects for each of the queries in `query`.
+        """
+        if filter is not None:
+            raise ValueError(
+                'Filtered vector search is not supported for ClickHouse backend'
+            )
+        query = np.array(query)
+        num_rows, n_dim = ndarray.get_array_rows(query)
+        if n_dim != 2:
+            query = query.reshape((num_rows, -1))
+
+        return [self._find_similar_vectors(q, limit=limit) for q in query]

--- a/docarray/array/storage/clickhouse/getsetdel.py
+++ b/docarray/array/storage/clickhouse/getsetdel.py
@@ -14,7 +14,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
             'doc_id': doc.id,
             'serialized_value': doc.to_base64(),
             'embedding': self._map_embedding(doc.embedding),
-            'text': ''
+            'text': '',
         }
 
         if doc.text:
@@ -25,7 +25,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
 
     def _del_doc_by_id(self, _id: str):
         self._client.execute(
-            f"ALTER TABLE {self._table_name} DELETE WHERE startsWith(doc_id, '{_id}') = 1")
+            f"ALTER TABLE {self._table_name} DELETE WHERE startsWith(doc_id, '{_id}') = 1"
+        )
         self._offset2ids.delete_by_id(_id)
 
     def _set_doc_by_id(self, _id: str, value: 'Document'):

--- a/docarray/array/storage/clickhouse/getsetdel.py
+++ b/docarray/array/storage/clickhouse/getsetdel.py
@@ -1,0 +1,71 @@
+from operator import itemgetter
+from typing import Dict
+
+from ..base.getsetdel import BaseGetSetDelMixin
+from ..base.helper import Offset2ID
+from .... import Document
+
+
+class GetSetDelMixin(BaseGetSetDelMixin):
+    """Implement required and derived functions that power `getitem`, `setitem`, `delitem`"""
+
+    def _document_to_ch(self, doc: 'Document') -> Dict:
+        ch_doc = {
+            'doc_id': doc.id,
+            'serialized_value': doc.to_base64(),
+            'embedding': self._map_embedding(doc.embedding),
+            'text': ''
+        }
+
+        if doc.text:
+            ch_doc['text'] = doc.text
+        return ch_doc
+
+    # essential methods start
+
+    def _del_doc_by_id(self, _id: str):
+        self._client.execute(
+            f"ALTER TABLE {self._table_name} DELETE WHERE startsWith(doc_id, '{_id}') = 1")
+        self._offset2ids.delete_by_id(_id)
+
+    def _set_doc_by_id(self, _id: str, value: 'Document'):
+        ch_doc = self._document_to_ch(value)
+
+        self._client.execute(
+            f"""
+                    ALTER TABLE {self._table_name}
+                    UPDATE doc_id= '{ch_doc['doc_id']}',
+                        serialized_value = '{ch_doc['serialized_value']}',
+                        embedding={ch_doc['embedding']},
+                        text='{ch_doc['text']}'
+                    WHERE startsWith(doc_id, '{_id}') = 1
+                """
+        )
+
+    def _get_doc_by_id(self, id: str) -> 'Document':
+        self._client.execute(
+            f"SELECT serialized_value FROM {self._table_name} WHERE startsWith(doc_id, '{id}') = 1"
+        )
+        res = self._client.fetchone()
+        if res is None:
+            raise KeyError(f'Can not find Document with id=`{id}`')
+        doc = Document.from_base64(res[0])
+        return doc
+
+    def _load_offset2ids(self):
+        self._client.execute(
+            f"SELECT doc_id FROM {self._table_name} ORDER BY item_order",
+        )
+        ids = self._client.fetchall()
+        self._offset2ids = Offset2ID(list(map(itemgetter(0), ids)))
+
+    def _save_offset2ids(self):
+        for offset, doc_id in enumerate(self._offset2ids):
+            self._client.execute(
+                f"ALTER TABLE {self._table_name} UPDATE item_order = {offset} WHERE doc_id = '{doc_id}'"
+            )
+
+    # essentials end here
+
+    def _clear_storage(self):
+        self._client.execute(f'TRUNCATE TABLE {self._table_name}')

--- a/docarray/array/storage/clickhouse/helper.py
+++ b/docarray/array/storage/clickhouse/helper.py
@@ -1,0 +1,89 @@
+import clickhouse_driver
+
+
+def initialize_table(
+    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+) -> None:
+    if not _is_metadata_table_initialized(cur):
+        _do_initialize_metadata_table(cur)
+
+    if not _is_table_initialized(table_name, container_type_name, schema_version, cur):
+        _do_create_table(table_name, cur)
+        _do_tidy_table_metadata(
+            table_name, container_type_name, schema_version, cur)
+
+
+def _is_metadata_table_initialized(cur: clickhouse_driver.dbapi.cursor.Cursor) -> bool:
+    try:
+        _ = cur.execute('SELECT 1 FROM metadata LIMIT 1')
+        return True
+    except Exception as _:
+        pass
+    return False
+
+
+def _do_initialize_metadata_table(cur: clickhouse_driver.dbapi.cursor.Cursor) -> None:
+    cur.execute(
+        '''
+        CREATE TABLE metadata
+        (
+            `table_name` TEXT NOT NULL,
+            `schema_version` TEXT NOT NULL,
+            `container_type` TEXT NOT NULL
+        )
+        ENGINE = MergeTree
+        PRIMARY KEY table_name
+        ORDER BY (table_name, container_type)
+        '''
+    )
+
+
+def _do_create_table(
+    table_name: str,
+    cur: clickhouse_driver.dbapi.cursor.Cursor,
+) -> None:
+    cur.execute(
+        f'''
+        CREATE TABLE IF NOT EXISTS {table_name}
+        (
+            `doc_id` TEXT NOT NULL,
+            `serialized_value` BLOB NOT NULL,
+            `embedding` Array(Float32) NOT NULL,
+            `text` String,
+            `item_order` INTEGER,
+            `indx` INTEGER
+        )
+        ENGINE = MergeTree
+        ORDER BY indx
+        '''
+    )
+
+
+def _is_table_initialized(
+    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+) -> bool:
+    try:
+        cur.execute(
+            'SELECT schema_version FROM metadata WHERE table_name=? AND container_type=?',
+            (table_name, container_type_name),
+        )
+        buf = cur.fetchone()
+        if buf is None:
+            return False
+        version = buf[0]
+        if version != schema_version:
+            return False
+        cur.execute(f'SELECT 1 FROM {table_name} LIMIT 1')
+        _ = list(cur)
+        return True
+    except Exception as _:
+        pass
+    return False
+
+
+def _do_tidy_table_metadata(
+    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+) -> None:
+    cur.execute(
+        f"INSERT INTO metadata VALUES ('{table_name}', '{schema_version}', '{container_type_name}')"
+    )

--- a/docarray/array/storage/clickhouse/helper.py
+++ b/docarray/array/storage/clickhouse/helper.py
@@ -2,15 +2,17 @@ import clickhouse_driver
 
 
 def initialize_table(
-    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+    table_name: str,
+    container_type_name: str,
+    schema_version: str,
+    cur: clickhouse_driver.dbapi.cursor.Cursor,
 ) -> None:
     if not _is_metadata_table_initialized(cur):
         _do_initialize_metadata_table(cur)
 
     if not _is_table_initialized(table_name, container_type_name, schema_version, cur):
         _do_create_table(table_name, cur)
-        _do_tidy_table_metadata(
-            table_name, container_type_name, schema_version, cur)
+        _do_tidy_table_metadata(table_name, container_type_name, schema_version, cur)
 
 
 def _is_metadata_table_initialized(cur: clickhouse_driver.dbapi.cursor.Cursor) -> bool:
@@ -60,7 +62,10 @@ def _do_create_table(
 
 
 def _is_table_initialized(
-    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+    table_name: str,
+    container_type_name: str,
+    schema_version: str,
+    cur: clickhouse_driver.dbapi.cursor.Cursor,
 ) -> bool:
     try:
         cur.execute(
@@ -82,7 +87,10 @@ def _is_table_initialized(
 
 
 def _do_tidy_table_metadata(
-    table_name: str, container_type_name: str, schema_version: str, cur: clickhouse_driver.dbapi.cursor.Cursor
+    table_name: str,
+    container_type_name: str,
+    schema_version: str,
+    cur: clickhouse_driver.dbapi.cursor.Cursor,
 ) -> None:
     cur.execute(
         f"INSERT INTO metadata VALUES ('{table_name}', '{schema_version}', '{container_type_name}')"

--- a/docarray/array/storage/clickhouse/seqlike.py
+++ b/docarray/array/storage/clickhouse/seqlike.py
@@ -1,0 +1,124 @@
+from typing import Union, Optional, Iterable
+
+from ..base.seqlike import BaseSequenceLikeMixin
+from .... import Document
+
+
+class SequenceLikeMixin(BaseSequenceLikeMixin):
+    """Implement sequence-like methods"""
+
+    def _insert_doc_at_idx(self, doc, idx: Optional[int] = None):
+        ch_doc = self._document_to_ch(doc)
+        if idx is None:
+            idx = len(self)
+        self._client.execute(
+            f"""
+                INSERT INTO {self._table_name}
+                VALUES
+                    ('{ch_doc['doc_id']}',
+                     '{ch_doc['serialized_value']}',
+                      {ch_doc['embedding']},
+                     '{ch_doc['text']}',
+                     '{idx}', '{idx}')
+            """
+        )
+        self._offset2ids.insert(idx, doc.id)
+
+    def _shift_index_right_backward(self, start: int):
+        idx = len(self) - 1
+        while idx >= start:
+            self._client.execute(
+                f"""
+                    ALTER TABLE {self._table_name}
+                    UPDATE item_order = {idx+1}
+                    WHERE item_order = {idx}
+                """
+            )
+            idx -= 1
+
+    def insert(self, index: int, value: 'Document'):
+        """Insert `doc` at `index`.
+
+        :param index: Position of the insertion.
+        :param value: The doc needs to be inserted.
+        """
+        length = len(self)
+        if index < 0:
+            index = length + index
+        index = max(0, min(length, index))
+        self._shift_index_right_backward(index)
+        self._insert_doc_at_idx(doc=value, idx=index)
+
+    def append(self, doc: 'Document') -> None:
+        ch_doc = self._document_to_ch(doc)
+        self._client.execute(
+            f"""
+                INSERT INTO {self._table_name}
+                VALUES
+                    ('{ch_doc['doc_id']}',
+                    '{ch_doc['serialized_value']}',
+                     {ch_doc['embedding']},
+                    '{ch_doc['text']}',
+                    '{len(self)}', '{len(self)}')
+            """
+        )
+        self._offset2ids.append(doc.id)
+
+    def __del__(self) -> None:
+        super().__del__()
+        if not self._persist:
+            self._client.execute(
+                f"""
+                    ALTER TABLE metadata
+                    DELETE
+                    WHERE table_name={self._table_name}
+                    AND container_type={self.__class__.__name__}
+                """
+            )
+            self._client.execute(f'DROP TABLE IF EXISTS {self._table_name}')
+
+    def __contains__(self, item: Union[str, 'Document']):
+        if isinstance(item, str):
+            self._client.execute(
+                    f"SELECT 1 FROM {self._table_name} WHERE startsWith(doc_id, '{item}') = 1")
+            r = self._client.fetchall()
+            return len(list(r)) > 0
+        elif isinstance(item, Document):
+            return item.id in self  # fall back to str check
+        else:
+            return False
+
+    def __len__(self) -> int:
+        # for _ in range(10):
+        request = self._client.execute(
+            f'SELECT COUNT(*) FROM {self._table_name}')
+        request = self._client.fetchone()
+        return request[0]
+
+    def __repr__(self):
+        return f'<DocumentArray[ClickHouse] (length={len(self)}) at {id(self)}>'
+
+    def __eq__(self, other):
+        """In ClockHouse backend, data are considered as identical if configs point to the same database source"""
+        return (
+            type(self) is type(other)
+            and type(self._config) is type(other._config)
+            and self._config == other._config
+        )
+
+    def extend(self, docs: Iterable['Document']) -> None:
+
+        self_len = len(self)
+        ch_docs = []
+        for doc in docs:
+            ch_doc = self._document_to_ch(doc)
+            ch_doc['item_order'] = self_len
+            ch_doc['indx'] = self_len
+            ch_docs.append(ch_doc)
+
+            self._offset2ids.append(doc.id)
+            self_len += 1
+
+        self._client.execute(
+            f"INSERT INTO {self._table_name} VALUES", ch_docs
+        )

--- a/docarray/array/storage/clickhouse/seqlike.py
+++ b/docarray/array/storage/clickhouse/seqlike.py
@@ -80,7 +80,8 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     def __contains__(self, item: Union[str, 'Document']):
         if isinstance(item, str):
             self._client.execute(
-                    f"SELECT 1 FROM {self._table_name} WHERE startsWith(doc_id, '{item}') = 1")
+                f"SELECT 1 FROM {self._table_name} WHERE startsWith(doc_id, '{item}') = 1"
+            )
             r = self._client.fetchall()
             return len(list(r)) > 0
         elif isinstance(item, Document):
@@ -90,8 +91,7 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
     def __len__(self) -> int:
         # for _ in range(10):
-        request = self._client.execute(
-            f'SELECT COUNT(*) FROM {self._table_name}')
+        request = self._client.execute(f'SELECT COUNT(*) FROM {self._table_name}')
         request = self._client.fetchone()
         return request[0]
 
@@ -119,6 +119,4 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             self._offset2ids.append(doc.id)
             self_len += 1
 
-        self._client.execute(
-            f"INSERT INTO {self._table_name} VALUES", ch_docs
-        )
+        self._client.execute(f"INSERT INTO {self._table_name} VALUES", ch_docs)

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -6,6 +6,7 @@ from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.annlite import AnnliteConfig
 from docarray.array.qdrant import QdrantConfig
 from docarray.array.elastic import ElasticConfig
+from docarray.array.clickhouse import ClickHouseConfig
 
 
 @pytest.fixture
@@ -27,6 +28,7 @@ def indices():
         ('annlite', AnnliteConfig(n_dim=123)),
         ('qdrant', QdrantConfig(n_dim=123)),
         ('elasticsearch', ElasticConfig(n_dim=123)),
+        ('clickhouse', ClickHouseConfig(n_dim=123)),
     ],
 )
 def test_getter_int_str(docs, storage, config, start_storage):
@@ -276,6 +278,7 @@ def test_sequence_str(docs, storage, config, start_storage):
         ('annlite', AnnliteConfig(n_dim=123)),
         ('qdrant', QdrantConfig(n_dim=123)),
         ('elasticsearch', ElasticConfig(n_dim=123)),
+        ('clickhouse', ClickHouseConfig(n_dim=123)),
     ],
 )
 def test_docarray_list_tuple(docs, storage, config, start_storage):
@@ -502,10 +505,10 @@ def test_advance_selector_mixed(storage):
 
 
 @pytest.mark.parametrize(
-    'storage', ['memory', 'sqlite', 'weaviate', 'annlite', 'qdrant', 'elasticsearch']
+    'storage', ['memory', 'sqlite', 'weaviate', 'annlite', 'qdrant', 'elasticsearch', 'clickhouse']
 )
 def test_single_boolean_and_padding(storage, start_storage):
-    if storage in ('annlite', 'weaviate', 'qdrant', 'elasticsearch'):
+    if storage in ('annlite', 'weaviate', 'qdrant', 'elasticsearch', 'clickhouse'):
         da = DocumentArray(storage=storage, config={'n_dim': 10})
     else:
         da = DocumentArray(storage=storage)

--- a/tests/unit/array/test_advance_indexing.py
+++ b/tests/unit/array/test_advance_indexing.py
@@ -505,7 +505,16 @@ def test_advance_selector_mixed(storage):
 
 
 @pytest.mark.parametrize(
-    'storage', ['memory', 'sqlite', 'weaviate', 'annlite', 'qdrant', 'elasticsearch', 'clickhouse']
+    'storage',
+    [
+        'memory',
+        'sqlite',
+        'weaviate',
+        'annlite',
+        'qdrant',
+        'elasticsearch',
+        'clickhouse',
+    ],
 )
 def test_single_boolean_and_padding(storage, start_storage):
     if storage in ('annlite', 'weaviate', 'qdrant', 'elasticsearch', 'clickhouse'):

--- a/tests/unit/array/test_construct.py
+++ b/tests/unit/array/test_construct.py
@@ -9,6 +9,7 @@ from docarray.array.annlite import DocumentArrayAnnlite, AnnliteConfig
 from docarray.array.storage.qdrant import QdrantConfig
 from docarray.array.weaviate import DocumentArrayWeaviate, WeaviateConfig
 from docarray.array.elastic import DocumentArrayElastic, ElasticConfig
+from docarray.array.clickhouse import DocumentArrayClickHouse, ClickHouseConfig
 
 
 @pytest.mark.parametrize(
@@ -20,6 +21,7 @@ from docarray.array.elastic import DocumentArrayElastic, ElasticConfig
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
         (DocumentArrayQdrant, QdrantConfig(n_dim=128)),
         (DocumentArrayElastic, ElasticConfig(n_dim=128)),
+        (DocumentArrayClickHouse, ClickHouseConfig(n_dim=128)),
     ],
 )
 def test_construct_docarray(da_cls, config, start_storage):
@@ -68,6 +70,7 @@ def test_construct_docarray(da_cls, config, start_storage):
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
         (DocumentArrayQdrant, QdrantConfig(n_dim=128)),
         (DocumentArrayElastic, ElasticConfig(n_dim=128)),
+        (DocumentArrayClickHouse, ClickHouseConfig(n_dim=128)),
     ],
 )
 @pytest.mark.parametrize('is_copy', [True, False])
@@ -97,6 +100,7 @@ def test_docarray_copy_singleton(da_cls, config, is_copy, start_storage):
         (DocumentArrayWeaviate, WeaviateConfig(n_dim=128)),
         (DocumentArrayQdrant, QdrantConfig(n_dim=128)),
         (DocumentArrayElastic, ElasticConfig(n_dim=128)),
+        (DocumentArrayClickHouse, ClickHouseConfig(n_dim=128)),
     ],
 )
 @pytest.mark.parametrize('is_copy', [True, False])
@@ -125,6 +129,7 @@ def test_docarray_copy_da(da_cls, config, is_copy, start_storage):
         (DocumentArrayAnnlite, AnnliteConfig(n_dim=1)),
         (DocumentArrayQdrant, QdrantConfig(n_dim=1)),
         (DocumentArrayElastic, ElasticConfig(n_dim=128)),
+        (DocumentArrayClickHouse, ClickHouseConfig(n_dim=128)),
     ],
 )
 @pytest.mark.parametrize('is_copy', [True, False])

--- a/tests/unit/array/test_sequence.py
+++ b/tests/unit/array/test_sequence.py
@@ -10,9 +10,11 @@ from docarray.array.sqlite import DocumentArraySqlite
 from docarray.array.storage.sqlite import SqliteConfig
 from docarray.array.weaviate import DocumentArrayWeaviate
 from docarray.array.elastic import DocumentArrayElastic
+from docarray.array.clickhouse import DocumentArrayClickHouse
 from docarray.array.storage.qdrant import QdrantConfig
 from docarray.array.storage.weaviate import WeaviateConfig
 from docarray.array.storage.elastic import ElasticConfig
+from docarray.array.storage.clickhouse import ClickHouseConfig
 import numpy as np
 
 from tests.conftest import tmpfile
@@ -26,6 +28,7 @@ from tests.conftest import tmpfile
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=1)),
         (DocumentArrayQdrant, lambda: QdrantConfig(n_dim=1)),
         (DocumentArrayElastic, lambda: ElasticConfig(n_dim=1)),
+        (DocumentArrayClickHouse, lambda: ClickHouseConfig(n_dim=1)),
     ],
 )
 def test_insert(da_cls, config, start_storage):
@@ -48,6 +51,7 @@ def test_insert(da_cls, config, start_storage):
         (DocumentArrayWeaviate, lambda: WeaviateConfig(n_dim=1)),
         (DocumentArrayQdrant, lambda: QdrantConfig(n_dim=1)),
         (DocumentArrayElastic, lambda: ElasticConfig(n_dim=1)),
+        (DocumentArrayClickHouse, lambda: ClickHouseConfig(n_dim=1)),
     ],
 )
 def test_append_extend(da_cls, config, start_storage):
@@ -81,6 +85,7 @@ def update_config_inplace(config, tmpdir, tmpfile):
         ('weaviate', {'n_dim': 3, 'name': 'Weaviate'}),
         ('qdrant', {'n_dim': 3, 'collection_name': 'qdrant'}),
         ('elasticsearch', {'n_dim': 3, 'index_name': 'elasticsearch'}),
+        ('clickhouse', {'n_dim': 3, 'table_name': 'Test'}),
     ],
 )
 def test_context_manager_from_disk(storage, config, start_storage, tmpdir, tmpfile):


### PR DESCRIPTION
Goals:

ClickHouse allows quick insertion and searches over a large quantity of data. We use Clickhouse internally for search over a large corpus of embeddings.
As Docarray provide a great pythonic API to manipulate unstructured data we decided to integrate it with CLickHouse for our internal needs.
But I hope this PR will be also valuable for other engineers.

Empirically all functionality of Docarray works properly with ClickHouse. But ClickHouse is not transactional DB, therefore it does not provide atomicity of operations. 
Because of this many tests in tests/unit/array/test_advance_indexing.py do not pass for now. I'm looking for a way how to overcome this.

