### PR TITLE
docs: add colab notebook for interactive 3d data visualization

### DIFF
--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -7,7 +7,14 @@ This feature requires `trimesh`. You can install it via `pip install "docarray[f
 
 A 3D mesh is the structural build of a 3D model consisting of polygons. Most 3D meshes are created via professional software packages, such as commercial suites like Unity, or the free open source Blender 3D.
 
-DocArray supports .obj, .glb and .ply files.
+DocArray supports the following file formats for 3D data handling: .obj, .glb and .ply.
+
+You can explore interactive 3D data visualization with DocArray in the following Google Colab Notebook:
+<p>
+<a target="_blank" href="https://colab.research.google.com/drive/17uHgNVndRlfAAV9CAB_HEHHuRdGgsBW2?usp=sharing">
+<img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+</a>
+</p>
 
 ## Vertices and faces representation 
 


### PR DESCRIPTION
Goals:

Add a link to a Google Colab notebook to demonstrate DocArray's 3d data handling and interactive visualization. Prepare examples for DocArrays point cloud representation as well as vertices and faces representation for users to interact with.

- [x] prepare notebook
- [x] prepare data and push to Jina Hub
- [x] add colab link to docs
