### PR TITLE
refactor: better management of stack mod

### DIFF
--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -167,9 +167,9 @@ class DocumentArrayStacked(AnyDocumentArray):
                 elif issubclass(type_, AbstractTensor):
                     columns[field_to_stack] = type_.__docarray_stack__(to_stack)  # type: ignore # noqa: E501
 
-        for field, column in columns.items():
+        for field_name, column in columns.items():
             for doc, val in zip(docs, column):
-                setattr(doc, field, val)
+                setattr(doc, field_name, val)
 
         return columns
 


### PR DESCRIPTION
Signed-off-by: Sami Jaghouar <sami.jaghouar@hotmail.fr>

# Context:

To give some context, when a DocumentArray enter in stacked mode the tensor data from each document is moved to the column and the document does not own the data anymore. 

What we were doing before this PR was to put None (or even recently to even delete the attribute) inside each document attributes data that has been moved to the DocumentArrayStacked columns, and only when accessing the DA stacked we were putting a view of the column in the data.

This cause several problems: this might lead to thread problem because we don't currently have any-lock to prevent access to the undefined data (still in the column but not in the document as a view) and the `stack` operation let the DocumentArray in a very weird state where it cannot really be use because the data is missing.

This PR change this behavior. Now the data of each document is replace with a view to the column. This mean the DocumentArray is the same after and before the stacking, just that the data in the document is just a view but everything will work the same.


