### PR TITLE
ci: increase timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           pytest --suppress-no-test-exit-code --cov=docarray --cov-report=xml \
             -v -s -m "not gpu" ${{ matrix.test-path }}
           echo "codecov_flag=docarray" >> $GITHUB_OUTPUT
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
           JINA_AUTH_TOKEN: "${{ secrets.JINA_AUTH_TOKEN }}"
       - name: Check codecov file
@@ -238,7 +238,7 @@ jobs:
           pytest --suppress-no-test-exit-code --cov=docarray --cov-report=xml \
             -v -s -m "not gpu" ${{ matrix.test-path }}
           echo "::set-output name=codecov_flag::docarray"
-        timeout-minutes: 60
+        timeout-minutes: 120
         env:
           JINA_AUTH_TOKEN: "${{ secrets.JINA_AUTH_TOKEN }}"
       - name: Check codecov file

--- a/docarray/array/storage/milvus/backend.py
+++ b/docarray/array/storage/milvus/backend.py
@@ -197,6 +197,15 @@ class BackendMixin(BaseBackendMixin):
             'params': self._config.index_params,
         }
         self._collection.create_index(field_name='embedding', index_params=index_params)
+        if self._list_like:
+            offset_index_params = {
+                'metric_type': 'L2',
+                'index_type': 'IVF_FLAT',
+                'params': {'nlist': 1024},
+            }
+            self._offset2id_collection.create_index(
+                field_name='dummy_vector', index_params=offset_index_params
+            )
 
     def _create_or_reuse_offset2id_collection(self):
         if has_collection(

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
             'redis>=4.3.0',
         ],
         'milvus': [
-            'pymilvus>=2.1.0',
+            'pymilvus~=2.2.0',
         ],
         'benchmark': [
             'pandas',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,7 @@ def tmpfile(tmpdir):
 
 @pytest.fixture(scope='module')
 def start_storage():
-    os.system(
-        f"docker-compose -f {compose_yml} --project-directory . up  --build -d "
-        f"--remove-orphans"
-    )
+    os.system(f"docker-compose -f {compose_yml} --project-directory . up  --build -d")
     os.system(
         f"docker-compose -f {milvus_compose_yml} --project-directory . up  --build -d"
     )

--- a/tests/unit/array/milvus-docker-compose.yml
+++ b/tests/unit/array/milvus-docker-compose.yml
@@ -1,4 +1,5 @@
-version: "3.3"
+version: '3.5'
+
 services:
   etcd:
     container_name: milvus-etcd
@@ -18,19 +19,21 @@ services:
     environment:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
+    ports:
+      - "9001:9001"
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
-    command: minio server /minio_data
+    command: minio server /minio_data --console-address ":9001"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 20s
       retries: 3
 
   standalone:
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.1.4
-    command: [ "milvus", "run", "standalone" ]
+    image: milvusdb/milvus:v2.2.0
+    command: ["milvus", "run", "standalone"]
     environment:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000


### PR DESCRIPTION
Tests on the CI are timing out, potentially because of the milvus storage backend. This is an attempt to fix it.
