### PR TITLE
fix: add support independent len calculation

### DIFF
--- a/docarray/array/storage/milvus/getsetdel.py
+++ b/docarray/array/storage/milvus/getsetdel.py
@@ -40,6 +40,8 @@ class GetSetDelMixin(BaseGetSetDelMixin):
                 )
             sorted_res = sorted(res, key=lambda k: int(k['offset']))
             self._offset2ids = Offset2ID([r['document_id'] for r in sorted_res])
+        else:
+            self._offset2ids = Offset2ID([], list_like=self._list_like)
 
     def _save_offset2ids(self):
         if self._list_like:

--- a/docarray/array/storage/redis/seqlike.py
+++ b/docarray/array/storage/redis/seqlike.py
@@ -26,8 +26,12 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
         :return: the length of this :class:`DocumentArrayRedis` object
         """
-        try:
+        if self._list_like:
             return len(self._offset2ids)
+        try:
+            lua_script = f'return #redis.pcall("keys", "{self._config.index_name}:*")'
+            cmd = self._client.register_script(lua_script)
+            return cmd()
         except:
             return 0
 

--- a/tests/unit/document/test_disable_offset2id.py
+++ b/tests/unit/document/test_disable_offset2id.py
@@ -25,9 +25,14 @@ def docs():
 )
 def test_disable_offset2id(docs, storage, config, start_storage):
     if config:
-        da = DocumentArray(docs, storage=storage, config=config)
+        da = DocumentArray(storage=storage, config=config)
     else:
-        da = DocumentArray(docs, storage=storage)
+        da = DocumentArray(storage=storage)
+
+    assert len(da) == 0
+
+    da.extend(docs)
+    assert len(da) == 3
 
     with pytest.raises(ValueError):
         da[0]


### PR DESCRIPTION
Signed-off-by: dong xiang <iamxiangdong@gmail.com>

Goals:

- ...
As reported by users, after disabling the list-like flag in Docarray backends, the len should still work, because otherwise the redis backend will fail. Therefore it is necessary to add this functionality.


- ...
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
