### PR TITLE
fix: remove offset index create on list like false elasticsearch

### DIFF
--- a/docarray/array/storage/elastic/backend.py
+++ b/docarray/array/storage/elastic/backend.py
@@ -126,7 +126,9 @@ class BackendMixin(BaseBackendMixin):
         return config_joined
 
     def _build_offset2id_index(self):
-        if not self._client.indices.exists(index=self._index_name_offset2id):
+        if self._list_like and not self._client.indices.exists(
+            index=self._index_name_offset2id
+        ):
             self._client.indices.create(index=self._index_name_offset2id, ignore=[404])
 
     def _build_schema_from_elastic_config(self, elastic_config):


### PR DESCRIPTION
Currently, when `list_like` is set to False, list-like operation is disabled but the offset2id elastic index still being created

Goals:

- handle offset2id index creation when list_like set to false
- ...
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
