### PR TITLE
fix: backwards compatibility for _is_subindex

### DIFF
--- a/docarray/array/mixins/setitem.py
+++ b/docarray/array/mixins/setitem.py
@@ -65,7 +65,7 @@ class SetItemMixin:
     ):
         from docarray.helper import check_root_id
 
-        if self._is_subindex:
+        if getattr(self, '_is_subindex', None):
             check_root_id(self, value)
 
         self._update_subindices_set(index, value)

--- a/docarray/array/storage/base/seqlike.py
+++ b/docarray/array/storage/base/seqlike.py
@@ -75,7 +75,7 @@ class BaseSequenceLikeMixin(MutableSequence[Document]):
 
         from docarray.helper import check_root_id
 
-        if self._is_subindex:
+        if getattr(self, '_is_subindex', None):
             check_root_id(self, values)
 
         self._extend(values, **kwargs)


### PR DESCRIPTION
Signed-off-by: AnneY <evangeline-lun@foxmail.com>

Goals:

Serialized DocumentArray from old version may not have the attribute `_is_subindex` set. This PR enable backwards compatibility for `_is_subindex`.