### PR TITLE
refactor: renamed docarray private method

### DIFF
--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -150,7 +150,7 @@ class DocumentArrayStacked(AnyDocumentArray):
                 column_shape = (
                     (len(docs), *tensor.shape) if tensor is not None else (len(docs),)
                 )
-                columns[field] = type_.__docarray_from_native__(
+                columns[field] = type_._docarray_from_native(
                     type_.get_comp_backend().empty(column_shape)
                 )
 

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -61,7 +61,7 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
 
     @classmethod
     @abc.abstractmethod
-    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:
+    def _docarray_validate_shape(cls, t: T, shape: Tuple[int]) -> T:
         """Every tensor has to implement this method in order to
         enable syntax of the form AnyTensor[shape].
 
@@ -82,7 +82,7 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
         ...
 
     @classmethod
-    def __docarray_validate_getitem__(cls, item: Any) -> Tuple[int]:
+    def _docarray_validate_getitem(cls, item: Any) -> Tuple[int]:
         """This method validates the input to __class_getitem__.
 
         It is called at "class creation time",
@@ -125,9 +125,7 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
                 config: 'BaseConfig',
             ):
                 t = super().validate(value, field, config)
-                return _cls.__docarray_validate_shape__(
-                    t, _cls.__docarray_target_shape__
-                )
+                return _cls._docarray_validate_shape(t, _cls.__docarray_target_shape__)
 
         _ParametrizedTensor.__name__ = f'{cls.__name__}[{shape_str}]'
         _ParametrizedTensor.__qualname__ = f'{cls.__qualname__}[{shape_str}]'
@@ -135,20 +133,20 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
         return _ParametrizedTensor
 
     def __class_getitem__(cls, item: Any):
-        target_shape = cls.__docarray_validate_getitem__(item)
+        target_shape = cls._docarray_validate_getitem(item)
         return cls._docarray_create_parametrized_type(target_shape)
 
     @classmethod
-    def __docarray_stack__(cls: Type[T], seq: Union[List[T], Tuple[T]]) -> T:
+    def _docarray_stack(cls: Type[T], seq: Union[List[T], Tuple[T]]) -> T:
         """Stack a sequence of tensors into a single tensor."""
         comp_backend = cls.get_comp_backend()
         # at runtime, 'T' is always the correct input type for .stack()
         # but mypy doesn't know that, so we ignore it here
-        return cls.__docarray_from_native__(comp_backend.stack(seq))  # type: ignore
+        return cls._docarray_from_native(comp_backend.stack(seq))  # type: ignore
 
     @classmethod
     @abc.abstractmethod
