### PR TITLE
feat: support device_id in embed

### DIFF
--- a/docarray/array/mixins/embed.py
+++ b/docarray/array/mixins/embed.py
@@ -186,10 +186,18 @@ class EmbedMixin:
             provider_options = [
                 {
                     'device_id': device_id,
-                    'arena_extend_strategy': 'kNextPowerOfTwo',
-                    'gpu_mem_limit': 2 * 1024 * 1024 * 1024,
-                    'cudnn_conv_algo_search': 'EXHAUSTIVE',
-                    'do_copy_in_default_stream': True,
+                    'arena_extend_strategy': kwargs.get(
+                        'arena_extend_strategy', 'kNextPowerOfTwo'
+                    ),
+                    'gpu_mem_limit': kwargs.get(
+                        'gpu_mem_limit', 2 * 1024 * 1024 * 1024
+                    ),
+                    'cudnn_conv_algo_search': kwargs.get(
+                        'cudnn_conv_algo_search', 'EXHAUSTIVE'
+                    ),
+                    'do_copy_in_default_stream': kwargs.get(
+                        'do_copy_in_default_stream', True
+                    ),
                 }
             ]
         else:

--- a/docs/fundamentals/documentarray/embedding.md
+++ b/docs/fundamentals/documentarray/embedding.md
@@ -6,7 +6,7 @@ you can use a neural network to {meth}`~docarray.array.mixins.embed.EmbedMixin.e
 i.e. filling `.embeddings`.
 
 Embeddings can be used to measure the relatedness of your data.
-Common cases include neural search, recommendation, clustering, outlier detection, deduplication etc.
+Common use cases include neural search, recommendation, clustering, outlier detection, deduplication, etc.
 
 Docarray provides an easy interface which allows you to encode your data with
 the {meth}`~docarray.array.mixins.embed.EmbedMixin.embed` method.

--- a/docs/fundamentals/documentarray/embedding.md
+++ b/docs/fundamentals/documentarray/embedding.md
@@ -6,7 +6,7 @@ you can use a neural network to {meth}`~docarray.array.mixins.embed.EmbedMixin.e
 i.e. filling `.embeddings`.
 
 Embeddings can be used to measure the relatedness of your data.
-Embeddings are commonly used for *neural search*, *recommendation*, *clustering*, *outlier detection*, *deduplication* etc.
+Common cases include neural search, recommendation, clustering, outlier detection, deduplication etc.
 
 Docarray provides an easy interface which allows you to encode your data with
 the {meth}`~docarray.array.mixins.embed.EmbedMixin.embed` method.

--- a/docs/fundamentals/documentarray/embedding.md
+++ b/docs/fundamentals/documentarray/embedding.md
@@ -20,8 +20,6 @@ Docarray {meth}`~docarray.array.mixins.embed.EmbedMixin.embed` endpoint support:
 2. Both CPU and CUDA devices.
 3. Embed in batches.
 
-## Embed in action
-
 ### Embed for Computer Vision
 
 ````{tab} Torchvision ResNet50
@@ -115,7 +113,7 @@ def collate_fn(da):
     )
 
 docs = DocumentArray.empty(1)
-docs.texts = ['this is some random text to embed']
+docs.texts = ['embed me!']
 docs.embed(model, collate_fn=collate_fn)
 ```
 
@@ -131,7 +129,7 @@ token = ''
 co = cohere.Client(token)
 
 docs = DocumentArray.empty(1)
-docs.texts = ['this is some random text to embed']
+docs.texts = ['embed me!']
 docs.embeddings = np.array(
     co.embed(docs.texts).embeddings
 )
@@ -146,7 +144,7 @@ from docarray import DocumentArray
 openai.api_key = ''
 
 docs = DocumentArray.empty(1)
-docs.texts = ['this is some random text to embed']
+docs.texts = ['embed me!']
 
 for doc in docs:
     doc.embedding = np.array(

--- a/docs/fundamentals/documentarray/embedding.md
+++ b/docs/fundamentals/documentarray/embedding.md
@@ -96,8 +96,9 @@ not suitable for serving as embedding layers.
 ```
 
 
-### Embed with Huggingface Transformers
+### Embed with Transformers
 
+````{tab} Huggingface Transformers
 ```python
 from docarray import DocumentArray
 from transformers import BertModel, BertTokenizer
@@ -116,6 +117,19 @@ docs = DocumentArray.empty(1)
 docs.texts = ['embed me!']
 docs.embed(model, collate_fn=collate_fn)
 ```
+````
+````{tab} Sentence Transformers
+```python
+from docarray import DocumentArray
+from sentence_transformers import SentenceTransformer
+
+model = SentenceTransformer('all-MiniLM-L6-v2')
+
+docs = DocumentArray.empty(1)
+docs.texts = ['embed me!']
+docs.embeddings = model.encode(docs.texts)
+```
+````
 
 ### Embed with Cohere & OpenAI API
 


### PR DESCRIPTION
Signed-off-by: bwanglzu <bo.wang@jina.ai>

Goals:

1. This pull request allow user to specify a `device_id` along with their `cuda` device. This give users more flexibility when inferencing with GPU, with no breaking change.
2. [I re-write the `embed documentarray` page completely,](https://ft-feat-embed-device-id--jina-docs.netlify.app/fundamentals/documentarray/embedding/) with more practical examples on how to embed using 3rd party providers, such as `torchvision`, `timm`, `paddlepaddle.vision`, `transformers`, `openai` and `cohere`. **every code snnippt can be copy-paste and run as it is (except 2 endpoint needs user token)**

Usage:

```diff
da.embed(
    embed_model='resnet_50_without_fc',
    device='cuda',
+   device_id=2,  # use the cuda device with index 2
    ...,
)
```

This one should also fix a paddle issue: paddle paddle use `gpu:device_id` to select cuda devices, not `cuda`. docs [here](https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/device/set_device_en.html#set-device).
The previous version of ONNX seems to be not working, now i'm adopting the code from [ONNX](https://github.com/microsoft/onnxruntime/blob/78a29aebbcbd0c3b6dab734f221e0f3bf1e24c97/onnxruntime/python/session.py#L57)


Need to test:

- [x] cuda on torch
- [x] cuda on tf
- [x] cuda on paddle
- [x] cuda on onnx

Need to change:

- [x] code
- [x] documentation

