### PR TITLE
fix: allow dict to be pass in a da stacked

### DIFF
--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -112,7 +112,7 @@ class DocumentArray(AnyDocumentArray):
         :return: Returns a list of the field value for each document
         in the array like container
         """
-        field_type = self.__class__.document_type.__fields__[field].type_
+        field_type = self.__class__.document_type._get_field_type(field)
 
         if (
             not is_union_type(field_type)

--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -112,9 +112,13 @@ class DocumentArray(AnyDocumentArray):
         :return: Returns a list of the field value for each document
         in the array like container
         """
-        field_type = self.__class__.document_type._get_nested_document_class(field)
+        field_type = self.__class__.document_type.__fields__[field].type_
 
-        if not is_union_type(field_type) and issubclass(field_type, BaseDocument):
+        if (
+            not is_union_type(field_type)
+            and isinstance(field_type, type)
+            and issubclass(field_type, BaseDocument)
+        ):
             # calling __class_getitem__ ourselves is a hack otherwise mypy complain
             # most likely a bug in mypy though
             # bug reported here https://github.com/python/mypy/issues/14111

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -82,9 +82,12 @@ class DocumentArrayStacked(AnyDocumentArray):
 
         columns_fields = list()
         for field_name, field in cls.document_type.__fields__.items():
-            field_type = field.type_
+            field_type = field.outer_type_
             if is_union_type(field_type):
