### PR TITLE
fix: value extraction of point cloud colors enum in display

### DIFF
--- a/docarray/document/mixins/mesh.py
+++ b/docarray/document/mixins/mesh.py
@@ -85,8 +85,8 @@ class MeshDataMixin:
         faces = mesh.faces.view(np.ndarray)
 
         self.chunks = [
-            Document(name=MeshEnum.VERTICES, tensor=vertices),
-            Document(name=MeshEnum.FACES, tensor=faces),
+            Document(name=MeshEnum.VERTICES.value, tensor=vertices),
+            Document(name=MeshEnum.FACES.value, tensor=faces),
         ]
 
         return self
@@ -101,9 +101,9 @@ class MeshDataMixin:
         faces = None
 
         for chunk in self.chunks:
-            if chunk.tags['name'] == MeshEnum.VERTICES:
+            if chunk.tags['name'] == MeshEnum.VERTICES.value:
                 vertices = chunk.tensor
-            if chunk.tags['name'] == MeshEnum.FACES:
+            if chunk.tags['name'] == MeshEnum.FACES.value:
                 faces = chunk.tensor
 
         if vertices is not None and faces is not None:

--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -191,7 +191,7 @@ class PlotMixin:
         for chunk in self.chunks:
             if (
                 'name' in chunk.tags.keys()
-                and chunk.tags['name'] == PointCloudEnum.COLORS
+                and chunk.tags['name'] == PointCloudEnum.COLORS.value
                 and chunk.tensor.shape[-1] in [3, 4]
             ):
                 colors = chunk.tensor

