### PR TITLE
fix(v2): handle properly slice in getitem  da

### DIFF
--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -86,7 +86,10 @@ class DocumentArray(AnyDocumentArray):
         return len(self._data)
 
     def __getitem__(self, item):
-        return self._data[item]
+        if type(item) == slice:
+            return self.__class__(self._data[item])
+        else:
+            return self._data[item]
 
     def __iter__(self):
         return iter(self._data)

--- a/tests/units/array/test_array.py
+++ b/tests/units/array/test_array.py
@@ -46,6 +46,12 @@ def test_extend():
         assert da.id == str(i)
 
 
+def test_slice(da):
+    da2 = da[0:5]
+    assert type(da2) == da.__class__
+    assert len(da2) == 5
+
+
 def test_document_array():
     class Text(BaseDocument):
         text: str


### PR DESCRIPTION
# Context


There is currently a bug in v2 when using slice.

`da[0:10]` return a list instead of a DocumentArray

# What this PR do

fix the behavior and return a DocumentArray