### PR TITLE
feat: add flag to disable list-like structure in DocArray

### DIFF
--- a/docarray/array/storage/annlite/backend.py
+++ b/docarray/array/storage/annlite/backend.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class AnnliteConfig:
     n_dim: int
     metric: str = 'cosine'
+    list_like: bool = True
     serialize_config: Dict = field(default_factory=dict)
     data_path: Optional[str] = None
     ef_construction: Optional[int] = None
@@ -98,7 +99,7 @@ class BackendMixin(BaseBackendMixin):
         self._config.columns = self._normalize_columns(self._config.columns)
         config = asdict(config)
         self.n_dim = config.pop('n_dim')
-
+        self._list_like = config.pop("list_like")
         from annlite import AnnLite
 
         self._annlite = AnnLite(self.n_dim, lock=False, **filter_dict(config))

--- a/docarray/array/storage/annlite/getsetdel.py
+++ b/docarray/array/storage/annlite/getsetdel.py
@@ -46,15 +46,25 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._annlite.close()
 
     def _load_offset2ids(self):
-        self._offsetmapping = OffsetMapping(
-            data_path=self._config.data_path, in_memory=False
-        )
-        self._offsetmapping.create_table()
-        self._offset2ids = Offset2ID(self._offsetmapping.get_all_ids())
+        if self._list_like:
+            self._offsetmapping = OffsetMapping(
+                data_path=self._config.data_path, in_memory=False
+            )
+            self._offsetmapping.create_table()
+            self._offset2ids = Offset2ID(
+                self._offsetmapping.get_all_ids(),
+                list_like=self._list_like,
+            )
+        else:
+            self._offset2ids = Offset2ID(
+                [],
+                list_like=self._list_like,
+            )
 
     def _save_offset2ids(self):
-        self._offsetmapping.drop()
-        self._offsetmapping.create_table()
-        self._offsetmapping._insert(
-            [(i, doc_id) for i, doc_id in enumerate(self._offset2ids.ids)]
-        )
+        if self._list_like:
+            self._offsetmapping.drop()
+            self._offsetmapping.create_table()
+            self._offsetmapping._insert(
+                [(i, doc_id) for i, doc_id in enumerate(self._offset2ids.ids)]
+            )

--- a/docarray/array/storage/base/getsetdel.py
+++ b/docarray/array/storage/base/getsetdel.py
@@ -129,7 +129,7 @@ class BaseGetSetDelMixin(ABC):
     def _del_all_docs(self):
         self._clear_subindices()
         self._clear_storage()
