### PR TITLE
docs: multimodal to datatypes

### DIFF
--- a/docs/datatypes/index.md
+++ b/docs/datatypes/index.md
@@ -1,4 +1,4 @@
-# Multimodal Data
+# Data Types
 
 DocArray lets you represent text, image, video, audio, and 3D meshes as Documents, whether separate, nested or combined, and process them as a DocumentArray. Here are some motivating examples:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ advanced/graphql-support/index
 
 
 ```{toctree}
-:caption: Developer References
+:caption: Developer Reference
 :hidden:
 :maxdepth: 1
 


### PR DESCRIPTION
Anyone got any objections to me changing "Multimodal Data" to "Data Types"?

Rationale: Most people working with DocArray are just working with one data type (as reflected in Google Analytics page/user views). Also we have "Multi-modal" under "Multimodal data" which seems odd.

I know we want to blow the multimodal trumpet, but I think it'd be good to get users building with DocArray for their single-data-types first then converting them to the cause.

- docs(index): fix developer reference(s) typo
- docs(datatypes): change page title to data types
