### PR TITLE
ci: impose jina dependencies at the end of CI CD environment setup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,12 +46,12 @@ jobs:
           python -m pip install wheel
           # pip does not properly resolve dependency versions with syntax pip install --no-cache-dir ".[test,full]"
           pip install --no-cache-dir ".[test]"
-          pip install --no-cache-dir ".[full]"
           pip install --no-cache-dir ".[qdrant]"
           pip install --no-cache-dir ".[annlite]"
           pip install --no-cache-dir ".[weaviate]"
           pip install --no-cache-dir ".[elasticsearch]"
           pip install --no-cache-dir ".[redis]"
+          pip install --no-cache-dir ".[full]"
           sudo apt-get install libsndfile1
       - name: Test
         id: test
@@ -96,12 +96,12 @@ jobs:
           python -m pip install wheel
           # pip does not properly resolve dependency versions with syntax pip install --no-cache-dir ".[test,full]"
           pip install --no-cache-dir ".[test]"
-          pip install --no-cache-dir ".[full]"
           pip install --no-cache-dir ".[qdrant]"
           pip install --no-cache-dir ".[annlite]"
           pip install --no-cache-dir ".[weaviate]"
           pip install --no-cache-dir ".[elasticsearch]"
           pip install --no-cache-dir ".[redis]"
+          pip install --no-cache-dir ".[full]"
           pip install --no-cache-dir "protobuf<3.20.0"
           sudo apt-get install libsndfile1
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,12 @@ jobs:
           python -m pip install wheel
           # pip does not properly resolve dependency versions with syntax pip install --no-cache-dir ".[test,full]"
           pip install --no-cache-dir ".[test]"
-          pip install --no-cache-dir ".[full]"
           pip install --no-cache-dir ".[qdrant]"
           pip install --no-cache-dir ".[annlite]"
           pip install --no-cache-dir ".[weaviate]"
           pip install --no-cache-dir ".[elasticsearch]"
           pip install --no-cache-dir ".[redis]"
+          pip install --no-cache-dir ".[full]"
           pip install --no-cache-dir "protobuf<3.20.0"
           sudo apt-get install libsndfile1
       - name: Test


### PR DESCRIPTION
In #726 we update qdrant version and as qdrant imposes grpcio 1.50.0 which is incompatible with Jina, we make sure to install docarray[full] at the end to respect the jina grpcio version restriction.
However, as we split out tests into proto and old proto tests we didn't respect this.
This PR fixes the order of installation.