### PR TITLE
feat: add exclude fields metas parameter

### DIFF
--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -141,7 +141,7 @@ class PlotMixin:
         :param channel_axis: only used when `image_sprites=True`. the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
         :param start_server: if set, start a HTTP server and open the frontend directly. Otherwise, you need to rely on ``return`` path and serve by yourself.
         :param image_source: specify where the image comes from, can be ``uri`` or ``tensor``. empty tensor will fallback to uri
-        :param exclude_fields_metas: specify if you want to exclude fields from metadata csv file
+        :param exclude_fields_metas: specify the fields that you want to exclude from metadata csv file
         :return: the path to the embeddings visualization info.
         """
         from docarray.helper import random_port, __resources_path__

--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from collections import Counter
 from math import sqrt, ceil, floor
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import numpy as np
 
@@ -126,6 +126,7 @@ class PlotMixin:
         host: str = '127.0.0.1',
         port: Optional[int] = None,
         image_source: str = 'tensor',
+        exclude_fields_metas: Optional[List[str]] = None,
     ) -> str:
         """Interactively visualize :attr:`.embeddings` using the Embedding Projector.
 
@@ -140,6 +141,7 @@ class PlotMixin:
         :param channel_axis: only used when `image_sprites=True`. the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
         :param start_server: if set, start a HTTP server and open the frontend directly. Otherwise, you need to rely on ``return`` path and serve by yourself.
         :param image_source: specify where the image comes from, can be ``uri`` or ``tensor``. empty tensor will fallback to uri
+        :param exclude_fields_metas: specify if you want to exclude fields from metadata csv file
         :return: the path to the embeddings visualization info.
         """
         from docarray.helper import random_port, __resources_path__
@@ -178,7 +180,10 @@ class PlotMixin:
 
         self.save_embeddings_csv(os.path.join(path, emb_fn), delimiter='\t')
 
-        _exclude_fields = ('embedding', 'tensor', 'scores')
+        _exclude_fields = ['embedding', 'tensor', 'scores', 'chunks']
+        if exclude_fields_metas:
+            _exclude_fields = _exclude_fields + exclude_fields_metas
+
         with_header = True
         if len(set(self[0].non_empty_fields).difference(set(_exclude_fields))) <= 1:
             with_header = False

--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -180,7 +180,7 @@ class PlotMixin:
 
         self.save_embeddings_csv(os.path.join(path, emb_fn), delimiter='\t')
 
-        _exclude_fields = ['embedding', 'tensor', 'scores', 'chunks']
+        _exclude_fields = ['embedding', 'tensor', 'scores']
         if exclude_fields_metas:
             _exclude_fields = _exclude_fields + exclude_fields_metas
 

--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -126,9 +126,9 @@ class PlotMixin:
         host: str = '127.0.0.1',
         port: Optional[int] = None,
         image_source: str = 'tensor',
-        exclude_fields: Optional[List[str]] = None,
+        exclude_fields_metas: Optional[List[str]] = None,
     ) -> str:
-        """Interactively visualize :attr:`.embeddings` using the Embedding Projector.
+        """Interactively visualize :attr:`.embeddings` using the Embedding Projector and store the visualization informations.
 
         :param title: the title of this visualization. If you want to compare multiple embeddings at the same time,
                 make sure to give different names each time and set ``path`` to the same value.
@@ -141,7 +141,7 @@ class PlotMixin:
         :param channel_axis: only used when `image_sprites=True`. the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
         :param start_server: if set, start a HTTP server and open the frontend directly. Otherwise, you need to rely on ``return`` path and serve by yourself.
         :param image_source: specify where the image comes from, can be ``uri`` or ``tensor``. empty tensor will fallback to uri
-        :param exclude_fields: specify the fields that you want to exclude from metadata csv file
+        :param exclude_fields_metas: specify the fields that you want to exclude from metadata tsv file
         :return: the path to the embeddings visualization info.
         """
         from docarray.helper import random_port, __resources_path__
@@ -180,15 +180,20 @@ class PlotMixin:
 
         self.save_embeddings_csv(os.path.join(path, emb_fn), delimiter='\t')
 
-        _exclude_fields = ['embedding', 'tensor', 'scores'] + (exclude_fields or [])
+        _exclude_fields_metas = ['embedding', 'tensor', 'scores'] + (
+            exclude_fields_metas or []
+        )
 
         with_header = True
-        if len(set(self[0].non_empty_fields).difference(set(_exclude_fields))) <= 1:
+        if (
+            len(set(self[0].non_empty_fields).difference(set(_exclude_fields_metas)))
+            <= 1
+        ):
             with_header = False
 
         self.save_csv(
             os.path.join(path, meta_fn),
-            exclude_fields=_exclude_fields,
+            exclude_fields=_exclude_fields_metas,
             dialect='excel-tab',
             with_header=with_header,
         )

