### PR TITLE
refactor: add typing abstract class

### DIFF
--- a/docarray/document/document.py
+++ b/docarray/document/document.py
@@ -3,6 +3,7 @@ from typing import Type
 
 import orjson
 from pydantic import BaseModel, Field
+from pydantic import parse_obj_as
 
 from docarray.document.abstract_document import AbstractDocument
 from docarray.document.base_node import BaseNode
@@ -16,7 +17,7 @@ class BaseDocument(BaseModel, ProtoMixin, AbstractDocument, BaseNode):
     The base class for Document
     """
 
-    id: ID = Field(default_factory=lambda: ID.validate(os.urandom(16).hex()))
+    id: ID = Field(default_factory=lambda: parse_obj_as(ID, os.urandom(16).hex()))
 
     class Config:
         json_loads = orjson.loads

--- a/docarray/typing/abstract_type.py
+++ b/docarray/typing/abstract_type.py
@@ -1,0 +1,30 @@
+from abc import abstractmethod
+from typing import Any, Type, TypeVar
+
+from pydantic import BaseConfig
+from pydantic.fields import ModelField
+
+from docarray.document.base_node import BaseNode
+
+T = TypeVar('T')
+
+
+class AbstractType(BaseNode):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    @abstractmethod
+    def validate(
+        cls: Type[T],
+        value: Any,
+        field: 'ModelField',
+        config: 'BaseConfig',
+    ) -> T:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_protobuf(cls: Type[T], pb_msg: T) -> T:
+        ...

--- a/docarray/typing/id.py
+++ b/docarray/typing/id.py
@@ -1,16 +1,15 @@
-from typing import Optional, Type, TypeVar, Union
+from typing import Type, TypeVar, Union
 from uuid import UUID
-
 from pydantic import BaseConfig, parse_obj_as
 from pydantic.fields import ModelField
 
-from docarray.document.base_node import BaseNode
 from docarray.proto import NodeProto
+from docarray.typing.abstract_type import AbstractType
 
 T = TypeVar('T', bound='ID')
 
 
-class ID(str, BaseNode):
+class ID(str, AbstractType):
     """
     Represent an unique ID
     """
@@ -23,8 +22,8 @@ class ID(str, BaseNode):
     def validate(
         cls: Type[T],
         value: Union[str, int, UUID],
-        field: Optional['ModelField'] = None,
-        config: Optional['BaseConfig'] = None,
+        field: 'ModelField',
+        config: 'BaseConfig',
     ) -> T:
 
         try:

--- a/docarray/typing/tensor/tensor.py
+++ b/docarray/typing/tensor/tensor.py
@@ -2,17 +2,18 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, TypeVar, Union, 
 
 import numpy as np
 
+from docarray.typing.abstract_type import AbstractType
+
 if TYPE_CHECKING:
     from pydantic.fields import ModelField
     from pydantic import BaseConfig
 
-from docarray.document.base_node import BaseNode
 from docarray.proto import NdArrayProto, NodeProto
 
 T = TypeVar('T', bound='Tensor')
 
 
-class Tensor(np.ndarray, BaseNode):
+class Tensor(np.ndarray, AbstractType):
     @classmethod
     def __get_validators__(cls):
         # one or more validators may be yielded which will be called in the

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Dict, Type, TypeVar, Union, cast
 import numpy as np
 import torch  # type: ignore
 
+from docarray.typing.abstract_type import AbstractType
+
 if TYPE_CHECKING:
     from pydantic.fields import ModelField
     from pydantic import BaseConfig
@@ -22,7 +24,7 @@ class metaTorchAndNode(torch_base, node_base):
     pass
 
 
-class TorchTensor(torch.Tensor, BaseNode, metaclass=metaTorchAndNode):
+class TorchTensor(AbstractType, torch.Tensor, metaclass=metaTorchAndNode):
     # Subclassing torch.Tensor following the advice from here:
     # https://pytorch.org/docs/stable/notes/extending.html#subclassing-torch-tensor
     @classmethod

--- a/docarray/typing/url/any_url.py
+++ b/docarray/typing/url/any_url.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Type, TypeVar
 from pydantic import AnyUrl as BaseAnyUrl
 from pydantic import errors, parse_obj_as
 
-from docarray.document.base_node import BaseNode
 from docarray.proto import NodeProto
+from docarray.typing.abstract_type import AbstractType
 
 if TYPE_CHECKING:
     from pydantic.networks import Parts
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 T = TypeVar('T', bound='AnyUrl')
 
 
-class AnyUrl(BaseAnyUrl, BaseNode):
+class AnyUrl(BaseAnyUrl, AbstractType):
     host_required = (
         False  # turn off host requirement to allow passing of local paths as URL
     )

--- a/docarray/typing/url/image_url.py
+++ b/docarray/typing/url/image_url.py
@@ -1,6 +1,6 @@
 import io
 import struct
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union, Type, Any
 
 import numpy as np
 
@@ -40,7 +40,6 @@ class ImageUrl(AnyUrl):
         field: 'ModelField',
         config: 'BaseConfig',
     ) -> T:
-
         url = super().validate(value, field, config)  # basic url validation
         has_image_extension = any(url.endswith(ext) for ext in IMAGE_FILE_FORMATS)
         if not has_image_extension:


### PR DESCRIPTION
Signed-off-by: dong xiang <iamxiangdong@gmail.com>

Goals:

We need to create an common interface via an abstract class for our docarray.typing obj


The abstract class should contain the following methods, 1. _to_node_protobuf (Convert Document into a NodeProto protobuf message). 2. from_protobuf (read value from a proto msg) 3. validate (inherited from pydantic about validating data.)


- ...
- ...
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
