### PR TITLE
docs: fix data management section

### DIFF
--- a/docs/fundamentals/cloud-support/data.md
+++ b/docs/fundamentals/cloud-support/data.md
@@ -1,8 +1,8 @@
 (data-management)=
-## Data Management
+# Data Management
 Jina AI Cloud offers data management of DocumentArrays, using either the console or the DocArray Python API.
 
-### Web Console
+## Web Console
 In order to use the web console to manage your storage, you need to log in at [cloud.jina.ai](https://cloud.jina.ai).
 Then, head to the [User Storage page](https://cloud.jina.ai/user/storage).
 
@@ -14,11 +14,11 @@ Your DocumentArrays should appear in the data section inside the storage page:
 You can delete, download, view, or change the visibility of your DocumentArray objects using the web console.
 
 
-### Python API
+## Python API
 DocArray offers a Python API for data management.
 Once you've successfully {ref}`logged in<login>`, you can start using `DocumentArray` methods to manage data.
 
-#### Push (create/update):
+### Push (create/update):
 You can push in-memory `DocumentArray` objects using the {meth}`~docarray.array.mixins.io.pushpull.PushPullMixin.push` method:
 ```python
 from docarray import DocumentArray
@@ -28,7 +28,7 @@ da.push('my_da', show_progress=True)
 ```
 This will create a DocumentArray object in the cloud or update it if it already exists.
 
-#### Pull (Read):
+### Pull (Read):
 You can download a DocumentArray stored in the cloud using the {meth}`~docarray.array.mixins.io.pushpull.PushPullMixin.pull` method:
 ```python
 from docarray import DocumentArray
@@ -36,7 +36,7 @@ from docarray import DocumentArray
 my_da = DocumentArray('my_da')
 ```
 
-#### List
+### List
 You can list all `DocumentArray` objects stored in the cloud using the {meth}`~docarray.array.mixins.io.pushpull.PushPullMixin.cloud_list` method: 
 ```python
 DocumentArray.cloud_list(show_table=True)
@@ -56,7 +56,7 @@ DocumentArray.cloud_list(show_table=True)
 Use the `show_table` parameter to show summary information about DocumentArrays in the cloud.
 ```
 
-#### Delete
+### Delete
 
 You can delete DocumentArray objects in the cloud using the method {meth}`~docarray.array.mixins.io.pushpull.PushPullMixin.cloud_delete`:
 ```python


### PR DESCRIPTION
the data management section currently returns 404:
https://docarray.jina.ai/fundamentals/cloud-support/data/
This PR fixes this issue