### PR TITLE
refactor(v2):  add namespace docarray to tensor private method

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -18,7 +18,7 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
 
     @classmethod
     @abc.abstractmethod
-    def __validate_shape__(cls, t: T, shape: Tuple[int]) -> T:
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:
         """Every tensor has to implement this method in order to
         enable syntax of the form Tensor[shape].
 
@@ -39,7 +39,7 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
         ...
 
     @classmethod
-    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
+    def __docarray_validate_getitem__(cls, item: Any) -> Tuple[int]:
         """This method validates the input to __class_getitem__.
 
         It is called at "class creation time",
@@ -65,7 +65,7 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
         return item
 
     @classmethod
-    def _create_parametrized_type(cls: Type[T], shape: Tuple[int]):
+    def _docarray_create_parametrized_type(cls: Type[T], shape: Tuple[int]):
         shape_str = ', '.join([str(s) for s in shape])
 
         class _ParametrizedTensor(
@@ -84,13 +84,13 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
                 config: 'BaseConfig',
             ):
                 t = super().validate(value, field, config)
-                return _cls.__validate_shape__(t, _cls._docarray_target_shape)
+                return _cls.__docarray_validate_shape__(t, _cls._docarray_target_shape)
 
         return _ParametrizedTensor
 
     def __class_getitem__(cls, item: Any):
-        target_shape = cls.__validate_getitem__(item)
-        return cls._create_parametrized_type(target_shape)
+        target_shape = cls.__docarray_validate_getitem__(item)
+        return cls._docarray_create_parametrized_type(target_shape)
 
     @classmethod
     @abc.abstractmethod

--- a/docarray/typing/tensor/embedding.py
+++ b/docarray/typing/tensor/embedding.py
@@ -12,8 +12,8 @@ class EmbeddingMixin(AbstractTensor, ABC):
     alternative_type: Optional[Type] = None
 
     @classmethod
-    def __validate_getitem__(cls, item: Any) -> Tuple[int]:
-        shape = super().__validate_getitem__(item)
+    def __docarray_validate_getitem__(cls, item: Any) -> Tuple[int]:
+        shape = super().__docarray_validate_getitem__(item)
         if len(shape) > 1:
             error_msg = f'`{cls}` can only have a single dimension/axis.'
             if cls.alternative_type:

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -77,7 +77,7 @@ class NdArray(AbstractTensor, np.ndarray, Generic[ShapeT]):
         yield cls.validate
 
     @classmethod
-    def __validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -94,7 +94,7 @@ class TorchTensor(
         yield cls.validate
 
     @classmethod
-    def __validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:


### PR DESCRIPTION
# Context

Our tensor type is built on top of torch tensor and numpy array. We inherit from both of this class and we add some custom prive function like `__validate_shape__` since that in a future we want to extend the tensor types to jax and tensorflow the likelihood that our custom private method clash with other framework private method increase. Therefore in this PR we rename all of the private method to `__docarray_XXX__`