### PR TITLE
refactor: optimization on stacking

### DIFF
--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -123,7 +123,7 @@ class DocumentArray(AnyDocumentArray):
             # most likely a bug in mypy though
             # bug reported here https://github.com/python/mypy/issues/14111
             return self.__class__.__class_getitem__(field_type)(
-                (getattr(doc, field) for doc in self)
+                (getattr(doc, field) for doc in self), tensor_type=self.tensor_type
             )
         else:
             return [getattr(doc, field) for doc in self]

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -158,7 +158,7 @@ class DocumentArrayStacked(AnyDocumentArray):
                     if val is None:
                         val = tensor_type.get_comp_backend().none_value()
 
-                    columns[field][i] = val
+                    cast(AbstractTensor, columns[field])[i] = val
                     setattr(doc, field, columns[field][i])
                     del val
 

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -27,10 +27,11 @@ if TYPE_CHECKING:
     from docarray.typing import TorchTensor
     from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
-else:
-    from docarray.typing import TorchTensor
 
-    torch_imported = True
+try:
+    from docarray.typing import TorchTensor
+except ImportError:
+    TorchTensor = None
 
 T = TypeVar('T', bound='DocumentArrayStacked')
 
@@ -321,7 +322,9 @@ class DocumentArrayStacked(AnyDocumentArray):
         nodes = list(AnyDocumentArray._traverse(node=self, access_path=access_path))
         flattened = AnyDocumentArray._flatten_one_level(nodes)
 
-        if len(flattened) == 1 and isinstance(flattened[0], (NdArray, TorchTensor)):
+        cls_to_check = (NdArray, TorchTensor) if TorchTensor else (NdArray,)
+
+        if len(flattened) == 1 and isinstance(flattened[0], cls_to_check):
             return flattened[0]
         else:
             return flattened

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -138,7 +138,9 @@ class DocumentArrayStacked(AnyDocumentArray):
                 column_shape = (
                     (len(docs), *tensor.shape) if tensor is not None else (len(docs),)
                 )
-                columns[field] = type_.get_comp_backend().empty(column_shape)
+                columns[field] = type_.__docarray_from_native__(
+                    type_.get_comp_backend().empty(column_shape)
+                )
 
                 for i, doc in enumerate(docs):
                     val = getattr(doc, field)

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 try:
     from docarray.typing import TorchTensor
 except ImportError:
-    TorchTensor = None
+    TorchTensor = None  # type: ignore
 
 T = TypeVar('T', bound='DocumentArrayStacked')
 
@@ -322,7 +322,7 @@ class DocumentArrayStacked(AnyDocumentArray):
         nodes = list(AnyDocumentArray._traverse(node=self, access_path=access_path))
         flattened = AnyDocumentArray._flatten_one_level(nodes)
 
-        cls_to_check = (NdArray, TorchTensor) if TorchTensor else (NdArray,)
+        cls_to_check = (NdArray, TorchTensor) if TorchTensor is not None else (NdArray,)
 
         if len(flattened) == 1 and isinstance(flattened[0], cls_to_check):
             return flattened[0]

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -1,5 +1,16 @@
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Type, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from docarray.array.abstract_array import AnyDocumentArray
 from docarray.array.array import DocumentArray
@@ -49,7 +60,7 @@ class DocumentArrayStacked(AnyDocumentArray):
         self: T,
         docs: DocumentArray,
     ):
-        self._columns: Dict[str, Union[T, AbstractTensor]] = {}
+        self._columns: Dict[str, Union['DocumentArrayStacked', AbstractTensor]] = {}
 
         self.from_document_array(docs)
 
@@ -62,7 +73,7 @@ class DocumentArrayStacked(AnyDocumentArray):
     def _from_columns(
         cls: Type[T],
         docs: DocumentArray,
-        columns: Dict[str, Union[T, AbstractTensor]],
+        columns: Mapping[str, Union['DocumentArrayStacked', AbstractTensor]],
     ) -> T:
         # below __class_getitem__ is called explicitly instead
         # of doing DocumentArrayStacked[docs.document_type]
@@ -99,7 +110,7 @@ class DocumentArrayStacked(AnyDocumentArray):
     def _get_columns_schema(
         cls: Type[T],
         tensor_type: Type[AbstractTensor],
-    ) -> Dict[str, Union[Type[AbstractTensor], Type[BaseDocument]]]:
+    ) -> Mapping[str, Union[Type[AbstractTensor], Type[BaseDocument]]]:
         """
         Return the list of fields that are tensors and the list of fields that are
         documents
@@ -123,7 +134,7 @@ class DocumentArrayStacked(AnyDocumentArray):
     @classmethod
     def _create_columns(
         cls: Type[T], docs: DocumentArray, tensor_type: Type[AbstractTensor]
-    ) -> Dict[str, Union[T, AbstractTensor]]:
+    ) -> Dict[str, Union['DocumentArrayStacked', AbstractTensor]]:
 
         if len(docs) == 0:
             return {}
@@ -159,7 +170,7 @@ class DocumentArrayStacked(AnyDocumentArray):
     def _get_array_attribute(
         self: T,
         field: str,
-    ) -> Union[List, T, AbstractTensor]:
+    ) -> Union[List, 'DocumentArrayStacked', AbstractTensor]:
         """Return all values of the fields from all docs this array contains
 
         :param field: name of the fields to extract

