### PR TITLE
chore: fix ci not running on refactoring dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat-rewritte-v2
   pull_request:
     types: [opened, synchronize]
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - feat-rewritte-v2
+      - feat-rewrite-v2
   pull_request:
     types: [opened, synchronize]
 jobs:


### PR DESCRIPTION
# context

CI was set to be triggered on pr or in master. But we are working on feat-rewritte-v2 so we need to add this branch for now to the ci check
