### PR TITLE
refactor: rename tensor to anytensor

### DIFF
--- a/docarray/predefined_document/image.py
+++ b/docarray/predefined_document/image.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from docarray.document import BaseDocument
-from docarray.typing import Embedding, ImageUrl, Tensor
+from docarray.typing import AnyTensor, Embedding, ImageUrl
 
 
 class Image(BaseDocument):
@@ -64,5 +64,5 @@ class Image(BaseDocument):
     """
 
     url: Optional[ImageUrl]
-    tensor: Optional[Tensor]
+    tensor: Optional[AnyTensor]
     embedding: Optional[Embedding]

--- a/docarray/predefined_document/mesh.py
+++ b/docarray/predefined_document/mesh.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from docarray.document import BaseDocument
-from docarray.typing import Embedding, Mesh3DUrl, Tensor
+from docarray.typing import AnyTensor, Embedding, Mesh3DUrl
 
 
 class Mesh3D(BaseDocument):
@@ -73,6 +73,6 @@ class Mesh3D(BaseDocument):
     """
 
     url: Optional[Mesh3DUrl]
-    vertices: Optional[Tensor]
-    faces: Optional[Tensor]
+    vertices: Optional[AnyTensor]
+    faces: Optional[AnyTensor]
     embedding: Optional[Embedding]

--- a/docarray/predefined_document/point_cloud.py
+++ b/docarray/predefined_document/point_cloud.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from docarray.document import BaseDocument
-from docarray.typing import Embedding, PointCloud3DUrl, Tensor
+from docarray.typing import AnyTensor, Embedding, PointCloud3DUrl
 
 
 class PointCloud3D(BaseDocument):
@@ -72,5 +72,5 @@ class PointCloud3D(BaseDocument):
     """
 
     url: Optional[PointCloud3DUrl]
-    tensor: Optional[Tensor]
+    tensor: Optional[AnyTensor]
     embedding: Optional[Embedding]

--- a/docarray/typing/__init__.py
+++ b/docarray/typing/__init__.py
@@ -1,5 +1,5 @@
 from docarray.typing.id import ID
-from docarray.typing.tensor import NdArray, Tensor
+from docarray.typing.tensor import AnyTensor, NdArray
 from docarray.typing.tensor.embedding import Embedding
 from docarray.typing.url import AnyUrl, ImageUrl, Mesh3DUrl, PointCloud3DUrl, TextUrl
 
@@ -12,7 +12,7 @@ __all__ = [
     'PointCloud3DUrl',
     'AnyUrl',
     'ID',
-    'Tensor',
+    'AnyTensor',
 ]
 
 try:

--- a/docarray/typing/tensor/__init__.py
+++ b/docarray/typing/tensor/__init__.py
@@ -1,10 +1,10 @@
 from docarray.typing.tensor.embedding import Embedding, NdArrayEmbedding
 from docarray.typing.tensor.ndarray import NdArray
-from docarray.typing.tensor.tensor import Tensor
+from docarray.typing.tensor.tensor import AnyTensor
 
 __all__ = [
     'NdArray',
-    'Tensor',
+    'AnyTensor',
     'Embedding',
     'NdArrayEmbedding',
 ]

--- a/docarray/typing/tensor/tensor.py
+++ b/docarray/typing/tensor/tensor.py
@@ -5,9 +5,9 @@ from docarray.typing.tensor.ndarray import NdArray
 try:
     import torch  # noqa: F401
 except ImportError:
-    Tensor = Union[NdArray]  # type: ignore
+    AnyTensor = Union[NdArray]  # type: ignore
 
 else:
     from docarray.typing.tensor.torch_tensor import TorchTensor  # noqa: F401
 
-    Tensor = Union[NdArray, TorchTensor]  # type: ignore
+    AnyTensor = Union[NdArray, TorchTensor]  # type: ignore

--- a/docarray/util/find.py
+++ b/docarray/util/find.py
@@ -1,18 +1,18 @@
 from typing import List, NamedTuple, Optional, Type, Union
 
 from docarray import Document, DocumentArray
-from docarray.typing import Tensor
+from docarray.typing import AnyTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
 
 class FindResult(NamedTuple):
     documents: DocumentArray
-    scores: Tensor
+    scores: AnyTensor
 
 
 def find(
     index: DocumentArray,
-    query: Union[Tensor, Document],
+    query: Union[AnyTensor, Document],
     embedding_field: str = 'embedding',
     metric: str = 'cosine_sim',
     limit: int = 10,
@@ -101,7 +101,7 @@ def find(
 
 def find_batched(
     index: DocumentArray,
-    query: Union[Tensor, DocumentArray],
+    query: Union[AnyTensor, DocumentArray],
     embedding_field: str = 'embedding',
     metric: str = 'cosine_sim',
     limit: int = 10,
@@ -208,9 +208,9 @@ def find_batched(
 
 
 def _extract_embedding_single(
-    data: Union[DocumentArray, Document, Tensor],
+    data: Union[DocumentArray, Document, AnyTensor],
     embedding_field: str,
-) -> Tensor:
+) -> AnyTensor:
     """Extract the embeddings from a single query,
     and return it in a batched representation.
 
@@ -231,10 +231,10 @@ def _extract_embedding_single(
 
 
 def _extraxt_embeddings(
-    data: Union[DocumentArray, Document, Tensor],
+    data: Union[DocumentArray, Document, AnyTensor],
     embedding_field: str,
     embedding_type: Type,
-) -> Tensor:
+) -> AnyTensor:
     """Extract the embeddings from the data.
 
     :param data: the data
@@ -259,7 +259,7 @@ def _extraxt_embeddings(
     return emb
 
 
-def _da_attr_type(da: DocumentArray, attr: str) -> Type[Tensor]:
+def _da_attr_type(da: DocumentArray, attr: str) -> Type[AnyTensor]:
     """Get the type of the attribute according to the Document type
     (schema) of the DocumentArray.
 

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -3,13 +3,13 @@ import torch
 
 from docarray import Document, Image, Text
 from docarray.typing import (
+    AnyTensor,
     AnyUrl,
     Embedding,
     ImageUrl,
     Mesh3DUrl,
     NdArray,
     PointCloud3DUrl,
-    Tensor,
     TextUrl,
     TorchEmbedding,
     TorchTensor,
@@ -44,8 +44,8 @@ def test_all_types():
         torch_tensor_param: TorchTensor[224, 224, 3]
         np_array: NdArray
         np_array_param: NdArray[224, 224, 3]
-        generic_nd_array: Tensor
-        generic_torch_tensor: Tensor
+        generic_nd_array: AnyTensor
+        generic_torch_tensor: AnyTensor
         embedding: Embedding
         torch_embedding: TorchEmbedding[128]
         np_embedding: NdArrayEmbedding[128]

--- a/tests/integrations/typing/test_tensor.py
+++ b/tests/integrations/typing/test_tensor.py
@@ -2,12 +2,12 @@ import numpy as np
 import torch
 
 from docarray import Document
-from docarray.typing import NdArray, Tensor, TorchTensor
+from docarray.typing import AnyTensor, NdArray, TorchTensor
 
 
 def test_set_tensor():
     class MyDocument(Document):
-        tensor: Tensor
+        tensor: AnyTensor
 
     d = MyDocument(tensor=np.zeros((3, 224, 224)))
 


### PR DESCRIPTION
Signed-off-by: Johannes Messner <messnerjo@gmail.com>

Goals:

Rename type `Tensor` to `AnyTensor`. This should make it a bit more intuitive that it is just a Union type, and maybe steer users towards the specific tensor types
