### PR TITLE
fix: replace newline with whitespace to fix display in plot embeddings

### DIFF
--- a/docarray/array/mixins/io/csv.py
+++ b/docarray/array/mixins/io/csv.py
@@ -78,17 +78,17 @@ class CsvIOMixin:
                 writer.writeheader()
 
             for d in self:
-                pd = d.to_dict(
+                doc_dict = d.to_dict(
                     protocol='jsonschema',
                     exclude=set(exclude_fields) if exclude_fields else None,
                     exclude_none=True,
                 )
                 if flatten_tags:
-                    t = pd.pop('tags')
-                    pd.update({f'tag__{k}': v for k, v in t.items()})
+                    t = doc_dict.pop('tags')
+                    doc_dict.update({f'tag__{k}': v for k, v in t.items()})
 
-                pd = {k: str(v).replace('\n', ' ') for k, v in pd.items()}
-                writer.writerow(pd)
+                doc_dict = {k: str(v).replace('\n', ' ') for k, v in doc_dict.items()}
+                writer.writerow(doc_dict)
 
     @classmethod
     def load_csv(

--- a/docarray/array/mixins/io/csv.py
+++ b/docarray/array/mixins/io/csv.py
@@ -86,6 +86,8 @@ class CsvIOMixin:
                 if flatten_tags:
                     t = pd.pop('tags')
                     pd.update({f'tag__{k}': v for k, v in t.items()})
+
+                pd = {k: str(v).replace('\n', ' ') for k, v in pd.items()}
                 writer.writerow(pd)
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: anna-charlotte <charlotte.gerhaher@jina.ai>

If a Documents fields contain '\n' this messes up the display in `.plot_embeddings()`. 
Therefore we want to replace all '\n' with whitespaces for display.

E.g. for the following Document:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/73693835/210211574-c20e91ae-4a21-4baa-8e96-8a2823a605e0.png">

The information of that Document looks like this:
<img width="600" alt="Screenshot 2023-01-02 at 09 27 03" src="https://user-images.githubusercontent.com/73693835/210211355-fb19c0c8-2e50-42df-a457-f99d1e73ec60.png">

But should look like this:
<img width="600" alt="Screenshot 2023-01-02 at 09 06 41" src="https://user-images.githubusercontent.com/73693835/210211374-e1a767e1-ebb7-4479-9f5d-83f1247a7c5a.png">


- [x] replace all '\n' with whitespaces in `.plot_embeddings()`
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
