### PR TITLE
fix: calculate relevant docs on index instead of queries

### DIFF
--- a/docarray/array/mixins/evaluation.py
+++ b/docarray/array/mixins/evaluation.py
@@ -465,6 +465,9 @@ class EvaluationMixin:
             num_relevant_documents_per_label = dict(
                 Counter([d.tags[label_tag] for d in index_data])
             )
+            if only_one_dataset and exclude_self:
+                for k, v in num_relevant_documents_per_label:
+                    num_relevant_documents_per_label[k] -= 1
         else:
             num_relevant_documents_per_label = None
 

--- a/docarray/array/mixins/evaluation.py
+++ b/docarray/array/mixins/evaluation.py
@@ -458,13 +458,12 @@ class EvaluationMixin:
                     new_matches.append(m)
                 query_data[doc.id, 'matches'] = new_matches
 
-        if ground_truth and label_tag in ground_truth[0].tags:
+        if (
+            not (ground_truth and len(ground_truth) > 0 and ground_truth[0].matches)
+            and label_tag in index_data[0].tags
+        ):
             num_relevant_documents_per_label = dict(
-                Counter([d.tags[label_tag] for d in ground_truth])
-            )
-        elif not ground_truth and label_tag in query_data[0].tags:
-            num_relevant_documents_per_label = dict(
-                Counter([d.tags[label_tag] for d in query_data])
+                Counter([d.tags[label_tag] for d in index_data])
             )
         else:
             num_relevant_documents_per_label = None

--- a/docarray/array/mixins/evaluation.py
+++ b/docarray/array/mixins/evaluation.py
@@ -466,7 +466,7 @@ class EvaluationMixin:
                 Counter([d.tags[label_tag] for d in index_data])
             )
             if only_one_dataset and exclude_self:
-                for k, v in num_relevant_documents_per_label:
+                for k, v in num_relevant_documents_per_label.items():
                     num_relevant_documents_per_label[k] -= 1
         else:
             num_relevant_documents_per_label = None

--- a/tests/unit/array/mixins/oldproto/test_eval_class.py
+++ b/tests/unit/array/mixins/oldproto/test_eval_class.py
@@ -529,6 +529,54 @@ def test_embed_and_evaluate_single_da(storage, config, start_storage):
 
 
 @pytest.mark.parametrize(
+    'exclude_self, expected_results',
+    [
+        (
+            True,
+            {
+                'r_precision': 1,
+                'precision_at_k': 1.0,
+                'hit_at_k': 1.0,
+                'average_precision': 1.0,
+                'reciprocal_rank': 1.0,
+                'recall_at_k': 5.0 / 9.0,
+                'f1_score_at_k': (10.0 / 9.0) / (5.0 / 9.0 + 1),
+                'ndcg_at_k': 1.0,
+            },
+        ),
+        (
+            False,
+            {
+                'r_precision': 1.0,
+                'precision_at_k': 1.0,
+                'hit_at_k': 1.0,
+                'average_precision': 1.0,
+                'reciprocal_rank': 1.0,
+                'recall_at_k': 0.5,
+                'f1_score_at_k': 1.0 / 1.5,
+                'ndcg_at_k': 1.0,
+            },
+        ),
+    ],
+)
+def test_embed_and_evaluate_with_and_without_exclude_self(
+    exclude_self, expected_results
+):
+    queries_da = DocumentArray(
+        [Document(text=str(i % 10), label=i % 10) for i in range(100)]
+    )
+    res = queries_da.embed_and_evaluate(
+        metrics=list(expected_results.keys()),
+        exclude_self=exclude_self,
+        embed_funcs=dummy_embed_function,
+        match_batch_size=1,
+        limit=5,
+    )
+    for key in expected_results:
+        assert abs(res[key] - expected_results[key]) < 1e-5
+
+
+@pytest.mark.parametrize(
     'sample_size',
     [None, 10],
 )