-    def __docarray_from_native__(cls: Type[T], value: Any) -> T:
+    def _docarray_from_native(cls: Type[T], value: Any) -> T:
         """
         Create a DocArray tensor from a tensor that is native to the given framework,
         e.g. from numpy.ndarray or torch.Tensor.

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -34,8 +34,8 @@ class _ParametrizedMeta(type):
         is_tensor = AbstractTensor in subclass.mro()
         same_parents = is_tensor and cls.mro()[1:] == subclass.mro()[1:]
 
-        subclass_target_shape = getattr(subclass, '__docarray_target_shape__', False)
-        self_target_shape = getattr(cls, '__docarray_target_shape__', False)
+        subclass_target_shape = getattr(subclass, '_docarray_target_shape', False)
+        self_target_shape = getattr(cls, '_docarray_target_shape', False)
         same_shape = (
             same_parents
             and subclass_target_shape
@@ -115,7 +115,7 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
             cls,  # type: ignore
             metaclass=cls.__parametrized_meta__,  # type: ignore
         ):
-            __docarray_target_shape__ = shape
+            _docarray_target_shape = shape
 
             @classmethod
             def validate(
@@ -125,7 +125,7 @@ class AbstractTensor(Generic[ShapeT], AbstractType, ABC):
                 config: 'BaseConfig',
             ):
                 t = super().validate(value, field, config)
-                return _cls._docarray_validate_shape(t, _cls.__docarray_target_shape__)
+                return _cls._docarray_validate_shape(t, _cls._docarray_target_shape)
 
         _ParametrizedTensor.__name__ = f'{cls.__name__}[{shape_str}]'
         _ParametrizedTensor.__qualname__ = f'{cls.__qualname__}[{shape_str}]'

--- a/docarray/typing/tensor/embedding/embedding_mixin.py
+++ b/docarray/typing/tensor/embedding/embedding_mixin.py
@@ -8,8 +8,8 @@ class EmbeddingMixin(AbstractTensor, ABC):
     alternative_type: Optional[Type] = None
 
     @classmethod
-    def _docarray_validate_getitem(cls, item: Any) -> Tuple[int]:
-        shape = super()._docarray_validate_getitem(item)
+    def __docarray_validate_getitem__(cls, item: Any) -> Tuple[int]:
+        shape = super().__docarray_validate_getitem__(item)
         if len(shape) > 1:
             error_msg = f'`{cls}` can only have a single dimension/axis.'
             if cls.alternative_type:

--- a/docarray/typing/tensor/embedding/embedding_mixin.py
+++ b/docarray/typing/tensor/embedding/embedding_mixin.py
@@ -8,8 +8,8 @@ class EmbeddingMixin(AbstractTensor, ABC):
     alternative_type: Optional[Type] = None
 
     @classmethod
-    def __docarray_validate_getitem__(cls, item: Any) -> Tuple[int]:
-        shape = super().__docarray_validate_getitem__(item)
+    def _docarray_validate_getitem(cls, item: Any) -> Tuple[int]:
+        shape = super()._docarray_validate_getitem(item)
         if len(shape) > 1:
             error_msg = f'`{cls}` can only have a single dimension/axis.'
             if cls.alternative_type:

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -91,7 +91,7 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
         yield cls.validate
 
     @classmethod
-    def _docarray_validate_shape(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -91,7 +91,7 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
         yield cls.validate
 
     @classmethod
-    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def _docarray_validate_shape(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:
@@ -100,7 +100,7 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
                 f'of shape {t.shape} to shape {shape}'
             )
             try:
-                value = cls.__docarray_from_native__(np.reshape(t, shape))
+                value = cls._docarray_from_native(np.reshape(t, shape))
                 return cast(T, value)
             except RuntimeError:
                 raise ValueError(
@@ -115,25 +115,25 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
         config: 'BaseConfig',
     ) -> T:
         if isinstance(value, np.ndarray):
-            return cls.__docarray_from_native__(value)
+            return cls._docarray_from_native(value)
         elif isinstance(value, NdArray):
             return cast(T, value)
         elif isinstance(value, list) or isinstance(value, tuple):
             try:
                 arr_from_list: np.ndarray = np.asarray(value)
-                return cls.__docarray_from_native__(arr_from_list)
+                return cls._docarray_from_native(arr_from_list)
             except Exception:
                 pass  # handled below
         else:
             try:
                 arr: np.ndarray = np.ndarray(value)
-                return cls.__docarray_from_native__(arr)
+                return cls._docarray_from_native(arr)
             except Exception:
                 pass  # handled below
         raise ValueError(f'Expected a numpy.ndarray compatible type, got {type(value)}')
 
     @classmethod
-    def __docarray_from_native__(cls: Type[T], value: np.ndarray) -> T:
+    def _docarray_from_native(cls: Type[T], value: np.ndarray) -> T:
         return value.view(cls)
 
     @classmethod
@@ -194,9 +194,9 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
         source = pb_msg.dense
         if source.buffer:
             x = np.frombuffer(bytearray(source.buffer), dtype=source.dtype)
-            return cls.__docarray_from_native__(x.reshape(source.shape))
+            return cls._docarray_from_native(x.reshape(source.shape))
         elif len(source.shape) > 0:
-            return cls.__docarray_from_native__(np.zeros(source.shape))
+            return cls._docarray_from_native(np.zeros(source.shape))
         else:
             raise ValueError(f'proto message {pb_msg} cannot be cast to a NdArray')
 

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -91,7 +91,7 @@ class TorchTensor(
         yield cls.validate
 
     @classmethod
-    def _docarray_validate_shape(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -91,7 +91,7 @@ class TorchTensor(
         yield cls.validate
 
     @classmethod
-    def __docarray_validate_shape__(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
+    def _docarray_validate_shape(cls, t: T, shape: Tuple[int]) -> T:  # type: ignore
         if t.shape == shape:
             return t
         else:
@@ -100,7 +100,7 @@ class TorchTensor(
                 f'of shape {t.shape} to shape {shape}'
             )
             try:
-                value = cls.__docarray_from_native__(t.view(shape))
+                value = cls._docarray_from_native(t.view(shape))
                 return cast(T, value)
             except RuntimeError:
                 raise ValueError(
@@ -117,12 +117,12 @@ class TorchTensor(
         if isinstance(value, TorchTensor):
             return cast(T, value)
         elif isinstance(value, torch.Tensor):
-            return cls.__docarray_from_native__(value)
+            return cls._docarray_from_native(value)
 
         else:
             try:
                 arr: torch.Tensor = torch.tensor(value)
-                return cls.__docarray_from_native__(arr)
+                return cls._docarray_from_native(arr)
             except Exception:
                 pass  # handled below
         raise ValueError(f'Expected a torch.Tensor compatible type, got {type(value)}')
@@ -168,7 +168,7 @@ class TorchTensor(
         return value
 
     @classmethod
-    def __docarray_from_native__(cls: Type[T], value: torch.Tensor) -> T:
+    def _docarray_from_native(cls: Type[T], value: torch.Tensor) -> T:
         """Create a TorchTensor from a native torch.Tensor
 
         :param value: the native torch.Tensor
