### PR TITLE
chore: allow test to pass even if commit name is not good

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
 
   prep-testbed:
     runs-on: ubuntu-latest
-    needs: [commit-lint, lint-flake-8, check-black, import-test]
+    needs: [lint-flake-8, check-black, import-test]
     steps:
       - uses: actions/checkout@v2.5.0
       - id: set-matrix
@@ -257,7 +257,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [docarray-test, docarray-oldproto-test]
+    needs: [commit-lint, docarray-test, docarray-oldproto-test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Context

we forbid test to be run when commit name are not good. This should not be the good we should run the test in the CI but just mark that the name is not good. External contributors have a hard time in the first contribution
