### PR TITLE
chore: remove commit lint ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,50 +9,6 @@ on:
     types: [opened, synchronize]
 jobs:
 
-  commit-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: find the prev warning if exist
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "bad commit message"
-      - name: Delete comment if exist
-        if: ${{ steps.fc.outputs.comment-id != 0 }}
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.deleteComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: ${{ steps.fc.outputs.comment-id }},
-            })
-      - uses: actions/checkout@v2.5.0
-        with:
-          fetch-depth: 0
-      - run: 'echo "module.exports = {extends: [''@commitlint/config-conventional'']}" > commitlint.config.js'
-      - uses: wagoid/commitlint-github-action@v1
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: if lint failed
-        if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Thanks for your contribution :heart:
-            :broken_heart: Unfortunately, this PR has one ore more **bad commit messages**, it can not be merged. To fix this problem, please refer to:
-            - [Commit Message Guideline for the First Time Contributor](https://github.com/jina-ai/jina/issues/553)
-            - [Contributing Guideline](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md)
-
-            Note, other CI tests will *not* *start* until the commit messages get fixed.
-
-            This message will be deleted automatically when the commit messages get fixed.
-          reaction-type: "eyes"
-
   lint-ruff:
     runs-on: ubuntu-latest
     steps:
@@ -179,7 +135,7 @@ jobs:
 
   # just for blocking the merge until all parallel core-test are successful
   success-all-test:
-    needs: [docarray-test, check-mypy, commit-lint]
+    needs: [docarray-test, check-mypy]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Context

the commit lint of the CI is not working on the main/dev branch because it is suppose to work on a PR directly. But we squash merge the PR anyway so the name of the commit does not matter inside the pr branch. So the commit lint is actually never used. This pr just remove it