--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -126,7 +126,7 @@ class PlotMixin:
         host: str = '127.0.0.1',
         port: Optional[int] = None,
         image_source: str = 'tensor',
-        exclude_fields_metas: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
     ) -> str:
         """Interactively visualize :attr:`.embeddings` using the Embedding Projector.
 
@@ -141,7 +141,7 @@ class PlotMixin:
         :param channel_axis: only used when `image_sprites=True`. the axis id of the color channel, ``-1`` indicates the color channel info at the last axis
         :param start_server: if set, start a HTTP server and open the frontend directly. Otherwise, you need to rely on ``return`` path and serve by yourself.
         :param image_source: specify where the image comes from, can be ``uri`` or ``tensor``. empty tensor will fallback to uri
-        :param exclude_fields_metas: specify the fields that you want to exclude from metadata csv file
+        :param exclude_fields: specify the fields that you want to exclude from metadata csv file
         :return: the path to the embeddings visualization info.
         """
         from docarray.helper import random_port, __resources_path__
@@ -180,9 +180,7 @@ class PlotMixin:
 
         self.save_embeddings_csv(os.path.join(path, emb_fn), delimiter='\t')
 
-        _exclude_fields = ['embedding', 'tensor', 'scores'] + (
-            exclude_fields_metas or []
-        )
+        _exclude_fields = ['embedding', 'tensor', 'scores'] + (exclude_fields or [])
 
         with_header = True
         if len(set(self[0].non_empty_fields).difference(set(_exclude_fields))) <= 1:

--- a/docarray/array/mixins/plot.py
+++ b/docarray/array/mixins/plot.py
@@ -180,9 +180,9 @@ class PlotMixin:
 
         self.save_embeddings_csv(os.path.join(path, emb_fn), delimiter='\t')
 
-        _exclude_fields = ['embedding', 'tensor', 'scores']
-        if exclude_fields_metas:
-            _exclude_fields = _exclude_fields + exclude_fields_metas
+        _exclude_fields = ['embedding', 'tensor', 'scores'] + (
+            exclude_fields_metas or []
+        )
 
         with_header = True
         if len(set(self[0].non_empty_fields).difference(set(_exclude_fields))) <= 1:

--- a/docs/fundamentals/documentarray/visualization.md
+++ b/docs/fundamentals/documentarray/visualization.md
@@ -91,3 +91,8 @@ da.plot_embeddings(image_sprites=True)
 ```{figure} images/embedding-projector.gif
 :align: center
 ```
+
+````{admonition} Note
+:class: note
+If you have large amounts of metadata, the plotting might be slowed down since the metadata is stored in a corresponding csv file. With the `exclude_fields` parameter you can speed up plotting by excluding fields, such as `chunks` or `matches`, from storing to the csv metadata file.
+````

--- a/docs/fundamentals/documentarray/visualization.md
+++ b/docs/fundamentals/documentarray/visualization.md
@@ -94,5 +94,5 @@ da.plot_embeddings(image_sprites=True)
 
 ````{admonition} Note
 :class: note
-If you have a lot of metadata, plotting may be slow since that metadata is stored in a corresponding CSV file. You can speed up plotting with the `exclude_fields` parameter, preventing fields (like `chunks` or `matches`) from being written to the CSV.
+If you have a lot of metadata, plotting may be slow since that metadata is stored in a corresponding TSV file. You can speed up plotting with the `exclude_fields_metas` parameter, preventing fields (like `chunks` or `matches`) from being written to the TSV.
 ````

--- a/docs/fundamentals/documentarray/visualization.md
+++ b/docs/fundamentals/documentarray/visualization.md
@@ -94,5 +94,5 @@ da.plot_embeddings(image_sprites=True)
 
 ````{admonition} Note
 :class: note
-If you have large amounts of metadata, the plotting might be slowed down since the metadata is stored in a corresponding csv file. With the `exclude_fields` parameter you can speed up plotting by excluding fields, such as `chunks` or `matches`, from storing to the csv metadata file.
+If you have a lot of metadata, plotting may be slow since that metadata is stored in a corresponding CSV file. You can speed up plotting with the `exclude_fields` parameter, preventing fields (like `chunks` or `matches`) from being written to the CSV.
 ````


### PR DESCRIPTION
Signed-off-by: anna-charlotte <charlotte.gerhaher@jina.ai>

Add the option to exclude additional fields from csv metadata file, such as `.chunks` by adding the parameter `exclude_fields_metas` to `.plot_embedding`. 

- [x] add parameter `exclude_fields_metas`
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