@@ -570,7 +618,7 @@ def test_embed_and_evaluate_two_das(storage, config, sample_size, start_storage)
 def test_embed_and_evaluate_two_different_das():
     queries_da = DocumentArray([Document(text=str(i), label=i % 10) for i in range(10)])
     index_da = DocumentArray(
-        [Document(text=str(i), label=i % 10) for i in range(10, 110)]
+        [Document(text=str(i % 10), label=i % 10) for i in range(10, 210)]
     )
     res = queries_da.embed_and_evaluate(
         index_data=index_da,
@@ -579,7 +627,10 @@ def test_embed_and_evaluate_two_different_das():
         match_batch_size=1,
         limit=10,
     )
-    print(res)
+    assert res['precision_at_k'] == 1.0
+    assert res['reciprocal_rank'] == 1.0
+    assert res['recall_at_k'] == 0.5
+    assert abs(res['f1_score_at_k'] - 1.0 / 1.5) < 1e-5
 
 
 @pytest.mark.parametrize(
@@ -654,7 +705,16 @@ def test_embed_and_evaluate_labeled_dataset(
     ],
 )
 def test_embed_and_evaluate_on_real_data(two_embed_funcs, kwargs):
-    metric_names = ['precision_at_k', 'reciprocal_rank', 'recall_at_k']
+    metric_names = [
+        'r_precision',
+        'precision_at_k',
+        'hit_at_k',
+        'average_precision',
+        'reciprocal_rank',
+        'recall_at_k',
+        'f1_score_at_k',
+        'ndcg_at_k',
+    ]
 
     labels = ['18828_alt.atheism', '18828_comp.graphics']
     news = [load_dataset('newsgroup', label) for label in labels]

--- a/tests/unit/array/mixins/oldproto/test_eval_class.py
+++ b/tests/unit/array/mixins/oldproto/test_eval_class.py
@@ -541,7 +541,6 @@ def test_embed_and_evaluate_single_da(storage, config, start_storage):
                 'reciprocal_rank': 1.0,
                 'recall_at_k': 5.0 / 9.0,
                 'f1_score_at_k': (10.0 / 9.0) / (5.0 / 9.0 + 1),
-                'ndcg_at_k': 1.0,
             },
         ),
         (
@@ -554,7 +553,6 @@ def test_embed_and_evaluate_single_da(storage, config, start_storage):
                 'reciprocal_rank': 1.0,
                 'recall_at_k': 0.5,
                 'f1_score_at_k': 1.0 / 1.5,
-                'ndcg_at_k': 1.0,
             },
         ),
     ],
@@ -622,12 +620,23 @@ def test_embed_and_evaluate_two_different_das():
     )
     res = queries_da.embed_and_evaluate(
         index_data=index_da,
-        metrics=['precision_at_k', 'reciprocal_rank', 'recall_at_k', 'f1_score_at_k'],
+        metrics=[
+            'r_precision',
+            'precision_at_k',
+            'hit_at_k',
+            'average_precision',
+            'reciprocal_rank',
+            'recall_at_k',
+            'f1_score_at_k',
+        ],
         embed_funcs=dummy_embed_function,
         match_batch_size=1,
         limit=10,
     )
+    assert res['r_precision'] == 1.0
     assert res['precision_at_k'] == 1.0
+    assert res['hit_at_k'] == 1.0
+    assert res['average_precision'] == 1.0
     assert res['reciprocal_rank'] == 1.0
     assert res['recall_at_k'] == 0.5
     assert abs(res['f1_score_at_k'] - 1.0 / 1.5) < 1e-5
@@ -713,7 +722,7 @@ def test_embed_and_evaluate_on_real_data(two_embed_funcs, kwargs):
         'reciprocal_rank',
         'recall_at_k',
         'f1_score_at_k',
-        'ndcg_at_k',
+        'dcg_at_k',
     ]
 
     labels = ['18828_alt.atheism', '18828_comp.graphics']


### PR DESCRIPTION
Goals:

- The `num_relevant_documents_per_label` is calculated in the `embed_and_evaluate` method on the documents in `self`. However, this is only correct if `self` is matched against itself. Instead it should be calculated on the `index_data` attribute if it is provided.

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
