### PR TITLE
refactor: instances of parametrized tensors are no longer parametrized

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -67,7 +67,9 @@ class _ParametrizedMeta(type):
         is_tensor = isinstance(instance, AbstractTensor)
         if is_tensor:  # custom handling
             _cls = cast(Type[AbstractTensor], cls)
-            if _cls.__parentcls__:
+            if (
+                _cls.__unparametrizedcls__
+            ):  # This is not None if the tensor is parametrized
                 try:
                     parse_obj_as(_cls, instance)
                     return True
@@ -81,7 +83,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
 
     __parametrized_meta__: type = _ParametrizedMeta
     _PROTO_FIELD_NAME: str
-    __parentcls__: Optional[type] = None
+    __unparametrizedcls__: Optional[type] = None
 
     @classmethod
     def __docarray_validate_shape__(cls, t: T, shape: Tuple[Union[int, str]]) -> T:
@@ -172,7 +174,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
             metaclass=cls.__parametrized_meta__,  # type: ignore
         ):
             __docarray_target_shape__ = shape
-            __parentcls__ = cls
+            __unparametrizedcls__ = cls
 
             @classmethod
             def validate(

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -100,7 +100,6 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
         nd_proto = self.to_protobuf()
         return NodeProto(ndarray=nd_proto, type=self._proto_type_name)
 
-
     @classmethod
     def __docarray_validate_shape__(cls, t: T, shape: Tuple[Union[int, str]]) -> T:
         """Every tensor has to implement this method in order to

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -7,12 +7,15 @@ from typing import (
     Dict,
     Generic,
     List,
+    Optional,
     Tuple,
     Type,
     TypeVar,
     Union,
     cast,
 )
+
+from pydantic import parse_obj_as
 
 from docarray.computation import AbstractComputationalBackend
 from docarray.typing.abstract_type import AbstractType
@@ -63,6 +66,13 @@ class _ParametrizedMeta(type):
     def __instancecheck__(cls, instance):
         is_tensor = isinstance(instance, AbstractTensor)
         if is_tensor:  # custom handling
+            _cls = cast(Type[AbstractTensor], cls)
+            if _cls.__parentcls__:
+                try:
+                    parse_obj_as(_cls, instance)
+                    return True
+                except ValueError:
+                    return False
             return any(issubclass(candidate, cls) for candidate in type(instance).mro())
         return super().__instancecheck__(instance)
 
@@ -71,6 +81,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
 
     __parametrized_meta__: type = _ParametrizedMeta
     _PROTO_FIELD_NAME: str
+    __parentcls__: Optional[type] = None
 
     @classmethod
     def __docarray_validate_shape__(cls, t: T, shape: Tuple[Union[int, str]]) -> T:
@@ -161,6 +172,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
             metaclass=cls.__parametrized_meta__,  # type: ignore
         ):
             __docarray_target_shape__ = shape
+            __parentcls__ = cls
 
             @classmethod
             def validate(

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -120,6 +120,8 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
 
     @classmethod
     def _docarray_from_native(cls: Type[T], value: np.ndarray) -> T:
+        if cls.__parentcls__:
+            return value.view(cls.__parentcls__)
         return value.view(cls)
 
     @classmethod

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -120,8 +120,8 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
 
     @classmethod
     def _docarray_from_native(cls: Type[T], value: np.ndarray) -> T:
-        if cls.__parentcls__:
-            return value.view(cls.__parentcls__)
+        if cls.__unparametrizedcls__:  # This is not None if the tensor is parametrized
+            return value.view(cls.__unparametrizedcls__)
         return value.view(cls)
 
     @classmethod

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -159,7 +159,10 @@ class TorchTensor(
         :param value: the native torch.Tensor
         :return: a TorchTensor
         """
-        value.__class__ = cls
+        if cls.__parentcls__:
+            value.__class__ = cls.__parentcls__
+        else:
+            value.__class__ = cls
         return cast(T, value)
 
     @classmethod

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -159,8 +159,8 @@ class TorchTensor(
         :param value: the native torch.Tensor
         :return: a TorchTensor
         """
-        if cls.__parentcls__:
-            value.__class__ = cls.__parentcls__
+        if cls.__unparametrizedcls__:  # This is not None if the tensor is parametrized
+            value.__class__ = cls.__unparametrizedcls__
         else:
             value.__class__ = cls
         return cast(T, value)

--- a/tests/units/typing/tensor/test_cross_backend.py
+++ b/tests/units/typing/tensor/test_cross_backend.py
@@ -1,0 +1,14 @@
+import numpy as np
+from pydantic import parse_obj_as
+
+from docarray.typing import NdArray, TorchTensor
+
+
+def test_coercion_behavior():
+    t_np = parse_obj_as(NdArray[128], np.zeros(128))
+    t_th = parse_obj_as(TorchTensor[128], np.zeros(128))
+
+    assert isinstance(t_np, NdArray[128])
+    assert not isinstance(t_np, TorchTensor[128])
+    assert isinstance(t_th, TorchTensor[128])
+    assert not isinstance(t_th, NdArray[128])

--- a/tests/units/typing/tensor/test_np_ops.py
+++ b/tests/units/typing/tensor/test_np_ops.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from docarray import BaseDocument
+from docarray.typing import NdArray
+
+
+def test_tensor_ops():
+    class A(BaseDocument):
+        tensor: NdArray[3, 224, 224]
+
+    class B(BaseDocument):
+        tensor: NdArray[3, 112, 224]
+
+    tensor = A(tensor=np.ones((3, 224, 224))).tensor
+    tensord = A(tensor=np.ones((3, 224, 224))).tensor
+    tensorn = np.zeros((3, 224, 224))
+    tensorhalf = B(tensor=np.ones((3, 112, 224))).tensor
+    tensorfull = np.concatenate([tensorhalf, tensorhalf], axis=1)
+
+    assert type(tensor) == NdArray
+    assert type(tensor + tensord) == NdArray
+    assert type(tensor + tensorn) == NdArray
+    assert type(tensor + tensorfull) == NdArray

--- a/tests/units/typing/tensor/test_tensor.py
+++ b/tests/units/typing/tensor/test_tensor.py
@@ -138,6 +138,8 @@ def test_parametrized_instance():
     assert isinstance(t, np.ndarray)
 
     assert not isinstance(t, NdArray[256])
+    assert not isinstance(t, NdArray[2, 64])
+    assert not isinstance(t, NdArray[2, 2, 32])
 
 
 def test_parametrized_equality():

--- a/tests/units/typing/tensor/test_torch_ops.py
+++ b/tests/units/typing/tensor/test_torch_ops.py
@@ -1,0 +1,23 @@
+import torch
+
+from docarray import BaseDocument
+from docarray.typing import TorchTensor
+
+
+def test_tensor_ops():
+    class A(BaseDocument):
+        tensor: TorchTensor[3, 224, 224]
+
+    class B(BaseDocument):
+        tensor: TorchTensor[3, 112, 224]
+
+    tensor = A(tensor=torch.ones(3, 224, 224)).tensor
+    tensord = A(tensor=torch.ones(3, 224, 224)).tensor
+    tensorn = torch.zeros(3, 224, 224)
+    tensorhalf = B(tensor=torch.ones(3, 112, 224)).tensor
+    tensorfull = torch.cat([tensorhalf, tensorhalf], dim=1)
+
+    assert type(tensor) == TorchTensor
+    assert type(tensor + tensord) == TorchTensor
+    assert type(tensor + tensorn) == TorchTensor
+    assert type(tensor + tensorfull) == TorchTensor

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -90,7 +90,11 @@ def test_parametrized():
 
 @pytest.mark.parametrize('shape', [(3, 224, 224), (224, 224, 3)])
 def test_parameterized_tensor_class_name(shape):
-    tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(shape))
+    MyTT = TorchTensor[3, 224, 224]
+    tensor = parse_obj_as(MyTT, torch.zeros(shape))
+
+    assert MyTT.__name__ == 'TorchTensor[3, 224, 224]'
+    assert MyTT.__qualname__ == 'TorchTensor[3, 224, 224]'
 
     assert tensor.__class__.__name__ == 'TorchTensor'
     assert tensor.__class__.__qualname__ == 'TorchTensor'

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -130,6 +130,8 @@ def test_parametrized_instance():
     assert isinstance(t, torch.Tensor)
 
     assert not isinstance(t, TorchTensor[256])
+    assert not isinstance(t, TorchTensor[2, 128])
+    assert not isinstance(t, TorchTensor[2, 2, 64])
 
 
 def test_parametrized_equality():

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -92,9 +92,9 @@ def test_parametrized():
 def test_parameterized_tensor_class_name(shape):
     tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(shape))
 
-    assert tensor.__class__.__name__ == 'TorchTensor[3, 224, 224]'
-    assert tensor.__class__.__qualname__ == 'TorchTensor[3, 224, 224]'
-    assert f'{tensor[0][0][0]}' == 'TorchTensor[3, 224, 224](0.)'
+    assert tensor.__class__.__name__ == 'TorchTensor'
+    assert tensor.__class__.__qualname__ == 'TorchTensor'
+    assert f'{tensor[0][0][0]}' == 'TorchTensor(0.)'
 
 
 def test_torch_embedding():
@@ -137,7 +137,8 @@ def test_parametrized_equality():
     t2 = parse_obj_as(TorchTensor[128], torch.zeros(128))
     t3 = parse_obj_as(TorchTensor[256], torch.zeros(256))
     assert (t1 == t2).all()
-    assert not t1 == t3
+    with pytest.raises(RuntimeError):
+        t1 == t3
 
 
 def test_parametrized_operations():


### PR DESCRIPTION
This is because parametrizing them can cause them to be wrong when operations are performed.
We only need the parametrization during instantiation for validation.
After that, we make no guarantees about the shape.

Goals:
- Addresses #994 
- Doesnt seem like it is mentioned in the docs. Not sure if its relevant to add a section about this
