### PR TITLE
Fix proper name da stacked

### DIFF
--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -42,8 +42,8 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
             setattr(_DocumentArrayTyped, field, _property_generator(field))
             # this generates property on the fly based on the schema of the item
 
-        _DocumentArrayTyped.__name__ = f'DocumentArray[{item.__name__}]'
-        _DocumentArrayTyped.__qualname__ = f'DocumentArray[{item.__name__}]'
+        _DocumentArrayTyped.__name__ = f'{cls.__name__}[{item.__name__}]'
+        _DocumentArrayTyped.__qualname__ = f'{cls.__name__}[{item.__name__}]'
 
         return _DocumentArrayTyped
 


### PR DESCRIPTION
# Context

atm doing 
```python
DocumentArray[Image](batch).stack()
>>> <docarray.array.abstract_array.DocumentArray[Image] at 0x7f0952aab040>
```

but it is a DocumentArrayStacked

this pr fix the __name__ of the class so that it is printed

```python
>>> <docarray.array.abstract_array.DocumentArrayStacked[Image] at 0x7f0952aab040>
```