-                if field.type_ == AnyTensor or field.type_ == Optional[AnyTensor]:
+                if (
+                    field.outer_type_ == AnyTensor
+                    or field.outer_type_ == Optional[AnyTensor]
+                ):
                     columns_fields.append(field_name)
             elif isinstance(field_type, type):
                 is_torch_subclass = (
@@ -113,7 +116,7 @@ class DocumentArrayStacked(AnyDocumentArray):
 
         for field_to_stack, to_stack in columns_to_stack.items():
 
-            type_ = cls.document_type.__fields__[field_to_stack].type_
+            type_ = cls.document_type._get_field_type(field_to_stack)
             if is_union_type(type_):
                 if type_ == AnyTensor or type_ == Optional[AnyTensor]:
                     columns[field_to_stack] = tensor_type.__docarray_stack__(to_stack)  # type: ignore # noqa: E501

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -86,7 +86,7 @@ class DocumentArrayStacked(AnyDocumentArray):
             if is_union_type(field_type):
                 if field.type_ == AnyTensor or field.type_ == Optional[AnyTensor]:
                     columns_fields.append(field_name)
-            else:
+            elif isinstance(field_type, type):
                 is_torch_subclass = (
                     issubclass(field_type, torch.Tensor) if torch_imported else False
                 )
@@ -117,7 +117,7 @@ class DocumentArrayStacked(AnyDocumentArray):
             if is_union_type(type_):
                 if type_ == AnyTensor or type_ == Optional[AnyTensor]:
                     columns[field_to_stack] = tensor_type.__docarray_stack__(to_stack)  # type: ignore # noqa: E501
-            else:
+            elif isinstance(type_, type):
                 if issubclass(type_, BaseDocument):
                     columns[field_to_stack] = DocumentArray.__class_getitem__(type_)(
                         to_stack, tensor_type=tensor_type

--- a/docarray/document/abstract_document.py
+++ b/docarray/document/abstract_document.py
@@ -17,7 +17,7 @@ class AbstractDocument(Iterable):
 
     @classmethod
     @abstractmethod
-    def _get_nested_document_class(cls, field: str) -> Type['ProtoMixin']:
+    def _get_field_type(cls, field: str) -> Type['ProtoMixin']:
         ...
 
     @classmethod

--- a/docarray/document/any_document.py
+++ b/docarray/document/any_document.py
@@ -13,7 +13,7 @@ class AnyDocument(BaseDocument):
         self.__dict__.update(kwargs)
 
     @classmethod
-    def _get_nested_document_class(cls, field: str) -> Type['BaseDocument']:
+    def _get_field_type(cls, field: str) -> Type['BaseDocument']:
         """
         Accessing the nested python Class define in the schema.
         Could be useful for reconstruction of Document in

--- a/docarray/document/document.py
+++ b/docarray/document/document.py
@@ -30,4 +30,4 @@ class BaseDocument(BaseModel, ProtoMixin, AbstractDocument, BaseNode):
         :param field: name of the field
         :return:
         """
-        return cls.__fields__[field].type_
+        return cls.__fields__[field].outer_type_

--- a/docarray/document/document.py
+++ b/docarray/document/document.py
@@ -2,8 +2,7 @@ import os
 from typing import Type
 
 import orjson
-from pydantic import BaseModel, Field
-from pydantic import parse_obj_as
+from pydantic import BaseModel, Field, parse_obj_as
 
 from docarray.document.abstract_document import AbstractDocument
 from docarray.document.base_node import BaseNode
@@ -24,7 +23,7 @@ class BaseDocument(BaseModel, ProtoMixin, AbstractDocument, BaseNode):
         json_dumps = orjson_dumps
 
     @classmethod
-    def _get_nested_document_class(cls, field: str) -> Type['BaseDocument']:
+    def _get_field_type(cls, field: str) -> Type['BaseDocument']:
         """
         Accessing the nested python Class define in the schema. Could be useful for
         reconstruction of Document in serialization/deserilization

--- a/docarray/document/mixins/proto.py
+++ b/docarray/document/mixins/proto.py
@@ -65,7 +65,7 @@ class ProtoMixin(AbstractDocument, BaseNode):
             elif content_type == 'text':
                 fields[field] = value.text
             elif content_type == 'nested':
-                fields[field] = cls._get_nested_document_class(field).from_protobuf(
+                fields[field] = cls._get_field_type(field).from_protobuf(
                     value.nested
                 )  # we get to the parent class
             elif content_type == 'chunks':

--- a/docarray/util/find.py
+++ b/docarray/util/find.py
@@ -272,7 +272,7 @@ def _da_attr_type(da: AnyDocumentArray, attr: str) -> Type[AnyTensor]:
     :param attr: the attribute name
     :return: the type of the attribute
     """
-    field_type = da.document_type.__fields__[attr].type_
+    field_type = da.document_type._get_field_type(attr)
     if is_union_type(field_type):
         # determine type based on the fist element
         field_type = type(getattr(da[0], attr))

--- a/tests/integrations/typing/test_typing_proto.py
+++ b/tests/integrations/typing/test_typing_proto.py
@@ -44,4 +44,4 @@ def test_proto_all_types():
             # embedding is a Union type, not supported by isinstance
             assert isinstance(value, np.ndarray) or isinstance(value, torch.Tensor)
         else:
-            assert isinstance(value, doc._get_nested_document_class(field))
+            assert isinstance(value, doc._get_field_type(field))

--- a/tests/units/array/test_stack_mod.py
+++ b/tests/units/array/test_stack_mod.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import pytest
@@ -244,3 +244,10 @@ def test_any_tensor_with_optional():
 
     assert 'tensor' in da.img._columns.keys()
     assert isinstance(da.img._columns['tensor'], TorchTensor)
+
+
+def test_dict_stack():
+    class MyDoc(BaseDocument):
+        my_dict: Dict[str, int]
+
+    DocumentArray[MyDoc]([MyDoc(my_dict={'a': 1, 'b': 2}) for _ in range(10)]).stack()

--- a/tests/units/array/test_stack_mod.py
+++ b/tests/units/array/test_stack_mod.py
@@ -250,4 +250,8 @@ def test_dict_stack():
     class MyDoc(BaseDocument):
         my_dict: Dict[str, int]
 
-    DocumentArray[MyDoc]([MyDoc(my_dict={'a': 1, 'b': 2}) for _ in range(10)]).stack()
+    da = DocumentArray[MyDoc](
+        [MyDoc(my_dict={'a': 1, 'b': 2}) for _ in range(10)]
+    ).stack()
+
+    da.my_dict


### PR DESCRIPTION
Signed-off-by: Sami Jaghouar <sami.jaghouar@hotmail.fr>

# Context


there is a bug with not class object in document atm : 

```python
    class MyDoc(BaseDocument):
        my_dict: Dict[str, int]

    DocumentArray[MyDoc]([MyDoc(my_dict={'a': 1, 'b': 2}) for _ in range(10)]).stack()
```
```
File ~/Documents/workspace/Jina/docarray2/docarray/docarray/array/array_stacked.py:91, in DocumentArrayStacked._create_columns(cls, docs, tensor_type)
     88         columns_fields.append(field_name)
     89 else:
     90     is_torch_subclass = (
---> 91         issubclass(field_type, torch.Tensor) if torch_imported else False
     92     )
     94     if (
     95         is_torch_subclass
     96         or issubclass(field_type, BaseDocument)
     97         or issubclass(field_type, NdArray)
     98     ):
     99         columns_fields.append(field_name)

TypeError: issubclass() arg 1 must be a class
```

# What this pr do

fix this by checking if the type is a class before doing issubclass