-        self._offset2ids = Offset2ID()
+        self._offset2ids = Offset2ID(list_like=self._list_like)
 
     def _del_docs_by_ids(self, ids):
         """This function is derived from :meth:`_del_doc_by_id`

--- a/docarray/array/storage/base/helper.py
+++ b/docarray/array/storage/base/helper.py
@@ -2,44 +2,64 @@ from typing import Iterator, Dict
 
 
 class Offset2ID:
-    def __init__(self, ids=None):
+    def __init__(self, ids=None, list_like=True):
         self.ids = ids or []
+        self._list_like = list_like
 
     def get_id(self, idx):
+        if not self._list_like:
+            raise ValueError(
+                "The offset2id is not enabled for list-like indexes. To avoid this error, configure the "
+                "`list_like` to True"
+            )
         return self.ids[idx]
 
     def append(self, data):
-        self.ids.append(data)
+        if self._list_like:
+            self.ids.append(data)
 
     def extend(self, data):
-        self.ids.extend(data)
+        if self._list_like:
+            self.ids.extend(data)
 
     def update(self, position, data_id):
-        self.ids[position] = data_id
+        if self._list_like:
+            self.ids[position] = data_id
 
     def delete_by_id(self, _id):
-        del self.ids[self.ids.index(_id)]
+        if self._list_like:
+            del self.ids[self.ids.index(_id)]
 
     def index(self, _id):
+        if not self._list_like:
+            raise ValueError(
+                "The offset2id is not enabled for list-like indexes. To avoid this error, configure the "
+                "`list_like` to True"
+            )
         return self.ids.index(_id)
 
     def delete_by_offset(self, position):
-        del self.ids[position]
+        if self._list_like:
+            del self.ids[position]
 
     def insert(self, position, data_id):
-        self.ids.insert(position, data_id)
+        if self._list_like:
+            self.ids.insert(position, data_id)
 
     def clear(self):
-        self.ids.clear()
+        if self._list_like:
+            self.ids.clear()
 
     def delete_by_ids(self, ids):
-        ids = set(ids)
-        self.ids = list(filter(lambda _id: _id not in ids, self.ids))
+        if self._list_like:
+            ids = set(ids)
+            self.ids = list(filter(lambda _id: _id not in ids, self.ids))
 
     def update_ids(self, _ids_map: Dict[str, str]):
-        for i in range(len(self.ids)):
-            if self.ids[i] in _ids_map:
-                self.ids[i] = _ids_map[self.ids[i]]
+        if self._list_like:
+            for i in range(len(self.ids)):
+                if self.ids[i] in _ids_map:
+                    self.ids[i] = _ids_map[self.ids[i]]
 
     def save(self):
         pass

--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -38,6 +38,7 @@ class ElasticConfig:
         str, List[Union[str, Mapping[str, Union[str, int]]]], None
     ] = 'http://localhost:9200'
     index_name: Optional[str] = None
+    list_like: bool = True
     es_config: Dict[str, Any] = field(default_factory=dict)
     index_text: bool = False
     tag_indices: List[str] = field(default_factory=list)
@@ -93,6 +94,7 @@ class BackendMixin(BaseBackendMixin):
 
         self.n_dim = self._config.n_dim
         self._client = self._build_client()
+        self._list_like = self._config.list_like
         self._build_offset2id_index()
 
         # Note super()._init_storage() calls _load_offset2ids which calls _get_offset2ids_meta

--- a/docarray/array/storage/elastic/getsetdel.py
+++ b/docarray/array/storage/elastic/getsetdel.py
@@ -123,8 +123,12 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._client.indices.delete(index=self._config.index_name)
 
     def _load_offset2ids(self):
-        ids = self._get_offset2ids_meta()
-        self._offset2ids = Offset2ID(ids)
+        if self._list_like:
+            ids = self._get_offset2ids_meta()
+            self._offset2ids = Offset2ID(ids, list_like=self._list_like)
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
-        self._update_offset2ids_meta()
+        if self._list_like:
+            self._update_offset2ids_meta()

--- a/docarray/array/storage/elastic/seqlike.py
+++ b/docarray/array/storage/elastic/seqlike.py
@@ -87,9 +87,14 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     def _extend(self, docs: Iterable['Document'], **kwargs):
         docs = list(docs)
         successful_indexed_ids = self._upload_batch(docs, **kwargs)
-        self._offset2ids.extend(
-            [_id for _id in successful_indexed_ids if _id not in self._offset2ids.ids]
-        )
+        if self._list_like:
+            self._offset2ids.extend(
+                [
+                    _id
+                    for _id in successful_indexed_ids
+                    if _id not in self._offset2ids.ids
+                ]
+            )
 
         if len(successful_indexed_ids) != len(docs):
             doc_ids = [doc.id for doc in docs]

--- a/docarray/array/storage/qdrant/backend.py
+++ b/docarray/array/storage/qdrant/backend.py
@@ -38,6 +38,7 @@ class QdrantConfig:
     n_dim: int
     distance: str = 'cosine'
     collection_name: Optional[str] = None
+    list_like: bool = True
     host: Optional[str] = field(default="localhost")
     port: Optional[int] = field(default=6333)
     grpc_port: Optional[int] = field(default=6334)
@@ -116,7 +117,7 @@ class BackendMixin(BaseBackendMixin):
         )
 
         self._config = config
-
+        self._list_like = config.list_like
         self._config.columns = self._normalize_columns(self._config.columns)
 
         self._config.collection_name = (

--- a/docarray/array/storage/qdrant/getsetdel.py
+++ b/docarray/array/storage/qdrant/getsetdel.py
@@ -123,11 +123,15 @@ class GetSetDelMixin(BaseGetSetDelMixin):
                 break
 
     def _load_offset2ids(self):
-        ids = self._get_offset2ids_meta()
-        self._offset2ids = Offset2ID(ids)
+        if self._list_like:
+            ids = self._get_offset2ids_meta()
+            self._offset2ids = Offset2ID(ids, list_like=self._list_like)
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
-        self._update_offset2ids_meta()
+        if self._list_like:
+            self._update_offset2ids_meta()
 
     def _clear_storage(self):
         self.client.recreate_collection(

--- a/docarray/array/storage/redis/backend.py
+++ b/docarray/array/storage/redis/backend.py
@@ -21,6 +21,7 @@ class RedisConfig:
     host: str = field(default='localhost')
     port: int = field(default=6379)
     index_name: Optional[str] = None
+    list_like: bool = True
     update_schema: bool = field(default=True)
     distance: str = field(default='COSINE')
     redis_config: Dict[str, Any] = field(default_factory=dict)
@@ -79,6 +80,7 @@ class BackendMixin(BaseBackendMixin):
         self._offset2id_key = config.index_name + '__offset2id'
         self._config = config
         self.n_dim = self._config.n_dim
+        self._list_like = config.list_like
         self._doc_prefix = config.index_name + ':'
         self._config.columns = self._normalize_columns(self._config.columns)
 

--- a/docarray/array/storage/redis/getsetdel.py
+++ b/docarray/array/storage/redis/getsetdel.py
@@ -111,11 +111,15 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         return payload
 
     def _load_offset2ids(self):
-        ids = self._get_offset2ids_meta()
-        self._offset2ids = Offset2ID(ids)
+        if self._list_like:
+            ids = self._get_offset2ids_meta()
+            self._offset2ids = Offset2ID(ids, list_like=self._list_like)
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
-        self._update_offset2ids_meta()
+        if self._list_like:
+            self._update_offset2ids_meta()
 
     def _clear_storage(self):
         self._client.ft(index_name=self._config.index_name).dropindex(

--- a/docarray/array/storage/redis/seqlike.py
+++ b/docarray/array/storage/redis/seqlike.py
@@ -61,4 +61,5 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
         da = DocumentArray(docs)
         for batch_of_docs in da.batch(self._config.batch_size):
             self._upload_batch(batch_of_docs)
-            self._offset2ids.extend(batch_of_docs[:, 'id'])
+            if self._list_like:
+                self._offset2ids.extend(batch_of_docs[:, 'id'])

--- a/docarray/array/storage/sqlite/backend.py
+++ b/docarray/array/storage/sqlite/backend.py
@@ -24,6 +24,7 @@ def _sanitize_table_name(table_name: str, raise_warning=True) -> str:
 class SqliteConfig:
     connection: Optional[Union[str, 'sqlite3.Connection']] = None
     table_name: Optional[str] = None
+    list_like: bool = True
     serialize_config: Dict = field(default_factory=dict)
     conn_config: Dict = field(default_factory=dict)
     journal_mode: str = 'WAL'
@@ -99,7 +100,7 @@ class BackendMixin(BaseBackendMixin):
         )
         self._connection.commit()
         self._config = config
-
+        self._list_like = config.list_like
         super()._init_storage()
 
         if _docs is None:

--- a/docarray/array/storage/sqlite/getsetdel.py
+++ b/docarray/array/storage/sqlite/getsetdel.py
@@ -52,20 +52,26 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._commit()
 
     def _load_offset2ids(self):
-        r = self._sql(
-            f"SELECT doc_id FROM {self._table_name} ORDER BY item_order",
-        )
-        self._offset2ids = Offset2ID(list(map(itemgetter(0), r)))
+        if self._list_like:
+            r = self._sql(
+                f"SELECT doc_id FROM {self._table_name} ORDER BY item_order",
+            )
+            self._offset2ids = Offset2ID(
+                list(map(itemgetter(0), r)), list_like=self._list_like
+            )
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
-        for offset, doc_id in enumerate(self._offset2ids):
-            self._sql(
-                f"""
-                    UPDATE {self._table_name} SET item_order = ? WHERE {self._table_name}.doc_id = ?
-                """,
-                (offset, doc_id),
-            )
-        self._commit()
+        if self._list_like:
+            for offset, doc_id in enumerate(self._offset2ids):
+                self._sql(
+                    f"""
+                        UPDATE {self._table_name} SET item_order = ? WHERE {self._table_name}.doc_id = ?
+                    """,
+                    (offset, doc_id),
+                )
+            self._commit()
 
     def _del_docs(self, ids):
         super()._del_docs(ids)

--- a/docarray/array/storage/weaviate/backend.py
+++ b/docarray/array/storage/weaviate/backend.py
@@ -32,6 +32,7 @@ class WeaviateConfig:
     port: Optional[int] = field(default=8080)
     protocol: Optional[str] = field(default='http')
     name: Optional[str] = None
+    list_like: bool = True
     serialize_config: Dict = field(default_factory=dict)
     n_dim: Optional[int] = None  # deprecated, not used anymore since weaviate 1.10
     # vectorIndexConfig parameters
@@ -128,7 +129,7 @@ class BackendMixin(BaseBackendMixin):
         self._config.columns = self._normalize_columns(self._config.columns)
 
         self._schemas = self._load_or_create_weaviate_schema()
-
+        self._list_like = config.list_like
         _REGISTRY[self.__class__.__name__][self._class_name].append(self)
 
         super()._init_storage(_docs, **kwargs)

--- a/docarray/array/storage/weaviate/getsetdel.py
+++ b/docarray/array/storage/weaviate/getsetdel.py
@@ -77,8 +77,12 @@ class GetSetDelMixin(BaseGetSetDelMixin):
             self._load_or_create_weaviate_schema()
 
     def _load_offset2ids(self):
-        ids, self._offset2ids_wid = self._get_offset2ids_meta()
-        self._offset2ids = Offset2ID(ids)
+        if self._list_like:
+            ids, self._offset2ids_wid = self._get_offset2ids_meta()
+            self._offset2ids = Offset2ID(ids, list_like=self._list_like)
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
-        self._update_offset2ids_meta()
+        if self._list_like:
+            self._update_offset2ids_meta()

--- a/docs/advanced/document-store/index.md
+++ b/docs/advanced/document-store/index.md
@@ -564,6 +564,42 @@ The solution is simple: use {ref}`column-selector<bulk-access>`:
 da[0, 'text'] = 'hello'
 ```
 
+### Performance Issue caused by List-like structure
+DocArray allows list-like behavior by adding an offset-to-id mapping structure to storage backends. Such feature (adding this structure) means the database stores, 
+along with documents, meta information about document order.
+However, list_like behavior is not useful in indexers where concurrent usage is possible and users do not need information about document location. 
+Besides, updating list-like operation comes with a cost.
+You can disable list-like behavior in the config as follows
+```python
+from docarray import DocumentArray
+
+da = DocumentArray(storage='annlite', config={'n_dim': 2, 'list_like': False})
+```
+
+When list_like is disabled, all the list-like operations will not be allowed and raise errors.
+like this:
+```python
+from docarray import DocumentArray, Document
+import numpy as np
+
+
+def docs():
+    d1 = Document(embedding=np.array([10, 0]))
+    d2 = Document(embedding=np.array([0, 10]))
+    d3 = Document(embedding=np.array([-10, -10]))
+    yield d1, d2, d3
+
+
+da = DocumentArray(docs, storage='annlite', config={'n_dim': 2, 'list_like': False})
+da[0]  # This will raise an error.
+```
+
+```{admonition} Hint
+By default, `list_like` will be true.
+```
+
+
+
 ### Elements access is slower
 
 Obviously, a DocumentArray with on-disk storage is slower than in-memory DocumentArray. However, if you choose to use on-disk storage, then often your concern of persistence overwhelms the concern of efficiency.

--- a/tests/unit/document/test_disable_offset2id.py
+++ b/tests/unit/document/test_disable_offset2id.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from docarray import DocumentArray, Document
+from docarray.array.storage.base.helper import Offset2ID
+
+
+@pytest.fixture(scope='function')
+def docs():
+    d1 = Document(embedding=np.array([10, 0]))
+    d2 = Document(embedding=np.array([0, 10]))
+    d3 = Document(embedding=np.array([-10, -10]))
+    yield d1, d2, d3
+
+
+@pytest.mark.parametrize(
+    'storage,config',
+    [
+        ('weaviate', {'n_dim': 2, 'list_like': False}),
+        ('annlite', {'n_dim': 2, 'list_like': False}),
+        ('qdrant', {'n_dim': 2, 'list_like': False}),
+        ('elasticsearch', {'n_dim': 2, 'list_like': False}),
+        ('redis', {'n_dim': 2, 'list_like': False}),
+    ],
+)
+def test_disable_offset2id(docs, storage, config, start_storage):
+    if config:
+        da = DocumentArray(docs, storage=storage, config=config)
+    else:
+        da = DocumentArray(docs, storage=storage)
+
+    with pytest.raises(ValueError):
+        da[0]
+
+
+def test_offset2ids(docs, start_storage):
+    list_like = False
+    ids = [str(i) for i in range(3)]
+    offset2id = Offset2ID(ids, list_like)
+    len_before = len(offset2id)
+    offset2id.append("4")
+    len_after = len(offset2id)
+    assert len_before == len_after
+
+    len_before = len(offset2id)
+    offset2id.extend("4")
+    len_after = len(offset2id)
+    assert len_before == len_after
+
+    len_before = len(offset2id)
+    offset2id.delete_by_ids("3")
+    len_after = len(offset2id)
+    assert len_before == len_after
+
+    with pytest.raises(ValueError):
+        offset2id.index(2)
+    with pytest.raises(ValueError):
+        offset2id.get_id("2")


### PR DESCRIPTION
Goals:

- ...
- ...DocArray allows list-like behavior by adding offset2id structure to storage backends. This means the database stores, along with documents, meta information about document order.
This information is only updated/synced when a DA is destroyed or quit the context manager. Furthermore, offset2id is updated in memory in all update operations.
However, offset2id is not useful in indexers where concurrent usage is possible and users do not need information about document location. Besides, updating offset2id is not efficient.
Therefore, it's important to have an option that disables list-like behavior (and offset2id with it) and use it in DocumentArray indexers.
```python
@dataclass
class QdrantConfig:
    n_dim: int
    distance: str = 'cosine'
    list_like: bool = True
    collection_name: Optional[str] = None
    host: Optional[str] = field(default="localhost")
    port: Optional[int] = field(default=6333)
    serialize_config: Dict = field(default_factory=dict)
    scroll_batch_size: int = 64
    ef_construct: Optional[int] = None
    full_scan_threshold: Optional[int] = None
    m: Optional[int] = None
    columns: Optional[Union[List[Tuple[str, str]], Dict[str, str]]] = None
```

- ...
- ...
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
