### PR TITLE
fix: rebuild index when clear storage

### DIFF
--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -93,8 +93,14 @@ class BackendMixin(BaseBackendMixin):
         self._config.columns = self._normalize_columns(self._config.columns)
 
         self.n_dim = self._config.n_dim
-        self._client = self._build_client()
         self._list_like = self._config.list_like
+
+        self._client = Elasticsearch(
+            hosts=self._config.hosts,
+            **self._config.es_config,
+        )
+
+        self._build_index()
         self._build_offset2id_index()
 
         # Note super()._init_storage() calls _load_offset2ids which calls _get_offset2ids_meta
@@ -166,22 +172,15 @@ class BackendMixin(BaseBackendMixin):
             ] = index_options
         return da_schema
 
-    def _build_client(self):
-
-        client = Elasticsearch(
-            hosts=self._config.hosts,
-            **self._config.es_config,
-        )
-
+    def _build_index(self):
         schema = self._build_schema_from_elastic_config(self._config)
 
-        if not client.indices.exists(index=self._config.index_name):
-            client.indices.create(
+        if not self._client.indices.exists(index=self._config.index_name):
+            self._client.indices.create(
                 index=self._config.index_name, mappings=schema['mappings']
             )
 
-        client.indices.refresh(index=self._config.index_name)
-        return client
+        self._client.indices.refresh(index=self._config.index_name)
 
     def _send_requests(self, request, **kwargs) -> List[Dict]:
         """Send bulk request to Elastic and gather the successful info"""

--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -95,11 +95,7 @@ class BackendMixin(BaseBackendMixin):
         self.n_dim = self._config.n_dim
         self._list_like = self._config.list_like
 
-        self._client = Elasticsearch(
-            hosts=self._config.hosts,
-            **self._config.es_config,
-        )
-
+        self._client = self._build_client()
         self._build_index()
         self._build_offset2id_index()
 
@@ -171,6 +167,14 @@ class BackendMixin(BaseBackendMixin):
                 'index_options'
             ] = index_options
         return da_schema
+
+    def _build_client(self):
+        client = Elasticsearch(
+            hosts=self._config.hosts,
+            **self._config.es_config,
+        )
+
+        return client
 
     def _build_index(self):
         schema = self._build_schema_from_elastic_config(self._config)
@@ -286,7 +290,4 @@ class BackendMixin(BaseBackendMixin):
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._client = Elasticsearch(
-            hosts=self._config.hosts,
-            **self._config.es_config,
-        )
+        self._client = self._build_client()

--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -286,4 +286,7 @@ class BackendMixin(BaseBackendMixin):
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._client = self._build_client()
+        self._client = Elasticsearch(
+            hosts=self._config.hosts,
+            **self._config.es_config,
+        )

--- a/docarray/array/storage/elastic/getsetdel.py
+++ b/docarray/array/storage/elastic/getsetdel.py
@@ -121,6 +121,7 @@ class GetSetDelMixin(BaseGetSetDelMixin):
     def _clear_storage(self):
         """Concrete implementation of base class' ``_clear_storage``"""
         self._client.indices.delete(index=self._config.index_name)
+        self._build_index()
 
     def _load_offset2ids(self):
         if self._list_like:

--- a/docarray/array/storage/redis/backend.py
+++ b/docarray/array/storage/redis/backend.py
@@ -90,7 +90,7 @@ class BackendMixin(BaseBackendMixin):
             **self._config.redis_config,
         )
 
-        self._initialize_redis_index()
+        self._build_index()
 
         super()._init_storage()
 
@@ -101,7 +101,7 @@ class BackendMixin(BaseBackendMixin):
         elif isinstance(_docs, Document):
             self.append(_docs)
 
-    def _initialize_redis_index(self, rebuild: bool = False):
+    def _build_index(self, rebuild: bool = False):
         if self._config.update_schema or rebuild:
             if self._config.index_name.encode() in self._client.execute_command(
                 'FT._LIST'

--- a/docarray/array/storage/redis/backend.py
+++ b/docarray/array/storage/redis/backend.py
@@ -84,12 +84,7 @@ class BackendMixin(BaseBackendMixin):
         self._doc_prefix = config.index_name + ':'
         self._config.columns = self._normalize_columns(self._config.columns)
 
-        self._client = Redis(
-            host=self._config.host,
-            port=self._config.port,
-            **self._config.redis_config,
-        )
-
+        self._client = self._build_client()
         self._build_index()
 
         super()._init_storage()
@@ -100,6 +95,14 @@ class BackendMixin(BaseBackendMixin):
             self.extend(_docs)
         elif isinstance(_docs, Document):
             self.append(_docs)
+
+    def _build_client(self):
+        client = Redis(
+            host=self._config.host,
+            port=self._config.port,
+            **self._config.redis_config,
+        )
+        return client
 
     def _build_index(self, rebuild: bool = False):
         if self._config.update_schema or rebuild:
@@ -196,8 +199,4 @@ class BackendMixin(BaseBackendMixin):
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self._client = Redis(
-            host=self._config.host,
-            port=self._config.port,
-            **self._config.redis_config,
-        )
+        self._client = self._build_client()

--- a/docarray/array/storage/redis/getsetdel.py
+++ b/docarray/array/storage/redis/getsetdel.py
@@ -125,5 +125,5 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._client.ft(index_name=self._config.index_name).dropindex(
             delete_documents=True
         )
-        self._initialize_redis_index(rebuild=True)
+        self._build_index(rebuild=True)
         self._client.delete(self._offset2id_key)

--- a/docarray/array/storage/redis/getsetdel.py
+++ b/docarray/array/storage/redis/getsetdel.py
@@ -125,4 +125,5 @@ class GetSetDelMixin(BaseGetSetDelMixin):
         self._client.ft(index_name=self._config.index_name).dropindex(
             delete_documents=True
         )
+        self._initialize_redis_index(rebuild=True)
         self._client.delete(self._offset2id_key)


### PR DESCRIPTION
Signed-off-by: AnneY <evangeline-lun@foxmail.com>

Goals:

This PR is related to issue #829  and will rebuild index for Redis and ElasticSearch when `_clear_storage` is called.

- [x] change for Redis
- [x] change for ElasticSearch
- [x] add related test
