### PR TITLE
fix: native milvus len

### DIFF
--- a/docarray/array/storage/base/seqlike.py
+++ b/docarray/array/storage/base/seqlike.py
@@ -50,7 +50,7 @@ class BaseSequenceLikeMixin(MutableSequence[Document]):
         ...
 
     def __len__(self):
-        return len(self._offset2ids)
+        ...
 
     def __iter__(self) -> Iterator['Document']:
         for _id in self._offset2ids:

--- a/docarray/array/storage/milvus/seqlike.py
+++ b/docarray/array/storage/milvus/seqlike.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Iterator, Union, TYPE_CHECKING
 from docarray.array.storage.base.seqlike import BaseSequenceLikeMixin
-from docarray.array.storage.milvus.backend import _batch_list
+from docarray.array.storage.milvus.backend import _batch_list, _always_true_expr
 from docarray import Document
 
 
@@ -56,3 +56,11 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             payload = self._docs_to_milvus_payload(docs_batch)
             self._collection.insert(payload, **kwargs)
             self._offset2ids.extend([doc.id for doc in docs_batch])
+
+    def __len__(self):
+        with self.loaded_collection():
+            res = self._collection.query(
+                expr=_always_true_expr('document_id'),
+                output_fields=['document_id'],
+            )
+            return len(res)

--- a/docarray/array/storage/milvus/seqlike.py
+++ b/docarray/array/storage/milvus/seqlike.py
@@ -58,9 +58,14 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
             self._offset2ids.extend([doc.id for doc in docs_batch])
 
     def __len__(self):
-        with self.loaded_collection():
-            res = self._collection.query(
-                expr=_always_true_expr('document_id'),
-                output_fields=['document_id'],
-            )
-            return len(res)
+        if self._list_like:
+            return len(self._offset2ids)
+        else:
+            # Milvus has no native way to get num of entities
+            # so only use it as fallback option
+            with self.loaded_collection():
+                res = self._collection.query(
+                    expr=_always_true_expr('document_id'),
+                    output_fields=['document_id'],
+                )
+                return len(res)

--- a/docs/advanced/document-store/extend.md
+++ b/docs/advanced/document-store/extend.md
@@ -145,6 +145,9 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
     def __add__(self, other: Union['Document', Iterable['Document']]):
         ...
 
+    def __len__(self):
+        ...
+
     def insert(self, index: int, value: 'Document'):
         # Optional. By default, this will add a new item and update offset2id
         # if you want to customize this, make sure to handle offset2id
@@ -156,10 +159,6 @@ class SequenceLikeMixin(BaseSequenceLikeMixin):
 
     def _extend(self, values: Iterable['Document']) -> None:
         # Optional. Override this if you have better implementation than appending one by one
-        ...
-
-    def __len__(self):
-        # Optional. By default, this will rely on offset2id to get the length
         ...
 
     def __iter__(self) -> Iterator['Document']:


### PR DESCRIPTION
Implement len (somewhat) natively for milvus, not retlying on offset2id.

Milvus has no real native way to get the number of entities in a collection, so we have to send a full-on general filter query with an expression that always evaluates to true, and then count the returns. Therefore this is only done if list-like is turned off.
