### PR TITLE
fix(v2): parameterized tensor display

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -73,8 +73,6 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
             metaclass=cls.__parametrized_meta__,  # type: ignore
         ):
             _docarray_target_shape = shape
-            __name__ = f'{cls.__name__}[{shape_str}]'
-            __qualname__ = f'{cls.__qualname__}[{shape_str}]'
 
             @classmethod
             def validate(
@@ -85,6 +83,9 @@ class AbstractTensor(AbstractType, Generic[ShapeT], ABC):
             ):
                 t = super().validate(value, field, config)
                 return _cls.__docarray_validate_shape__(t, _cls._docarray_target_shape)
+
+        _ParametrizedTensor.__name__ = f'{cls.__name__}[{shape_str}]'
+        _ParametrizedTensor.__qualname__ = f'{cls.__qualname__}[{shape_str}]'
 
         return _ParametrizedTensor
 

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -58,9 +58,8 @@ def test_parametrized():
     with pytest.raises(ValueError):
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
 
-@pytest.mark.parametrize(
-    'shape', [(3, 224, 224), (224, 224, 3)]
-)
+
+@pytest.mark.parametrize('shape', [(3, 224, 224), (224, 224, 3)])
 def test_parameterized_tensor_class_name(shape):
     tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(shape))
 

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -58,15 +58,15 @@ def test_parametrized():
     with pytest.raises(ValueError):
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
 
+@pytest.mark.parametrize(
+    'shape', [(3, 224, 224), (224, 224, 3)]
+)
+def test_parameterized_tensor_class_name(shape):
+    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(shape))
 
-def test_parameterized_tensor_class_name():
-    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(3, 224, 224))
     assert tensor.__class__.__name__ == 'TorchTensor[3, 224, 224]'
     assert tensor.__class__.__qualname__ == 'TorchTensor[3, 224, 224]'
-
-    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224, 3))
-    assert tensor.__class__.__name__ == 'TorchTensor[3, 224, 224]'
-    assert tensor.__class__.__qualname__ == 'TorchTensor[3, 224, 224]'
+    assert f'{tensor[0][0][0]}' == 'TorchTensor[3, 224, 224](0.)'
 
 
 def test_torch_embedding():

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -59,6 +59,16 @@ def test_parametrized():
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
 
 
+def test_parameterized_tensor_class_name():
+    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(3, 224, 224))
+    assert tensor.__class__.__name__ == 'TorchTensor[3, 224, 224]'
+    assert tensor.__class__.__qualname__ == 'TorchTensor[3, 224, 224]'
+
+    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224, 3))
+    assert tensor.__class__.__name__ == 'TorchTensor[3, 224, 224]'
+    assert tensor.__class__.__qualname__ == 'TorchTensor[3, 224, 224]'
+
+
 def test_torch_embedding():
     # correct shape
     tensor = parse_obj_as(TorchEmbedding[128], torch.zeros(128))


### PR DESCRIPTION
Goals:
The parameterized tensor type is currently not correctly displayed

```python
from docarray import Document
from docarray.typing import TorchTensor

import torch

class MyDoc(Document):
    image_tensor: TorchTensor[3, 224, 224]
    tensor: TorchTensor


doc = MyDoc(tensor=torch.zeros(3, 224 ,224), image_tensor=torch.zeros(3, 224, 224))

print(doc.tensor[0][0][0])
print(doc.image_tensor[0][0][0])
>>>TorchTensor(0.)
>>> _ParametrizedTensor(0.)
```

Instead of `_ParametrizedTensor(0.)` we want it to print `TorchTensor[3, 224, 224](0.)`


- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
