### PR TITLE
fix: keep docs text attr after calling load_uri_to_cloud_point_tensor

### DIFF
--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -274,3 +274,17 @@ def test_glb_converters(uri, chunk_num):
     doc.load_uri_to_point_cloud_tensor(2000, as_chunks=True)
     assert len(doc.chunks) == chunk_num
     assert doc.chunks[0].tensor.shape == (2000, 3)
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        os.path.join(cur_dir, 'toydata/test.glb'),
+        'https://github.com/jina-ai/docarray/raw/main/tests/unit/document/toydata/test.glb',
+    ],
+)
+def test_glb_not_removing_docs_text_attribute(uri):
+    doc = Document(uri=uri, text='hello')
+    doc.load_uri_to_point_cloud_tensor(2000)
+
+    assert doc.text == 'hello'


### PR DESCRIPTION
Goals:

- Currently, a documents `text` attribute disappears after calling `load_uri_to_point_cloud_tensor` on the Document instance, and one can no longer access it. This has been described in the following issue: https://github.com/jina-ai/docarray/issues/678
- We therefore want to ensure that a documents text attribute is not being removed after calling this method on the Document instance.
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
