### PR TITLE
docs: add more explanation for docarray and n_dim

### DIFF
--- a/docs/advanced/document-store/elasticsearch.md
+++ b/docs/advanced/document-store/elasticsearch.md
@@ -51,6 +51,7 @@ da = DocumentArray(storage='elasticsearch', config={'n_dim': 128})
 
 The usage would be the same as the ordinary DocumentArray, but the dimension of an embedding for a Document must be provided at creation time.
 
+Note for the documents stored in the DocumentArray, they should have the same dimension, otherwise for ElasticSearch.
 ### Secure connection
 
 By default, Elasticsearch server runs with security layer that disables the plain HTTP connection. You can pass the `host` with `api_id` or `ca_certs` inside `es_config` to the constructor. For example,

--- a/docs/advanced/document-store/index.md
+++ b/docs/advanced/document-store/index.md
@@ -353,6 +353,9 @@ Using DocumentArrays backed by a document store introduces an extra consideratio
 The DocumentArray object created in your Python program is now a view of the underlying implementation in the document store.
 This means that your DocumentArray object in Python can be out of sync with what is persisted to the document store.
 
+In the meantime, it also means when doing operations with DocArray, all the data are **NOT** stored in the memory as an intermediate 
+storage. 
+
 **For example**
 ```python
 from docarray import DocumentArray, Document


### PR DESCRIPTION
After some confusion in the community, I have added some explanations to the DocumentArray document to make it more clear.
1. Avoid confusion that DocumentArray will load data into memory first when having an external database. 
2. Explain that ElasticSearch will require the same n_dim for its storage. 