### PR TITLE
feat: embedding type

### DIFF
--- a/docarray/typing/__init__.py
+++ b/docarray/typing/__init__.py
@@ -1,5 +1,5 @@
 from docarray.typing.id import ID
-from docarray.typing.tensor import NdArray, Tensor, TorchTensor
+from docarray.typing.tensor import NdArray, Tensor, TorchEmbedding, TorchTensor
 from docarray.typing.tensor.embedding import Embedding
 from docarray.typing.url import AnyUrl, ImageUrl, TextUrl
 
@@ -12,4 +12,5 @@ __all__ = [
     'AnyUrl',
     'ID',
     'Tensor',
+    'TorchEmbedding',
 ]

--- a/docarray/typing/tensor/__init__.py
+++ b/docarray/typing/tensor/__init__.py
@@ -1,5 +1,5 @@
 from docarray.typing.tensor.ndarray import NdArray
 from docarray.typing.tensor.tensor import Tensor
-from docarray.typing.tensor.torch_tensor import TorchTensor
+from docarray.typing.tensor.torch_tensor import TorchEmbedding, TorchTensor
 
-__all__ = ['NdArray', 'TorchTensor', 'Tensor']
+__all__ = ['NdArray', 'TorchTensor', 'Tensor', 'TorchEmbedding']

--- a/docarray/typing/tensor/__init__.py
+++ b/docarray/typing/tensor/__init__.py
@@ -1,5 +1,13 @@
+from docarray.typing.tensor.embedding import Embedding, NdArrayEmbedding, TorchEmbedding
 from docarray.typing.tensor.ndarray import NdArray
 from docarray.typing.tensor.tensor import Tensor
-from docarray.typing.tensor.torch_tensor import TorchEmbedding, TorchTensor
+from docarray.typing.tensor.torch_tensor import TorchTensor
 
-__all__ = ['NdArray', 'TorchTensor', 'Tensor', 'TorchEmbedding']
+__all__ = [
+    'NdArray',
+    'TorchTensor',
+    'Tensor',
+    'Embedding',
+    'TorchEmbedding',
+    'NdArrayEmbedding',
+]

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -22,7 +22,7 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
         """Every tensor has to implement this method in order to
         enable syntax of the form Tensor[shape].
 
-        It is called at "data setting time",
+        It is called when a tensor is assigned to a field of this type.
         i.e. when a tensor is passed to a Document field of type Tensor[shape].
 
         The intended behaviour is as follows:

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -20,8 +20,12 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
     @abc.abstractmethod
     def __validate_shape__(cls, t: T, shape: Tuple[int]) -> T:
         """Every tensor has to implement this method in order to
-        enbale syntax of the form Tensor[shape].
-        The intended behavoiour is as follows:
+        enable syntax of the form Tensor[shape].
+
+        It is called at "data setting time",
+        i.e. when a tensor is passed to a Document field of type Tensor[shape].
+
+        The intended behaviour is as follows:
         - If the shape of `t` is equal to `shape`, return `t`.
         - If the shape of `t` is not equal to `shape`,
             but can be reshaped to `shape`, return `t` reshaped to `shape`.