@@ -184,7 +184,7 @@ class TorchTensor(
         :param value: the numpy array
         :return: a TorchTensor
         """
-        return cls.__docarray_from_native__(torch.from_numpy(value))
+        return cls._docarray_from_native(torch.from_numpy(value))
 
     def _to_node_protobuf(self: T) -> 'NodeProto':
         """Convert Document into a NodeProto protobuf message. This function should

--- a/docarray/utils/find.py
+++ b/docarray/utils/find.py
@@ -250,7 +250,7 @@ def _extraxt_embeddings(
 
     if isinstance(data, DocumentArray):
         emb = getattr(data, embedding_field)
-        emb = embedding_type.__docarray_stack__(emb)
+        emb = embedding_type._docarray_stack(emb)
     elif isinstance(data, DocumentArrayStacked):
         emb = getattr(data, embedding_field)
     elif isinstance(data, BaseDocument):

--- a/tests/units/document/proto/test_proto_based_object.py
+++ b/tests/units/document/proto/test_proto_based_object.py
@@ -17,7 +17,7 @@ def test_ndarray():
 
     original_ndarray = np.zeros((3, 224, 224))
 
-    custom_ndarray = NdArray.__docarray_from_native__(original_ndarray)
+    custom_ndarray = NdArray._docarray_from_native(original_ndarray)
 
     tensor = NdArray.from_protobuf(custom_ndarray.to_protobuf())
 
@@ -30,7 +30,7 @@ def test_document_proto_set():
 
     nested_item1 = NodeProto(text='hello')
 
-    ndarray = NdArray.__docarray_from_native__(np.zeros((3, 224, 224)))
+    ndarray = NdArray._docarray_from_native(np.zeros((3, 224, 224)))
     nd_proto = ndarray.to_protobuf()
 
     nested_item2 = NodeProto(ndarray=nd_proto)


### PR DESCRIPTION
Signed-off-by: Sami Jaghouar <sami.jaghouar@hotmail.fr>

# Context

rename all `__docarray_meth__` to `_docarray_meth`
