### PR TITLE
feat: only pydantic types

### DIFF
--- a/docarray/document/document.py
+++ b/docarray/document/document.py
@@ -16,6 +16,3 @@ class BaseDocument(BaseModel, ProtoMixin, AbstractDocument, BaseNode):
     """
 
     id: Union[int, str, UUID] = Field(default_factory=lambda: os.urandom(16).hex())
-
-    class Config:
-        arbitrary_types_allowed = True


### PR DESCRIPTION
# Context

by default pydantic only allow to use types that can be validated. We had to disable it but now that all of our type can be validated (tensor was the last one) it is not needed anymore
