### PR TITLE
refactor(v2): rename Document to BaseDocument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           python -m pip install poetry
           poetry install --without dev
       - name: Test basic import
-        run: poetry run python -c 'from docarray import DocumentArray, Document'
+        run: poetry run python -c 'from docarray import DocumentArray, BaseDocument'
 
 
   check-mypy:

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ doc.embedding = CLIPImageEncoder()(
 ### Compose nested Documents:
 
 ```python
-from docarray import Image, Text, Document
+from docarray import Image, Text, BaseDocument
 import numpy as np
 
 
-class MultiModalDocument(Document):
+class MultiModalDocument(BaseDocument):
     image_doc: Image
     text_doc: Text
 

--- a/docarray/__init__.py
+++ b/docarray/__init__.py
@@ -1,7 +1,7 @@
 __version__ = '0.1.0'
 
 from docarray.array.array import DocumentArray
-from docarray.document.document import BaseDocument as Document
+from docarray.document.document import BaseDocument
 from docarray.predefined_document import Image, Mesh3D, PointCloud3D, Text
 
-__all__ = ['Document', 'DocumentArray', 'Image', 'Text', 'Mesh3D', 'PointCloud3D']
+__all__ = ['BaseDocument', 'DocumentArray', 'Image', 'Text', 'Mesh3D', 'PointCloud3D']

--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -109,14 +109,14 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
 
         EXAMPLE USAGE
         .. code-block:: python
-            from docarray import Document, DocumentArray, Text
+            from docarray import BaseDocument, DocumentArray, Text
 
 
-            class Author(Document):
+            class Author(BaseDocument):
                 name: str
 
 
-            class Book(Document):
+            class Book(BaseDocument):
                 author: Author
                 content: Text
 
@@ -134,14 +134,14 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
 
         EXAMPLE USAGE
         .. code-block:: python
-            from docarray import Document, DocumentArray
+            from docarray import BaseDocument, DocumentArray
 
 
-            class Chapter(Document):
+            class Chapter(BaseDocument):
                 content: str
 
 
-            class Book(Document):
+            class Book(BaseDocument):
                 chapters: DocumentArray[Chapter]
 
 
@@ -161,7 +161,7 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
 
         EXAMPLE USAGE
         .. code-block:: python
-            class Image(Document):
+            class Image(BaseDocument):
                 tensor: TorchTensor[3, 224, 224]
 
 

--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -51,11 +51,11 @@ class DocumentArray(AnyDocumentArray):
 
     EXAMPLE USAGE
     .. code-block:: python
-        from docarray import Document, DocumentArray
+        from docarray import BaseDocument, DocumentArray
         from docarray.typing import NdArray, ImageUrl
 
 
-        class Image(Document):
+        class Image(BaseDocument):
             tensor: Optional[NdArray[100]]
             url: ImageUrl
 

--- a/docarray/predefined_document/image.py
+++ b/docarray/predefined_document/image.py
@@ -48,10 +48,10 @@ class Image(BaseDocument):
 
     .. code-block:: python
 
-        from docarray import Document, Image, Text
+        from docarray import BaseDocument, Image, Text
 
         # compose it
-        class MultiModalDoc(Document):
+        class MultiModalDoc(BaseDocument):
             image: Image
             text: Text
 

--- a/docarray/predefined_document/mesh.py
+++ b/docarray/predefined_document/mesh.py
@@ -57,10 +57,10 @@ class Mesh3D(BaseDocument):
 
     .. code-block:: python
 
-        from docarray import Document, Mesh3D, Text
+        from docarray import BaseDocument, Mesh3D, Text
 
         # compose it
-        class MultiModalDoc(Document):
+        class MultiModalDoc(BaseDocument):
             mesh: Mesh3D
             text: Text
 

--- a/docarray/predefined_document/point_cloud.py
+++ b/docarray/predefined_document/point_cloud.py
@@ -54,10 +54,10 @@ class PointCloud3D(BaseDocument):
 
     .. code-block:: python
 
-        from docarray import Document, PointCloud3D, Text
+        from docarray import BaseDocument, PointCloud3D, Text
 
         # compose it
-        class MultiModalDoc(Document):
+        class MultiModalDoc(BaseDocument):
             point_cloud: PointCloud3D
             text: Text
 

--- a/docarray/predefined_document/text.py
+++ b/docarray/predefined_document/text.py
@@ -49,10 +49,10 @@ class Text(BaseDocument):
 
     .. code-block:: python
 
-        from docarray import Document, Image, Text
+        from docarray import BaseDocument, Image, Text
 
         # compose it
-        class MultiModalDoc(Document):
+        class MultiModalDoc(BaseDocument):
             image_doc: Image
             text_doc: Text
 

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -39,12 +39,12 @@ class NdArray(AbstractTensor, np.ndarray, Generic[ShapeT]):
 
     .. code-block:: python
 
-        from docarray import Document
+        from docarray import BaseDocument
         from docarray.typing import NdArray
         import numpy as np
 
 
-        class MyDoc(Document):
+        class MyDoc(BaseDocument):
             arr: NdArray
             image_arr: NdArray[3, 224, 224]
 

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -44,12 +44,12 @@ class TorchTensor(
 
     .. code-block:: python
 
-        from docarray import Document
+        from docarray import BaseDocument
         from docarray.typing import TorchTensor
         import torch
 
 
-        class MyDoc(Document):
+        class MyDoc(BaseDocument):
             tensor: TorchTensor
             image_tensor: TorchTensor[3, 224, 224]
 

--- a/docarray/typing/url/image_url.py
+++ b/docarray/typing/url/image_url.py
@@ -66,12 +66,12 @@ class ImageUrl(AnyUrl):
 
         .. code-block:: python
 
-            from docarray import Document
+            from docarray import BaseDocument
             from docarray.typing import ImageUrl
             import numpy as np
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 img_url: ImageUrl
 
 
@@ -117,12 +117,12 @@ class ImageUrl(AnyUrl):
 
         .. code-block:: python
 
-            from docarray import Document
+            from docarray import BaseDocument
             from docarray.typing import ImageUrl
             import numpy as np
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 img_url: ImageUrl
 
 

--- a/docarray/typing/url/text_url.py
+++ b/docarray/typing/url/text_url.py
@@ -32,11 +32,11 @@ class TextUrl(AnyUrl):
 
         .. code-block:: python
 
-            from docarray import Document
+            from docarray import BaseDocument
             from docarray.typing import TextUrl
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 remote_url: TextUrl
                 local_url: TextUrl
 
@@ -63,11 +63,11 @@ class TextUrl(AnyUrl):
 
         .. code-block:: python
 
-            from docarray import Document
+            from docarray import BaseDocument
             from docarray.typing import TextUrl
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 remote_url: TextUrl
                 local_url: TextUrl
 

--- a/docarray/typing/url/url_3d/mesh_url.py
+++ b/docarray/typing/url/url_3d/mesh_url.py
@@ -36,13 +36,13 @@ class Mesh3DUrl(Url3D):
 
         .. code-block:: python
 
-            from docarray import Document
+            from docarray import BaseDocument
             import numpy as np
 
             from docarray.typing import Mesh3DUrl
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 mesh_url: Mesh3DUrl
 
 

--- a/docarray/typing/url/url_3d/point_cloud_url.py
+++ b/docarray/typing/url/url_3d/point_cloud_url.py
@@ -37,12 +37,12 @@ class PointCloud3DUrl(Url3D):
         .. code-block:: python
 
             import numpy as np
-            from docarray import Document
+            from docarray import BaseDocument
 
             from docarray.typing import PointCloud3DUrl
 
 
-            class MyDoc(Document):
+            class MyDoc(BaseDocument):
                 point_cloud_url: PointCloud3DvUrl
 
 

--- a/docarray/util/find.py
+++ b/docarray/util/find.py
@@ -2,7 +2,7 @@ from typing import List, NamedTuple, Optional, Type, Union
 
 from typing_inspect import is_union_type
 
-from docarray import Document, DocumentArray
+from docarray import BaseDocument, DocumentArray
 from docarray.array.abstract_array import AnyDocumentArray
 from docarray.array.array_stacked import DocumentArrayStacked
 from docarray.typing import AnyTensor
@@ -16,7 +16,7 @@ class FindResult(NamedTuple):
 
 def find(
     index: AnyDocumentArray,
-    query: Union[AnyTensor, Document],
+    query: Union[AnyTensor, BaseDocument],
     embedding_field: str = 'embedding',
     metric: str = 'cosine_sim',
     limit: int = 10,
@@ -43,12 +43,12 @@ def find(
 
     .. code-block:: python
 
-        from docarray import DocumentArray, Document
+        from docarray import DocumentArray, BaseDocument
         from docarray.typing import TorchTensor
         from docarray.util.find import find
 
 
-        class MyDocument(Document):
+        class MyDocument(BaseDocument):
             embedding: TorchTensor
 
 
@@ -132,12 +132,12 @@ def find_batched(
 
     .. code-block:: python
 
-        from docarray import DocumentArray, Document
+        from docarray import DocumentArray, BaseDocument
         from docarray.typing import TorchTensor
         from docarray.util.find import find
 
 
-        class MyDocument(Document):
+        class MyDocument(BaseDocument):
             embedding: TorchTensor
 
 
@@ -212,7 +212,7 @@ def find_batched(
 
 
 def _extract_embedding_single(
-    data: Union[DocumentArray, Document, AnyTensor],
+    data: Union[DocumentArray, BaseDocument, AnyTensor],
     embedding_field: str,
 ) -> AnyTensor:
     """Extract the embeddings from a single query,
@@ -223,7 +223,7 @@ def _extract_embedding_single(
     :param embedding_type: type of the embedding: torch.Tensor, numpy.ndarray etc.
     :return: the embeddings
     """
-    if isinstance(data, Document):
+    if isinstance(data, BaseDocument):
         emb = getattr(data, embedding_field)
     else:  # treat data as tensor
         emb = data
@@ -235,7 +235,7 @@ def _extract_embedding_single(
 
 
 def _extraxt_embeddings(
-    data: Union[AnyDocumentArray, Document, AnyTensor],
+    data: Union[AnyDocumentArray, BaseDocument, AnyTensor],
     embedding_field: str,
     embedding_type: Type,
 ) -> AnyTensor:
@@ -252,7 +252,7 @@ def _extraxt_embeddings(
         emb = embedding_type.__docarray_stack__(emb)
     elif isinstance(data, DocumentArrayStacked):
         emb = getattr(data, embedding_field)
-    elif isinstance(data, Document):
+    elif isinstance(data, BaseDocument):
         emb = getattr(data, embedding_field)
     else:  # treat data as tensor
         emb = data

--- a/tests/integrations/array/test_torch_train.py
+++ b/tests/integrations/array/test_torch_train.py
@@ -2,12 +2,12 @@ from typing import Optional
 
 import torch
 
-from docarray import Document, DocumentArray
+from docarray import BaseDocument, DocumentArray
 from docarray.typing import TorchTensor
 
 
 def test_torch_train():
-    class Mmdoc(Document):
+    class Mmdoc(BaseDocument):
         text: str
         tensor: Optional[TorchTensor[3, 224, 224]]
 

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -1,10 +1,10 @@
 import numpy as np
 
-from docarray import Document, DocumentArray, Image, Text
+from docarray import BaseDocument, DocumentArray, Image, Text
 
 
 def test_multi_modal_doc():
-    class MyMultiModalDoc(Document):
+    class MyMultiModalDoc(BaseDocument):
         image: Image
         text: Text
 
@@ -12,7 +12,7 @@ def test_multi_modal_doc():
         image=Image(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
     )
 
-    assert isinstance(doc.image, Document)
+    assert isinstance(doc.image, BaseDocument)
     assert isinstance(doc.image, Image)
     assert isinstance(doc.text, Text)
 
@@ -21,7 +21,7 @@ def test_multi_modal_doc():
 
 
 def test_nested_chunks_document():
-    class ChunksDocument(Document):
+    class ChunksDocument(BaseDocument):
         text: str
         images: DocumentArray[Image]
 

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from docarray import Document, DocumentArray, Image, Text
+from docarray import BaseDocument, DocumentArray, Image, Text
 from docarray.typing import (
     AnyTensor,
     AnyUrl,
@@ -18,11 +18,11 @@ from docarray.typing.tensor import NdArrayEmbedding
 
 
 def test_multi_modal_doc_proto():
-    class MyMultiModalDoc(Document):
+    class MyMultiModalDoc(BaseDocument):
         image: Image
         text: Text
 
-    class MySUperDoc(Document):
+    class MySUperDoc(BaseDocument):
         doc: MyMultiModalDoc
         description: str
 
@@ -34,10 +34,10 @@ def test_multi_modal_doc_proto():
 
 
 def test_all_types():
-    class NestedDoc(Document):
+    class NestedDoc(BaseDocument):
         tensor: NdArray
 
-    class MyDoc(Document):
+    class MyDoc(BaseDocument):
         img_url: ImageUrl
         txt_url: TextUrl
         mesh_url: Mesh3DUrl

--- a/tests/integrations/externals/test_fastapi.py
+++ b/tests/integrations/externals/test_fastapi.py
@@ -3,13 +3,13 @@ import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
-from docarray import Document, Image, Text
+from docarray import BaseDocument, Image, Text
 from docarray.typing import NdArray
 
 
 @pytest.mark.asyncio
 async def test_fast_api():
-    class Mmdoc(Document):
+    class Mmdoc(BaseDocument):
         img: Image
         text: Text
         title: str
@@ -36,10 +36,10 @@ async def test_fast_api():
 
 @pytest.mark.asyncio
 async def test_image():
-    class InputDoc(Document):
+    class InputDoc(BaseDocument):
         img: Image
 
-    class OutputDoc(Document):
+    class OutputDoc(BaseDocument):
         embedding_clip: NdArray
         embedding_bert: NdArray
 
@@ -66,10 +66,10 @@ async def test_image():
 
 @pytest.mark.asyncio
 async def test_sentence_to_embeddings():
-    class InputDoc(Document):
+    class InputDoc(BaseDocument):
         text: str
 
-    class OutputDoc(Document):
+    class OutputDoc(BaseDocument):
         embedding_clip: NdArray
         embedding_bert: NdArray
 

--- a/tests/integrations/typing/test_anyurl.py
+++ b/tests/integrations/typing/test_anyurl.py
@@ -1,9 +1,9 @@
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import AnyUrl
 
 
 def test_set_any_url():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         any_url: AnyUrl
 
     d = MyDocument(any_url="https://jina.ai")

--- a/tests/integrations/typing/test_embedding.py
+++ b/tests/integrations/typing/test_embedding.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import Embedding
 
 
 def test_set_embedding():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         embedding: Embedding
 
     d = MyDocument(embedding=np.zeros((3, 224, 224)))

--- a/tests/integrations/typing/test_id.py
+++ b/tests/integrations/typing/test_id.py
@@ -1,9 +1,9 @@
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import ID
 
 
 def test_set_id():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         id: ID
 
     d = MyDocument(id="123")

--- a/tests/integrations/typing/test_image_url.py
+++ b/tests/integrations/typing/test_image_url.py
@@ -1,9 +1,9 @@
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import ImageUrl
 
 
 def test_set_image_url():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         image_url: ImageUrl
 
     d = MyDocument(image_url="https://jina.ai/img.png")

--- a/tests/integrations/typing/test_mesh_url.py
+++ b/tests/integrations/typing/test_mesh_url.py
@@ -1,9 +1,9 @@
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import Mesh3DUrl
 
 
 def test_set_mesh_url():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         mesh_url: Mesh3DUrl
 
     d = MyDocument(mesh_url="https://jina.ai/mesh.obj")

--- a/tests/integrations/typing/test_ndarray.py
+++ b/tests/integrations/typing/test_ndarray.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import NdArray
 
 
 def test_set_tensor():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         tensor: NdArray
 
     d = MyDocument(tensor=np.zeros((3, 224, 224)))

--- a/tests/integrations/typing/test_point_cloud_url.py
+++ b/tests/integrations/typing/test_point_cloud_url.py
@@ -1,9 +1,9 @@
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import PointCloud3DUrl
 
 
 def test_set_point_cloud_url():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         point_cloud_url: PointCloud3DUrl
 
     d = MyDocument(point_cloud_url="https://jina.ai/mesh.obj")

--- a/tests/integrations/typing/test_tensor.py
+++ b/tests/integrations/typing/test_tensor.py
@@ -1,12 +1,12 @@
 import numpy as np
 import torch
 
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import AnyTensor, NdArray, TorchTensor
 
 
 def test_set_tensor():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         tensor: AnyTensor
 
     d = MyDocument(tensor=np.zeros((3, 224, 224)))

--- a/tests/integrations/typing/test_torch_tensor.py
+++ b/tests/integrations/typing/test_torch_tensor.py
@@ -1,11 +1,11 @@
 import torch
 
-from docarray import Document
+from docarray import BaseDocument
 from docarray.typing import TorchEmbedding, TorchTensor
 
 
 def test_set_torch_tensor():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         tensor: TorchTensor
 
     d = MyDocument(tensor=torch.zeros((3, 224, 224)))
@@ -16,7 +16,7 @@ def test_set_torch_tensor():
 
 
 def test_set_torch_embedding():
-    class MyDocument(Document):
+    class MyDocument(BaseDocument):
         embedding: TorchEmbedding
 
     d = MyDocument(embedding=torch.zeros((128,)))

--- a/tests/integrations/typing/test_typing_proto.py
+++ b/tests/integrations/typing/test_typing_proto.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from docarray import Document
+from docarray import BaseDocument
 from docarray.document import AnyDocument
 from docarray.typing import (
     AnyUrl,
@@ -16,7 +16,7 @@ from docarray.typing import (
 
 
 def test_proto_all_types():
-    class Mymmdoc(Document):
+    class Mymmdoc(BaseDocument):
         tensor: NdArray
         torch_tensor: TorchTensor
         embedding: Embedding

--- a/tests/units/array/test_array.py
+++ b/tests/units/array/test_array.py
@@ -4,14 +4,13 @@ import numpy as np
 import pytest
 import torch
 
-from docarray import Document, DocumentArray
-from docarray.document import BaseDocument
+from docarray import BaseDocument, DocumentArray
 from docarray.typing import NdArray, TorchTensor
 
 
 @pytest.fixture()
 def da():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     return DocumentArray([Text(text='hello') for _ in range(10)])
@@ -23,7 +22,7 @@ def test_iterate(da):
 
 
 def test_append():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     da = DocumentArray[Text]([])
@@ -35,7 +34,7 @@ def test_append():
 
 
 def test_extend():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     da = DocumentArray[Text]([Text(text='hello', id=str(i)) for i in range(10)])
@@ -48,7 +47,7 @@ def test_extend():
 
 
 def test_document_array():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     da = DocumentArray([Text(text='hello') for _ in range(10)])
@@ -57,7 +56,7 @@ def test_document_array():
 
 
 def test_document_array_fixed_type():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     da = DocumentArray[Text]([Text(text='hello') for _ in range(10)])

--- a/tests/units/array/test_array_proto.py
+++ b/tests/units/array/test_array_proto.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-from docarray import Document, DocumentArray, Image, Text
+from docarray import BaseDocument, DocumentArray, Image, Text
 from docarray.array.array_stacked import DocumentArrayStacked
 from docarray.typing import NdArray
 
 
 def test_simple_proto():
-    class CustomDoc(Document):
+    class CustomDoc(BaseDocument):
         text: str
         tensor: NdArray
 
@@ -22,7 +22,7 @@ def test_simple_proto():
 
 
 def test_nested_proto():
-    class CustomDocument(Document):
+    class CustomDocument(BaseDocument):
         text: Text
         image: Image
 
@@ -39,7 +39,7 @@ def test_nested_proto():
 
 
 def test_nested_proto_any_doc():
-    class CustomDocument(Document):
+    class CustomDocument(BaseDocument):
         text: Text
         image: Image
 
@@ -56,7 +56,7 @@ def test_nested_proto_any_doc():
 
 
 def test_stacked_proto():
-    class CustomDocument(Document):
+    class CustomDocument(BaseDocument):
         image: NdArray
 
     da = DocumentArray[CustomDocument](

--- a/tests/units/array/test_generic_array.py
+++ b/tests/units/array/test_generic_array.py
@@ -1,9 +1,9 @@
-from docarray import DocumentArray, Document
+from docarray import BaseDocument, DocumentArray
 from docarray.document import AnyDocument
 
 
 def test_generic_init():
-    class Text(Document):
+    class Text(BaseDocument):
         text: str
 
     da = DocumentArray[Text]([])

--- a/tests/units/array/test_stack_mod.py
+++ b/tests/units/array/test_stack_mod.py
@@ -4,13 +4,13 @@ import numpy as np
 import pytest
 import torch
 
-from docarray import Document, DocumentArray
+from docarray import BaseDocument, DocumentArray
 from docarray.typing import NdArray, TorchTensor
 
 
 @pytest.fixture()
 def batch():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
     batch = DocumentArray[Image](
@@ -49,7 +49,7 @@ def test_stack_optional(batch):
 
 
 def test_stack_numpy():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: NdArray[3, 224, 224]
 
     batch = DocumentArray[Image](
@@ -79,10 +79,10 @@ def test_stack(batch):
 
 
 def test_stack_mod_nested_document():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
-    class MMdoc(Document):
+    class MMdoc(BaseDocument):
         img: Image
 
     batch = DocumentArray[MMdoc](
@@ -104,7 +104,7 @@ def test_stack_mod_nested_document():
 
 
 def test_convert_to_da(batch):
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
     batch = DocumentArray[Image](
@@ -119,10 +119,10 @@ def test_convert_to_da(batch):
 
 
 def test_unstack_nested_document():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
-    class MMdoc(Document):
+    class MMdoc(BaseDocument):
         img: Image
 
     batch = DocumentArray[MMdoc](
@@ -143,7 +143,7 @@ def test_proto_stacked_mode_torch(batch):
 
 
 def test_proto_stacked_mode_numpy():
-    class MyDoc(Document):
+    class MyDoc(BaseDocument):
         tensor: NdArray[3, 224, 224]
 
     da = DocumentArray[MyDoc](
@@ -156,7 +156,7 @@ def test_proto_stacked_mode_numpy():
 
 
 def test_stack_call():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
     da = DocumentArray[Image](
@@ -171,7 +171,7 @@ def test_stack_call():
 
 
 def test_context_manager():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
     da = DocumentArray[Image](
@@ -193,7 +193,7 @@ def test_context_manager():
 
 
 def test_stack_union():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: Union[TorchTensor[3, 224, 224], NdArray[3, 224, 224]]
 
     batch = DocumentArray[Image](

--- a/tests/units/array/test_traverse.py
+++ b/tests/units/array/test_traverse.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from docarray import Document, DocumentArray, Text
+from docarray import BaseDocument, DocumentArray, Text
 from docarray.array.abstract_array import AnyDocumentArray
 from docarray.typing import TorchTensor
 
@@ -14,15 +14,15 @@ num_sub_sub_docs = 3
 
 @pytest.fixture
 def multi_model_docs():
-    class SubSubDoc(Document):
+    class SubSubDoc(BaseDocument):
         sub_sub_text: Text
         sub_sub_tensor: TorchTensor[2]
 
-    class SubDoc(Document):
+    class SubDoc(BaseDocument):
         sub_text: Text
         sub_da: DocumentArray[SubSubDoc]
 
-    class MultiModalDoc(Document):
+    class MultiModalDoc(BaseDocument):
         mm_text: Text
         mm_tensor: Optional[TorchTensor[3, 2, 2]]
         mm_da: DocumentArray[SubDoc]
@@ -77,7 +77,7 @@ def test_traverse_flat(multi_model_docs, access_path, len_result):
 
 
 def test_traverse_stacked_da():
-    class Image(Document):
+    class Image(BaseDocument):
         tensor: TorchTensor[3, 224, 224]
 
     batch = DocumentArray[Image](
@@ -110,7 +110,7 @@ def test_flatten_one_level(input_list, output_list):
 
 
 def test_flatten_one_level_list_of_da():
-    doc = Document()
+    doc = BaseDocument()
     input_list = [DocumentArray([doc, doc, doc])]
 
     flattened = AnyDocumentArray._flatten_one_level(sequence=input_list)

--- a/tests/units/util/test_find.py
+++ b/tests/units/util/test_find.py
@@ -4,16 +4,16 @@ import numpy as np
 import pytest
 import torch
 
-from docarray import Document, DocumentArray
+from docarray import BaseDocument, DocumentArray
 from docarray.typing import NdArray, TorchTensor
 from docarray.util import find, find_batched
 
 
-class TorchDoc(Document):
+class TorchDoc(BaseDocument):
     tensor: TorchTensor
 
 
-class NdDoc(Document):
+class NdDoc(BaseDocument):
     tensor: NdArray
 
 
@@ -257,7 +257,7 @@ def test_find_batched_np_stacked(random_nd_batch_query, random_nd_index, stack_w
 
 
 def test_find_optional():
-    class MyDoc(Document):
+    class MyDoc(BaseDocument):
         embedding: Optional[TorchTensor]
 
     query = MyDoc(embedding=torch.rand(10))
@@ -275,7 +275,7 @@ def test_find_optional():
 
 
 def test_find_union():
-    class MyDoc(Document):
+    class MyDoc(BaseDocument):
         embedding: Union[TorchTensor, NdArray]
 
     query = MyDoc(embedding=torch.rand(10))
@@ -293,7 +293,7 @@ def test_find_union():
 
 
 def test_find_nested_union_optional():
-    class MyDoc(Document):
+    class MyDoc(BaseDocument):
         embedding: Union[Optional[TorchTensor], Optional[NdArray]]
         embedding2: Optional[Union[TorchTensor, NdArray]]
         embedding3: Optional[Optional[TorchTensor]]


### PR DESCRIPTION
Signed-off-by: Johannes Messner <messnerjo@gmail.com>

Goals:

Rename `Document` to `BaseDocument`, making it clear that it isn't suitable for direct use (similar to `BaseModel` in pydantic).

Closes #969
