### PR TITLE
fix: doc from dataclass with list

### DIFF
--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -209,7 +209,11 @@ class MultiModalMixin:
             attr_type = self._metadata[DocumentMetadata.MULTI_MODAL_SCHEMA][attr][
                 'attribute_type'
             ]
-            if attr_type == AttributeType.ITERABLE_DOCUMENT:
+            if attr_type in [
+                AttributeType.ITERABLE_DOCUMENT,
+                AttributeType.ITERABLE_NESTED,
+                AttributeType.ITERABLE_PRIMITIVE,
+            ]:
                 return mm_attr_da
             else:
                 return mm_attr_da[0]

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -2,7 +2,6 @@ import base64
 import typing
 
 from docarray.dataclasses.types import (
-    Field,
     is_multimodal,
     _is_field,
     AttributeTypeError,
@@ -104,7 +103,6 @@ class MultiModalMixin:
         # TODO: may have to modify this?
         root.tags = tags
         root._metadata[DocumentMetadata.MULTI_MODAL_SCHEMA] = multi_modal_schema
-
         return root
 
     def _get_mm_attr_postion(self, attr):
@@ -208,7 +206,13 @@ class MultiModalMixin:
     def __getattr__(self, attr):
         if self._has_multimodal_attr(attr):
             mm_attr_da = self.get_multi_modal_attribute(attr)
-            return mm_attr_da if len(mm_attr_da) > 1 else mm_attr_da[0]
+            attr_type = self._metadata[DocumentMetadata.MULTI_MODAL_SCHEMA][attr][
+                'attribute_type'
+            ]
+            if attr_type == AttributeType.ITERABLE_DOCUMENT:
+                return mm_attr_da
+            else:
+                return mm_attr_da if len(mm_attr_da) > 1 else mm_attr_da[0]
         else:
             raise AttributeError(f'{self.__class__.__name__} has no attribute `{attr}`')
 

--- a/docarray/document/mixins/multimodal.py
+++ b/docarray/document/mixins/multimodal.py
@@ -212,7 +212,7 @@ class MultiModalMixin:
             if attr_type == AttributeType.ITERABLE_DOCUMENT:
                 return mm_attr_da
             else:
-                return mm_attr_da if len(mm_attr_da) > 1 else mm_attr_da[0]
+                return mm_attr_da[0]
         else:
             raise AttributeError(f'{self.__class__.__name__} has no attribute `{attr}`')
 

--- a/tests/unit/document/test_multi_modal.py
+++ b/tests/unit/document/test_multi_modal.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from docarray import Document, DocumentArray
+from docarray.array.chunk import ChunkArray
 from docarray.dataclasses import dataclass, field
 from docarray.typing import Image, Text, Audio, Video, Mesh, Tabular, Blob, JSON
 from docarray.dataclasses.getter import image_getter
@@ -911,3 +912,24 @@ def test_empty_list_dataclass():
         text: List[Text]
 
     doc = Document(A(text=[]))
+
+
+def test_doc_with_dataclass_with_list_of_length_one():
+    @dataclass
+    class MyDoc:
+        title: Text
+        images: List[Image]
+
+    doc = Document(MyDoc(title='doc 1', images=[IMAGE_URI]))
+    assert type(doc.images) == ChunkArray
+    assert len(doc.images) == 1
+
+
+def test_doc_with_dataclass_without_list():
+    @dataclass
+    class MyDoc:
+        title: Text
+        image: Image
+
+    doc = Document(MyDoc(title='doc 1', image=IMAGE_URI))
+    assert type(doc.image) == Document


### PR DESCRIPTION
Goals:

If we create a `Document` instance from a `dataclass` instance, all  attributes are gonna be stored in their own Documents in the chunks. If one of the attributes is an iterable, such as a `List[Images]`, we want to be able to access this `DocumentArray` as such. If it is of length 1 though, when accesing the images, we get only one `Document` instead of a `DocumentArrray` of length 1.

To change this behaviour we need to check if the initial attribute type was an iterable, in which case return a DocumentArray. 

```python
from docarray import Document, dataclass
from docarray.typing import Text, Image
from typing import List


@dataclass
class MyDoc:
    title: Text
    images: List[Image]


doc1 = MyDoc(title='doc 1', images=[
    'https://bkimg.cdn.bcebos.com/pic/359b033b5bb5c9ea15ce3757e86fa1003af33a871573?x-bce-process=image/watermark,image_d2F0ZXIvYmFpa2UxNTA=,g_7,xp_5,yp_5',
])
doc1 = Document(doc1)
print(f"type(doc1.images) = {type(doc1.images)}")
print(f"doc1.images = {doc1.images}")

doc2 = MyDoc(title='doc 2', images=[
    'https://bkimg.cdn.bcebos.com/pic/359b033b5bb5c9ea15ce3757e86fa1003af33a871573?x-bce-process=image/watermark,image_d2F0ZXIvYmFpa2UxNTA=,g_7,xp_5,yp_5',
    'https://bkimg.cdn.bcebos.com/pic/359b033b5bb5c9ea15ce3757e86fa1003af33a871573?x-bce-process=image/watermark,image_d2F0ZXIvYmFpa2UxNTA=,g_7,xp_5,yp_5',
])

doc2 = Document(doc2)
print(f"type(doc2.images) = {type(doc2.images)}")
print(f"doc2.images = {doc2.images}")

```

Output:
```
type(doc1.images) = <class 'docarray.document.Document'>
doc1.images = <Document ('id', 'parent_id', 'granularity', 'tensor', 'uri', '_metadata', 'modality') at 8ad7d1ac2dfd5541a297d7378b0106cc>
type(doc2.images) = <class 'docarray.array.chunk.ChunkArray'>
doc2.images = <DocumentArray (length=2) at 4766922160>
```

Expected:
```
type(doc1.images) = <class 'docarray.array.chunk.ChunkArray'>
doc1.images = <DocumentArray (length=1) at 7483917480>
type(doc2.images) = <class 'docarray.array.chunk.ChunkArray'>
doc2.images = <DocumentArray (length=2) at 4766922160>
```

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