--- a/docarray/document/mixins/plot.py
+++ b/docarray/document/mixins/plot.py
@@ -133,7 +133,10 @@ class PlotMixin:
         """
         if self.chunks is not None:
             name_tags = [c.tags['name'] for c in self.chunks]
-            if MeshEnum.VERTICES in name_tags and MeshEnum.FACES in name_tags:
+            if (
+                MeshEnum.VERTICES.value in name_tags
+                and MeshEnum.FACES.value in name_tags
+            ):
                 return True
         else:
             return False
@@ -173,11 +176,13 @@ class PlotMixin:
             import trimesh
 
             vertices = [
-                c.tensor for c in self.chunks if c.tags['name'] == MeshEnum.VERTICES
+                c.tensor
+                for c in self.chunks
+                if c.tags['name'] == MeshEnum.VERTICES.value
             ][-1]
-            faces = [c.tensor for c in self.chunks if c.tags['name'] == MeshEnum.FACES][
-                -1
-            ]
+            faces = [
+                c.tensor for c in self.chunks if c.tags['name'] == MeshEnum.FACES.value
+            ][-1]
             mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
             display(mesh.show())
 

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -2576,16 +2576,13 @@ init();</script></body>
 </html>" width="100%" height="500px" style="border:none;"></iframe
 
 
-To display a colored point cloud, store the corresponding colors in the `.tensor` of a chunk `Document` with the name tag `PointCloudEnum.COLORS`. The colors have to be of shape (n_samples, 3) or (n_samples, 4).
+To display a colored point cloud, store the corresponding colors in the `.tensor` of a chunk `Document` with the name tag `'point_cloud_colors'`. The colors have to be of shape (n_samples, 3) or (n_samples, 4).
 
 ```python
-from docarray.document.mixins.mesh import PointCloudEnum
-
-
 n_samples = 1000
 colors = np.random.rand(n_samples, 3)
 doc = Document(uri='mesh_man.glb').load_uri_to_point_cloud_tensor(samples=n_samples)
-doc.chunks = [Document(tensor=colors, name=PointCloudEnum.COLORS)]
+doc.chunks = [Document(tensor=colors, name='point_cloud_colors')]
 ```
 
 ## RGB-D image representation

--- a/docs/datatypes/mesh/index.md
+++ b/docs/datatypes/mesh/index.md
@@ -2576,13 +2576,16 @@ init();</script></body>
 </html>" width="100%" height="500px" style="border:none;"></iframe
 
 
-To display a colored point cloud, store the corresponding colors in the `.tensor` of a chunk `Document` with the name tag `'point_cloud_colors'`. The colors have to be of shape (n_samples, 3) or (n_samples, 4).
+To display a colored point cloud, store the corresponding colors in the `.tensor` of a chunk `Document` with the name tag `PointCloudEnum.COLORS`. The colors have to be of shape (n_samples, 3) or (n_samples, 4).
 
 ```python
+from docarray.document.mixins.mesh import PointCloudEnum
+
+
 n_samples = 1000
 colors = np.random.rand(n_samples, 3)
 doc = Document(uri='mesh_man.glb').load_uri_to_point_cloud_tensor(samples=n_samples)
-doc.chunks = [Document(tensor=colors, name='point_cloud_colors')]
+doc.chunks = [Document(tensor=colors, name=PointCloudEnum.COLORS)]
 ```
 
 ## RGB-D image representation

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -321,9 +321,9 @@ def test_load_uri_to_vertices_and_faces(uri):
     doc.load_uri_to_vertices_and_faces()
 
     assert len(doc.chunks) == 2
-    assert doc.chunks[0].tags['name'] == MeshEnum.VERTICES
+    assert doc.chunks[0].tags['name'] == MeshEnum.VERTICES.value
     assert doc.chunks[0].tensor.shape[1] == 3
-    assert doc.chunks[1].tags['name'] == MeshEnum.FACES
+    assert doc.chunks[1].tags['name'] == MeshEnum.FACES.value
     assert doc.chunks[1].tensor.shape[1] == 3
 
 

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -6,7 +6,7 @@ import pytest
 
 from docarray import Document
 from docarray.document.generators import from_files
-from docarray.document.mixins.mesh import MeshEnum
+from docarray.document.mixins.mesh import MeshEnum, PointCloudEnum
 
 __windows__ = sys.platform == 'win32'
 
@@ -417,3 +417,16 @@ def test_load_uris_to_rgbd_tensor_doc_wo_uri_raise_exception():
         match='A chunk of the given Document does not provide a uri.',
     ):
         doc.load_uris_to_rgbd_tensor()
+
+
+@pytest.mark.parametrize(
+    'enum_value,expected_value',
+    [
+        (PointCloudEnum.COLORS.value, 'point_cloud_colors'),
+        (MeshEnum.VERTICES.value, 'vertices'),
+        (MeshEnum.FACES.value, 'faces'),
+        (MeshEnum.FILE_EXTENSIONS.value, ['glb', 'obj', 'ply']),
+    ],
+)
+def test_enum_value_extraction(enum_value, expected_value):
+    assert enum_value == expected_value

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -419,14 +419,12 @@ def test_load_uris_to_rgbd_tensor_doc_wo_uri_raise_exception():
         doc.load_uris_to_rgbd_tensor()
 
 
-@pytest.mark.parametrize(
-    'enum_value,expected_value',
-    [
-        (PointCloudEnum.COLORS.value, 'point_cloud_colors'),
-        (MeshEnum.VERTICES.value, 'vertices'),
-        (MeshEnum.FACES.value, 'faces'),
-        (MeshEnum.FILE_EXTENSIONS.value, ['glb', 'obj', 'ply']),
-    ],
-)
-def test_enum_value_extraction(enum_value, expected_value):
-    assert enum_value == expected_value
+def test_load_colors_to_point_cloud_doc():
+    n_samples = 1000
+    colors = np.random.rand(n_samples, 3)
+    coords = np.random.rand(n_samples, 3)
+    doc = Document(uri='mesh_man.glb', tensor=coords)
+    doc.chunks = [Document(tensor=colors, name='point_cloud_colors')]
+
+    assert np.allclose(doc.tensor, coords)
+    assert np.allclose(doc.chunks[0].tensor, colors)

--- a/tests/unit/document/test_converters.py
+++ b/tests/unit/document/test_converters.py
@@ -417,14 +417,3 @@ def test_load_uris_to_rgbd_tensor_doc_wo_uri_raise_exception():
         match='A chunk of the given Document does not provide a uri.',
     ):
         doc.load_uris_to_rgbd_tensor()
-
-
-def test_load_colors_to_point_cloud_doc():
-    n_samples = 1000
-    colors = np.random.rand(n_samples, 3)
-    coords = np.random.rand(n_samples, 3)
-    doc = Document(uri='mesh_man.glb', tensor=coords)
-    doc.chunks = [Document(tensor=colors, name='point_cloud_colors')]
-
-    assert np.allclose(doc.tensor, coords)
-    assert np.allclose(doc.chunks[0].tensor, colors)


### PR DESCRIPTION
Fix code snippet for point cloud display with color:
Add `PointCloudEnum.COLORS` as name tag instead of `'point_cloud_colors'`

- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
