### PR TITLE
chore(ci): update time out of tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
           pytest --suppress-no-test-exit-code --cov=docarray --cov-report=xml \
             -v -s -m "not gpu" ${{ matrix.test-path }}
           echo "codecov_flag=docarray" >> $GITHUB_OUTPUT
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           JINA_AUTH_TOKEN: "${{ secrets.JINA_AUTH_TOKEN }}"
       - name: Check codecov file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           pytest --suppress-no-test-exit-code --cov=docarray --cov-report=xml \
             -v -s -m "not gpu" ${{ matrix.test-path }}
           echo "codecov_flag=docarray" >> $GITHUB_OUTPUT
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           JINA_AUTH_TOKEN: "${{ secrets.JINA_AUTH_TOKEN }}"
       - name: Check codecov file


### PR DESCRIPTION
# Context

some test (like this one : https://github.com/docarray/docarray/actions/runs/3440631499/jobs/5739320626) Fail because of the time out.

# What this PR do:

Updating the timeout of the tests in the ci from 30 min to 45 min