@@ -33,6 +37,32 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
         :return: The validated tensor.
         """
         ...
+
+    @classmethod
+    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
+        """This method validates the input to __class_getitem__.
+
+        It is called at "class creation time",
+        i.e. when a class is created with syntax of the form Tensor[shape].
+
+        The default implementation tries to cast any `item` to a tuple of ints.
+        A subclass can override this method to implement custom validation logic.
+
+        The output of this is eventually passed to
+        {ref}`AbstractTensor.__validate_shape__` as its `shape` argument.
+
+        Raises `ValueError` if the input `item` does not pass validation.
+
+        :param item: The item to validate, passed to __class_getitem__ (`Tensor[item]`).
+        :return: The validated item == the target shape of this tensor.
+        """
+        if isinstance(item, int):
+            item = (item,)
+        try:
+            item = tuple(item)
+        except TypeError:
+            raise TypeError(f'{item} is not a valid tensor shape.')
+        return item
 
     @classmethod
     def _create_parametrized_type(cls: Type[T], shape: Tuple[int]):
@@ -58,12 +88,6 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
 
         return _ParametrizedTensor
 
-    def __class_getitem__(cls, item):
-        if isinstance(item, int):
-            item = (item,)
-        try:
-            item = tuple(item)
-        except TypeError:
-            raise TypeError(f'{item} is not a valid tensor shape.')
-
-        return cls._create_parametrized_type(item)
+    def __class_getitem__(cls, item: Any):
+        target_shape = cls.__validate_getitem__(item)
+        return cls._create_parametrized_type(target_shape)

--- a/docarray/typing/tensor/embedding.py
+++ b/docarray/typing/tensor/embedding.py
@@ -30,4 +30,4 @@ class TorchEmbedding(TorchTensor, EmbeddingMixin):
     alternative_type = TorchTensor
 
 
-Embedding = Union[TorchEmbedding, NdArrayEmbedding]
+Embedding = Union[NdArrayEmbedding, TorchEmbedding]

--- a/docarray/typing/tensor/embedding.py
+++ b/docarray/typing/tensor/embedding.py
@@ -1,18 +1,33 @@
-from typing import TypeVar
+from abc import ABC
+from typing import Any, Tuple, TypeVar, Union
 
-from docarray.proto import NodeProto
-from docarray.typing.tensor import NdArray
+from docarray.typing.tensor.abstract_tensor import AbstractTensor
+from docarray.typing.tensor.ndarray import NdArray
+from docarray.typing.tensor.torch_tensor import TorchTensor
 
 T = TypeVar('T', bound='Embedding')
 
 
-class Embedding(NdArray):
-    def _to_node_protobuf(self: T, field: str = 'tensor') -> NodeProto:
-        """Convert Document into a NodeProto protobuf message. This function should
-        be called when the Document is nested into another Document that need to be
-        converted into a protobuf
-        :param field: field in which to store the content in the node proto
-        :return: the nested item protobuf message
-        """
+class EmbeddingMixin(AbstractTensor, ABC):
+    alternative_type = None
 
-        return super()._to_node_protobuf(field='embedding')
+    @classmethod
+    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
+        shape = super().__validate_getitem__(item)
+        if len(shape) > 1:
+            error_msg = f'`{cls}` can only have a single dimension/axis.'
+            if cls.alternative_type:
+                error_msg += f' Consider using {cls.alternative_type} instead.'
+            raise ValueError(error_msg)
+        return shape
+
+
+class NdArrayEmbedding(NdArray, EmbeddingMixin):
+    alternative_type = NdArray
+
+
+class TorchEmbedding(TorchTensor, EmbeddingMixin):
+    alternative_type = TorchTensor
+
+
+Embedding = Union[TorchEmbedding, NdArrayEmbedding]

--- a/docarray/typing/tensor/embedding.py
+++ b/docarray/typing/tensor/embedding.py
@@ -1,5 +1,7 @@
 from abc import ABC
-from typing import Any, Tuple, TypeVar, Union
+from typing import Any, Optional, Tuple, Type, TypeVar, Union
+
+import torch
 
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.ndarray import NdArray
@@ -9,7 +11,7 @@ T = TypeVar('T', bound='Embedding')
 
 
 class EmbeddingMixin(AbstractTensor, ABC):
-    alternative_type = None
+    alternative_type: Optional[Type] = None
 
     @classmethod
     def __validate_getitem__(cls, item: Any) -> Tuple[int]:
@@ -26,7 +28,15 @@ class NdArrayEmbedding(NdArray, EmbeddingMixin):
     alternative_type = NdArray
 
 
-class TorchEmbedding(TorchTensor, EmbeddingMixin):
+torch_base = type(torch.Tensor)  # type: Any
+embedding_base = type(EmbeddingMixin)  # type: Any
+
+
+class metaTorchAndEmbedding(torch_base, embedding_base):
+    pass
+
+
+class TorchEmbedding(TorchTensor, EmbeddingMixin, metaclass=metaTorchAndEmbedding):
     alternative_type = TorchTensor
 
 

--- a/docarray/typing/tensor/embedding.py
+++ b/docarray/typing/tensor/embedding.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from typing import Any, Optional, Tuple, Type, TypeVar, Union
 
-import torch
-
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.ndarray import NdArray
 from docarray.typing.tensor.torch_tensor import TorchTensor
@@ -28,7 +26,7 @@ class NdArrayEmbedding(NdArray, EmbeddingMixin):
     alternative_type = NdArray
 
 
-torch_base = type(torch.Tensor)  # type: Any
+torch_base = type(TorchTensor)  # type: Any
 embedding_base = type(EmbeddingMixin)  # type: Any
 
 

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -212,15 +212,3 @@ class TorchTensor(
         pb_msg.dense.ClearField('shape')
         pb_msg.dense.shape.extend(list(value_np.shape))
         pb_msg.dense.dtype = value_np.dtype.str
-
-
-class TorchEmbedding(TorchTensor):
-    @classmethod
-    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
-        shape = super().__validate_getitem__(item)
-        if len(shape) > 1:
-            raise ValueError(
-                '`TorchEmbedding` can only have a single dimension/axis.'
-                'You can use `TorchTensor` as a general tensor instead.'
-            )
-        return shape

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -212,3 +212,15 @@ class TorchTensor(
         pb_msg.dense.ClearField('shape')
         pb_msg.dense.shape.extend(list(value_np.shape))
         pb_msg.dense.dtype = value_np.dtype.str
+
+
+class TorchEmbedding(TorchTensor):
+    @classmethod
+    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
+        shape = super().__validate_getitem__(item)
+        if len(shape) > 1:
+            raise ValueError(
+                '`TorchEmbedding` can only have a single dimension/axis.'
+                'You can use `TorchTensor` as a general tensor instead.'
+            )
+        return shape

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -9,8 +9,10 @@ from docarray.typing import (
     NdArray,
     Tensor,
     TextUrl,
+    TorchEmbedding,
     TorchTensor,
 )
+from docarray.typing.tensor import NdArrayEmbedding
 
 
 def test_multi_modal_doc_proto():
@@ -41,6 +43,8 @@ def test_all_types():
         generic_nd_array: Tensor
         generic_torch_tensor: Tensor
         embedding: Embedding
+        torch_embedding: TorchEmbedding[128]
+        np_embedding: NdArrayEmbedding[128]
 
     doc = MyDoc(
         img_url='test.png',
@@ -53,6 +57,8 @@ def test_all_types():
         generic_nd_array=np.zeros((3, 224, 224)),
         generic_torch_tensor=torch.zeros((3, 224, 224)),
         embedding=np.zeros((3, 224, 224)),
+        torch_embedding=torch.zeros((128,)),
+        np_embedding=np.zeros((128,)),
     )
     doc = MyDoc.from_protobuf(doc.to_protobuf())
 
@@ -77,5 +83,11 @@ def test_all_types():
 
     assert (doc.generic_torch_tensor == torch.zeros((3, 224, 224))).all()
     assert isinstance(doc.generic_torch_tensor, torch.Tensor)
+
+    assert (doc.torch_embedding == torch.zeros((128,))).all()
+    assert isinstance(doc.torch_embedding, torch.Tensor)
+
+    assert (doc.np_embedding == np.zeros((128,))).all()
+    assert isinstance(doc.np_embedding, np.ndarray)
 
     assert (doc.embedding == np.zeros((3, 224, 224))).all()

--- a/tests/integrations/typing/test_embedding.py
+++ b/tests/integrations/typing/test_embedding.py
@@ -10,6 +10,5 @@ def test_set_embedding():
 
     d = MyDocument(embedding=np.zeros((3, 224, 224)))
 
-    assert isinstance(d.embedding, Embedding)
     assert isinstance(d.embedding, np.ndarray)
     assert (d.embedding == np.zeros((3, 224, 224))).all()

--- a/tests/integrations/typing/test_torch_tensor.py
+++ b/tests/integrations/typing/test_torch_tensor.py
@@ -7,13 +7,19 @@ from docarray.typing import TorchEmbedding, TorchTensor
 def test_set_torch_tensor():
     class MyDocument(Document):
         tensor: TorchTensor
-        embedding: TorchEmbedding
 
-    d = MyDocument(tensor=torch.zeros((3, 224, 224)), embedding=torch.zeros((128,)))
+    d = MyDocument(tensor=torch.zeros((3, 224, 224)))
 
     assert isinstance(d.tensor, TorchTensor)
     assert isinstance(d.tensor, torch.Tensor)
     assert (d.tensor == torch.zeros((3, 224, 224))).all()
+
+
+def test_set_torch_embedding():
+    class MyDocument(Document):
+        embedding: TorchEmbedding
+
+    d = MyDocument(embedding=torch.zeros((128,)))
 
     assert isinstance(d.embedding, TorchTensor)
     assert isinstance(d.embedding, TorchEmbedding)

--- a/tests/integrations/typing/test_torch_tensor.py
+++ b/tests/integrations/typing/test_torch_tensor.py
@@ -1,15 +1,21 @@
 import torch
 
 from docarray import Document
-from docarray.typing import TorchTensor
+from docarray.typing import TorchEmbedding, TorchTensor
 
 
 def test_set_torch_tensor():
     class MyDocument(Document):
         tensor: TorchTensor
+        embedding: TorchEmbedding
 
-    d = MyDocument(tensor=torch.zeros((3, 224, 224)))
+    d = MyDocument(tensor=torch.zeros((3, 224, 224)), embedding=torch.zeros((128,)))
 
     assert isinstance(d.tensor, TorchTensor)
     assert isinstance(d.tensor, torch.Tensor)
     assert (d.tensor == torch.zeros((3, 224, 224))).all()
+
+    assert isinstance(d.embedding, TorchTensor)
+    assert isinstance(d.embedding, TorchEmbedding)
+    assert isinstance(d.embedding, torch.Tensor)
+    assert (d.embedding == torch.zeros((128,))).all()

--- a/tests/integrations/typing/test_typing_proto.py
+++ b/tests/integrations/typing/test_typing_proto.py
@@ -27,4 +27,8 @@ def test_proto_all_types():
     new_doc = AnyDocument.from_protobuf(doc.to_protobuf())
 
     for field, value in new_doc:
-        assert isinstance(value, doc._get_nested_document_class(field))
+        if field == 'embedding':
+            # embedding is a Union type, not supported by isinstance
+            assert isinstance(value, np.ndarray) or isinstance(value, torch.Tensor)
+        else:
+            assert isinstance(value, doc._get_nested_document_class(field))

--- a/tests/units/typing/tensor/test_tensor.py
+++ b/tests/units/typing/tensor/test_tensor.py
@@ -5,6 +5,7 @@ from pydantic.tools import parse_obj_as, schema_json_of
 
 from docarray.document.io.json import orjson_dumps
 from docarray.typing import NdArray
+from docarray.typing.tensor import NdArrayEmbedding
 
 
 def test_proto_tensor():
@@ -72,3 +73,20 @@ def test_parametrized():
     # wrong and not reshapable shape
     with pytest.raises(ValueError):
         parse_obj_as(NdArray[3, 224, 224], np.zeros((224, 224)))
+
+
+def test_np_embedding():
+    # correct shape
+    tensor = parse_obj_as(NdArrayEmbedding[128], np.zeros((128,)))
+    assert isinstance(tensor, NdArrayEmbedding)
+    assert isinstance(tensor, NdArray)
+    assert isinstance(tensor, np.ndarray)
+    assert tensor.shape == (128,)
+
+    # wrong shape at data setting time
+    with pytest.raises(ValueError):
+        parse_obj_as(NdArrayEmbedding[128], np.zeros((256,)))
+
+    # illegal shape at class creation time
+    with pytest.raises(ValueError):
+        parse_obj_as(NdArrayEmbedding[128, 128], np.zeros((128, 128)))

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -3,7 +3,7 @@ import torch
 from pydantic.tools import parse_obj_as, schema_json_of
 
 from docarray.document.io.json import orjson_dumps
-from docarray.typing import TorchTensor
+from docarray.typing import TorchEmbedding, TorchTensor
 
 
 def test_proto_tensor():
@@ -57,3 +57,19 @@ def test_parametrized():
     # wrong and not reshapable shape
     with pytest.raises(ValueError):
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
+
+
+def test_torch_embedding():
+    # correct shape
+    tensor = parse_obj_as(TorchEmbedding[128], torch.zeros(128))
+    assert isinstance(tensor, TorchEmbedding)
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (128,)
+
+    # wrong shape at data setting time
+    with pytest.raises(ValueError):
+        parse_obj_as(TorchEmbedding[128], torch.zeros(256))
+
+    # illegal shape at class creation time
+    with pytest.raises(ValueError):
+        parse_obj_as(TorchEmbedding[128, 128], torch.zeros(128, 128))


### PR DESCRIPTION
Proper embedding type that allows only 1d tensors:

```python
class MyDoc(Document):
    emb1: TorchEmbedding  # ok
    emb2: TorchEmbedding[128]  # ok
    emb3: TorchEmbedding[3, 224, 224]  # not ok, fails
```
