### PR TITLE
chore(ci): readd commint lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [docarray-test]
+    needs: [docarray-test, commit-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,51 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: find the prev warning if exist
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "bad commit message"
+      - name: Delete comment if exist
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }},
+            })
+      - uses: actions/checkout@v2.5.0
+        with:
+          fetch-depth: 0
+      - run: 'echo "module.exports = {extends: [''@commitlint/config-conventional'']}" > commitlint.config.js'
+      - uses: wagoid/commitlint-github-action@v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: if lint failed
+        if: ${{ failure() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thanks for your contribution :heart:
+            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
+            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
+            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
+
+            Note, other CI tests will *not* *start* until the commit messages get fixed.
+
+            This message will be deleted automatically when the commit messages get fixed.
+          reaction-type: "eyes"
+
   lint-ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
 #  prep-testbed:
 #    runs-on: ubuntu-latest
-#    needs: [lint-flake-8, check-black, import-test]
+#    needs: [lint-ruff, check-black, import-test]
 #    steps:
 #      - uses: actions/checkout@v2.5.0
 #      - id: set-matrix
@@ -131,7 +131,7 @@ jobs:
 #      matrix: ${{ steps.set-matrix.outputs.matrix }}
 
   docarray-test:
-    needs: [lint-flake-8, check-black, import-test]
+    needs: [lint-ruff, check-black, import-test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,24 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: find the prev warning if exist
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "bad commit message"
-      - name: Delete comment if exist
-        if: ${{ steps.fc.outputs.comment-id != 0 }}
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.deleteComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: ${{ steps.fc.outputs.comment-id }},
-            })
+#      - name: find the prev warning if exist
+#        uses: peter-evans/find-comment@v1
+#        id: fc
+#        with:
+#          issue-number: ${{ github.event.pull_request.number }}
+#          comment-author: "github-actions[bot]"
+#          body-includes: "bad commit message"
+#      - name: Delete comment if exist
+#        if: ${{ steps.fc.outputs.comment-id != 0 }}
+#        uses: actions/github-script@v3
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            github.issues.deleteComment({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              comment_id: ${{ steps.fc.outputs.comment-id }},
+#            })
       - uses: actions/checkout@v2.5.0
         with:
           fetch-depth: 0
@@ -32,21 +32,21 @@ jobs:
       - uses: wagoid/commitlint-github-action@v1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: if lint failed
-        if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Thanks for your contribution :heart:
-            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
-            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
-            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
-
-            Note, other CI tests will *not* *start* until the commit messages get fixed.
-
-            This message will be deleted automatically when the commit messages get fixed.
-          reaction-type: "eyes"
+#      - name: if lint failed
+#        if: ${{ failure() }}
+#        uses: peter-evans/create-or-update-comment@v1
+#        with:
+#          issue-number: ${{ github.event.pull_request.number }}
+#          body: |
+#            Thanks for your contribution :heart:
+#            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
+#            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
+#            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
+#
+#            Note, other CI tests will *not* *start* until the commit messages get fixed.
+#
+#            This message will be deleted automatically when the commit messages get fixed.
+#          reaction-type: "eyes"
 
   lint-ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Sami Jaghouar <sami.jaghouar@hotmail.fr>

# What this PR do

* commit name lint was disable when the refactoring was in PoC we need to enable it now
* fix some ruff ci part
