### PR TITLE
fix: add multiple connections to milvus

### DIFF
--- a/docarray/array/storage/milvus/backend.py
+++ b/docarray/array/storage/milvus/backend.py
@@ -128,7 +128,9 @@ class BackendMixin(BaseBackendMixin):
         self._config = config
         self._config.columns = self._normalize_columns(self._config.columns)
 
-        self._connection_alias = f'docarray_{config.host}_{config.port}'
+        self._connection_alias = (
+            f'docarray_{config.host}_{config.port}_{uuid.uuid4().hex}'
+        )
         connections.connect(
             alias=self._connection_alias, host=config.host, port=config.port
         )


### PR DESCRIPTION
Signed-off-by: anna-charlotte <charlotte.gerhaher@jina.ai>

Goals:

Create a new connection everytime `_init_storage()` is called from Milvus Document Storage.

- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
