### PR TITLE
feat: allow da bulk access to return da for document

### DIFF
--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from typing import Iterable, Type
 
 from docarray.document import BaseDocument
-from docarray.document.abstract_document import AbstractDocument
 
 
 class AbstractDocumentArray(Iterable):
@@ -14,5 +13,7 @@ class AbstractDocumentArray(Iterable):
         ...
 
     @abstractmethod
-    def __class_getitem__(cls, item: Type[BaseDocument]) -> Type['AbstractDocument']:
+    def __class_getitem__(
+        cls, item: Type[BaseDocument]
+    ) -> Type['AbstractDocumentArray']:
         ...

--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -10,5 +10,9 @@ class AbstractDocumentArray(Iterable):
     document_type: Type[BaseDocument]
 
     @abstractmethod
-    def __init__(self, docs: Iterable[AbstractDocument]):
+    def __init__(self, docs: Iterable[BaseDocument]):
+        ...
+
+    @abstractmethod
+    def __class_getitem__(cls, item: Type[BaseDocument]) -> Type['AbstractDocument']:
         ...

--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -7,7 +7,7 @@ from docarray.document.abstract_document import AbstractDocument
 
 
 class DocumentArray(
-    list,
+    list[AbstractDocument],
     ProtoArrayMixin,
     GetAttributeArrayMixin,
     AbstractDocumentArray,
@@ -21,7 +21,7 @@ class DocumentArray(
 
     document_type: Type[BaseDocument] = AnyDocument
 
-    def __init__(self, docs: Iterable[AbstractDocument]):
+    def __init__(self, docs: Iterable[BaseDocument]):
         super().__init__(doc_ for doc_ in docs)
 
     def __class_getitem__(cls, item: Type[BaseDocument]):
@@ -31,7 +31,7 @@ class DocumentArray(
             )
 
         class _DocumenArrayTyped(DocumentArray):
-            document_type = item
+            document_type: Type[BaseDocument] = item
 
         for field in _DocumenArrayTyped.document_type.__fields__.keys():
 

--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -3,11 +3,10 @@ from typing import Iterable, Type
 from docarray.array.abstract_array import AbstractDocumentArray
 from docarray.array.mixins import GetAttributeArrayMixin, ProtoArrayMixin
 from docarray.document import AnyDocument, BaseDocument, BaseNode
-from docarray.document.abstract_document import AbstractDocument
 
 
 class DocumentArray(
-    list[AbstractDocument],
+    list,
     ProtoArrayMixin,
     GetAttributeArrayMixin,
     AbstractDocumentArray,

--- a/docarray/array/mixins/attribute.py
+++ b/docarray/array/mixins/attribute.py
@@ -22,6 +22,7 @@ class GetAttributeArrayMixin(AbstractDocumentArray):
         if issubclass(field_type, BaseDocument):
             # calling __class_getitem__ ourselves is a hack otherwise mypy complain
             # most likely a bug in mypy though
+            # bug reported here https://github.com/python/mypy/issues/14111
             return self.__class__.__class_getitem__(field_type)(
                 (getattr(doc, field) for doc in self)
             )

--- a/docarray/array/mixins/attribute.py
+++ b/docarray/array/mixins/attribute.py
@@ -20,6 +20,10 @@ class GetAttributeArrayMixin(AbstractDocumentArray):
         field_type = self.__class__.document_type._get_nested_document_class(field)
 
         if issubclass(field_type, BaseDocument):
-            return self.__class__[field_type]((getattr(doc, field) for doc in self))
+            # calling __class_getitem__ ourselves is a hack otherwise mypy complain
+            # most likely a bug in mypy though
+            return self.__class__.__class_getitem__(field_type)(
+                (getattr(doc, field) for doc in self)
+            )
         else:
             return [getattr(doc, field) for doc in self]

--- a/docarray/array/mixins/attribute.py
+++ b/docarray/array/mixins/attribute.py
@@ -1,12 +1,15 @@
-from typing import List
+from typing import List, Union
 
 from docarray.array.abstract_array import AbstractDocumentArray
+from docarray.document import BaseDocument
 
 
 class GetAttributeArrayMixin(AbstractDocumentArray):
     """Helpers that provide attributes getter in bulk"""
 
-    def _get_documents_attribute(self, field: str) -> List:
+    def _get_documents_attribute(
+        self, field: str
+    ) -> Union[List, AbstractDocumentArray]:
         """Return all values of the fields from all docs this array contains
 
         :param field: name of the fields to extract
@@ -14,4 +17,9 @@ class GetAttributeArrayMixin(AbstractDocumentArray):
         in the array like container
         """
 
-        return [getattr(doc, field) for doc in self]
+        field_type = self.__class__.document_type._get_nested_document_class(field)
+
+        if issubclass(field_type, BaseDocument):
+            return self.__class__[field_type]((getattr(doc, field) for doc in self))
+        else:
+            return [getattr(doc, field) for doc in self]

--- a/docarray/document/mixins/proto.py
+++ b/docarray/document/mixins/proto.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Type, TypeVar
 
 from pydantic.tools import parse_obj_as
 
@@ -7,10 +7,12 @@ from docarray.document.base_node import BaseNode
 from docarray.proto import DocumentProto, NodeProto
 from docarray.typing import ID, AnyUrl, Embedding, ImageUrl, Tensor, TorchTensor
 
+T = TypeVar('T', bound='ProtoMixin')
+
 
 class ProtoMixin(AbstractDocument, BaseNode):
     @classmethod
-    def from_protobuf(cls, pb_msg: 'DocumentProto') -> 'ProtoMixin':
+    def from_protobuf(cls: Type[T], pb_msg: 'DocumentProto') -> T:
         """create a Document from a protobuf message"""
         from docarray import DocumentArray
 

--- a/tests/units/array/test_mixins/test_attribute.py
+++ b/tests/units/array/test_mixins/test_attribute.py
@@ -51,3 +51,19 @@ def test_get_bulk_attributes():
     assert len(texts) == N
     for i, text in enumerate(texts):
         assert text == f'hello{i}'
+
+
+def test_get_bulk_attributes_document():
+    class InnerDoc(BaseDocument):
+        text: str
+
+    class Mmdoc(BaseDocument):
+        inner: InnerDoc
+
+    N = 10
+
+    da = DocumentArray[Mmdoc](
+        (Mmdoc(inner=InnerDoc(text=f'hello{i}')) for i in range(N))
+    )
+
+    assert isinstance(da.inner, DocumentArray)


### PR DESCRIPTION
# Context


since https://github.com/docarray/docarray/pull/790 we can already do 

```python

from docarray import DocumentArray, Document

class Mmdoc(BaseDocument):
    text: str

da = DocumentArray[Mmdoc](
    (Mmdoc(text=f'hello') for _ in range(10))
)

assert da.text == 10*['hello']
```

never the less it always return a list of item for the field, even if the field is suppose to contain `Document`. In this case this should return a `DocumentArray` instead of a `List` of `Document`

# What this pr do
When the nested field is a Document it returns a `DocumentArray` instead of a `List` of `Document`

```python

from docarray import Text

class Mmdoc(BaseDocument):
    text: Text

da = DocumentArray[Mmdoc](
    (Mmdoc(text=Text(text='hello')) for _ in range(10))
)

assert da.text == DocumentArray[Text](10*[Text(text='hello'))])
```