### PR TITLE
hotfix: pull docarray with "username/da-name" format

### DIFF
--- a/docarray/array/mixins/io/pushpull.py
+++ b/docarray/array/mixins/io/pushpull.py
@@ -303,10 +303,12 @@ class PushPullMixin:
             from docarray.array.mixins.io.binary import LazyRequestReader
 
             _source = LazyRequestReader(r)
-            if local_cache and os.path.exists(f'{__cache_path__}/{name}'):
-                _cache_len = os.path.getsize(f'{__cache_path__}/{name}')
+
+            cache_file = f'{__cache_path__}/{name.replace("/", "_")}.da'
+            if local_cache and os.path.exists(cache_file):
+                _cache_len = os.path.getsize(cache_file)
                 if _cache_len == _da_len:
-                    _source = f'{__cache_path__}/{name}'
+                    _source = cache_file
 
             r = cls.load_binary(
                 _source,
@@ -319,7 +321,7 @@ class PushPullMixin:
 
             if isinstance(_source, LazyRequestReader) and local_cache:
                 Path(__cache_path__).mkdir(parents=True, exist_ok=True)
-                with open(f'{__cache_path__}/{name}', 'wb') as fp:
+                with open(cache_file, 'wb') as fp:
                     fp.write(_source.content)
 
             return r

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -115,11 +115,12 @@ def test_push_with_public(mocker, monkeypatch, public):
     assert form_data['public'] == [str(public)]
 
 
-def test_pull(mocker, monkeypatch):
+@pytest.mark.parametrize('da_name', ['test_name', 'username/test_name'])
+def test_pull(mocker, monkeypatch, da_name):
     mock = mocker.Mock()
     _mock_get(mock, monkeypatch)
 
-    DocumentArray.pull(name='test_name')
+    DocumentArray.pull(name=da_name)
 
     assert mock.call_count == 2  # 1 for pull, 1 for download
 


### PR DESCRIPTION
Goals:

- To fix `FileNotFoundError: [Errno 2] No such file or directory: '.../username/test_name'` error when pulling docarray with "username/da-name" formatted name
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