--- a/docarray/computation/abstract_comp_backend.py
+++ b/docarray/computation/abstract_comp_backend.py
@@ -33,6 +33,11 @@ class AbstractComputationalBackend(ABC, typing.Generic[TTensor]):
 
     @staticmethod
     @abstractmethod
+    def empty(shape: Tuple[int, ...]) -> 'TTensor':
+        ...
+
+    @staticmethod
+    @abstractmethod
     def none_value() -> typing.Any:
         """Provide a compatible value that represents None in the Tensor Backend."""
         ...

--- a/docarray/computation/numpy_backend.py
+++ b/docarray/computation/numpy_backend.py
@@ -65,6 +65,10 @@ class NumpyCompBackend(AbstractComputationalBackend[np.ndarray]):
         return array.ndim
 
     @staticmethod
+    def empty(shape: Tuple[int, ...]) -> 'np.ndarray':
+        return np.empty(shape)
+
+    @staticmethod
     def none_value() -> Any:
         """Provide a compatible value that represents None in numpy."""
         return None

--- a/docarray/computation/torch_backend.py
+++ b/docarray/computation/torch_backend.py
@@ -61,6 +61,10 @@ class TorchCompBackend(AbstractComputationalBackend[torch.Tensor]):
         return tensor.to(device)
 
     @staticmethod
+    def empty(shape: Tuple[int, ...]) -> torch.Tensor:
+        return torch.empty(shape)
+
+    @staticmethod
     def n_dim(array: 'torch.Tensor') -> int:
         return array.ndim
 

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -124,6 +124,10 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
         """Get a slice of this tensor."""
         ...
 
+    def __setitem__(self, index, value):
+        """Set a slice of this tensor."""
+        ...
+
     def __iter__(self):
         """Iterate over the elements of this tensor."""
         ...

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -267,7 +267,7 @@ def test_get_from_slice_stacked():
     N = 10
 
     da = DocumentArray[Doc](
-        (Doc(text=f'hello{i}', tensor=np.zeros((3, 224, 224))) for i in range(N))
+        [Doc(text=f'hello{i}', tensor=np.zeros((3, 224, 224))) for i in range(N)]
     ).stack()
 
     da_sliced = da[0:10:2]

--- a/tests/units/computation_backends/numpy_backend/test_basics.py
+++ b/tests/units/computation_backends/numpy_backend/test_basics.py
@@ -7,3 +7,8 @@ from docarray.computation.numpy_backend import NumpyCompBackend
 def test_to_device():
     with pytest.raises(NotImplementedError):
         NumpyCompBackend.to_device(np.random.rand(10, 3), 'meta')
+
+
+def test_empty():
+    array = NumpyCompBackend.empty((10, 3))
+    assert array.shape == (10, 3)

--- a/tests/units/computation_backends/torch_backend/test_basics.py
+++ b/tests/units/computation_backends/torch_backend/test_basics.py
@@ -8,3 +8,8 @@ def test_to_device():
     assert t.device == torch.device('cpu')
     t = TorchCompBackend.to_device(t, 'meta')
     assert t.device == torch.device('meta')
+
+
+def test_empty():
+    tensor = TorchCompBackend.empty((10, 3))
+    assert tensor.shape == (10, 3)

--- a/tests/units/util/test_typing.py
+++ b/tests/units/util/test_typing.py
@@ -29,6 +29,7 @@ def test_is_type_tensor(type_, is_tensor):
     [
         (int, False),
         (TorchTensor, False),
+        (NdArray, False),
         (Optional[TorchTensor], True),
         (Optional[NdArray], True),
         (Union[NdArray, TorchTensor], True),


### PR DESCRIPTION
# Context


We recently introduced some refactoring on DocumentArrayStacked : https://github.com/docarray/docarray/pull/1008 which change a little bit the way we handled the stacking (We removed any state where the document does not hold the data but instead some time its hold a view of the data that has been moved to the column)

As noticed by @JohannesMessner this new way of stacking could be optimized because once the data has been stacked we re traverse the DocumentArray to put the view from the column to the document.


_Originally posted by @samsja in https://github.com/docarray/docarray/pull/1008#discussion_r1067114135_ there is room for improvements. 
We could:
* pre-allocate the data for the tensor column (we can predict the shape and the type by looking at the first row of the da)
* when collecting the actual data we could replace the data with a view to the pre alocated column 
* when stacking put the data into the preallocate column in place. Therefore each document has already a view to the good part of the column and we don't need iterate again


# What this PR do:

* Use the optimization explained above
* refactor the column creation code base to make it more concise and more readable
