### PR TITLE
refactor: comp backend 

### DIFF
--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -95,14 +95,9 @@ class DocumentArrayStacked(AnyDocumentArray):
         for field in self._columns.keys():
             col = self._columns[field]
             if isinstance(col, AbstractTensor):
-                # the casting below is arbitrary, in reality `col` could be of any
-                # subclass of AbstractTensor. But to make mypy happy we have to cast
-                # it to a concrete subclass thereof
-                # see mypy issue: https://github.com/python/mypy/issues/14421
-                col_ = cast('TorchTensor', col)
-                self._columns[field] = col_.get_comp_backend().to_device(col_, device)
-            elif isinstance(col, NdArray):
-                self._columns[field] = col.get_comp_backend().to_device(col, device)
+                self._columns[field] = col.__class__._docarray_from_native(
+                    col.get_comp_backend().to_device(col, device)
+                )
             else:  # recursive call
                 col_docarray = cast(T, col)
                 col_docarray.to(device)

--- a/docarray/computation/abstract_comp_backend.py
+++ b/docarray/computation/abstract_comp_backend.py
@@ -1,18 +1,17 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union, overload
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 if TYPE_CHECKING:
     import numpy as np
 
 # In practice all of the below will be the same type
 TTensor = TypeVar('TTensor')
-TAbstractTensor = TypeVar('TAbstractTensor')
 TTensorRetrieval = TypeVar('TTensorRetrieval')
 TTensorMetrics = TypeVar('TTensorMetrics')
 
 
-class AbstractComputationalBackend(ABC, typing.Generic[TTensor, TAbstractTensor]):
+class AbstractComputationalBackend(ABC, typing.Generic[TTensor]):
     """
     Abstract base class for computational backends.
     Every supported tensor/ML framework (numpy, torch etc.) should define its own
@@ -69,37 +68,8 @@ class AbstractComputationalBackend(ABC, typing.Generic[TTensor, TAbstractTensor]
         """Get shape of tensor"""
         ...
 
-    @overload
-    @staticmethod
-    def reshape(tensor: 'TAbstractTensor', shape: Tuple[int, ...]) -> 'TAbstractTensor':
-        """
-        Gives a new shape to tensor without changing its data.
-
-        :param tensor: tensor to be reshaped
-        :param shape: the new shape
-        :return: a tensor with the same data and number of elements as tensor
-            but with the specified shape.
-        """
-        ...
-
-    @overload
     @staticmethod
     def reshape(tensor: 'TTensor', shape: Tuple[int, ...]) -> 'TTensor':
-        """
-        Gives a new shape to tensor without changing its data.
-
-        :param tensor: tensor to be reshaped
-        :param shape: the new shape
-        :return: a tensor with the same data and number of elements as tensor
-            but with the specified shape.
-        """
-        ...
-
-    @staticmethod
-    @abstractmethod
-    def reshape(
-        tensor: Union['TTensor', 'TAbstractTensor'], shape: Tuple[int, ...]
-    ) -> Union['TTensor', 'TAbstractTensor']:
         """
         Gives a new shape to tensor without changing its data.
 

--- a/docarray/computation/abstract_comp_backend.py
+++ b/docarray/computation/abstract_comp_backend.py
@@ -69,6 +69,7 @@ class AbstractComputationalBackend(ABC, typing.Generic[TTensor]):
         ...
 
     @staticmethod
+    @abstractmethod
     def reshape(tensor: 'TTensor', shape: Tuple[int, ...]) -> 'TTensor':
         """
         Gives a new shape to tensor without changing its data.

--- a/docarray/computation/numpy_backend.py
+++ b/docarray/computation/numpy_backend.py
@@ -1,10 +1,9 @@
 import warnings
-from typing import Any, List, Optional, Tuple, Union, overload
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 
 from docarray.computation import AbstractComputationalBackend
-from docarray.typing import NdArray
 
 
 def _expand_if_single_axis(*matrices: np.ndarray) -> List[np.ndarray]:
@@ -30,7 +29,7 @@ def _expand_if_scalar(arr: np.ndarray) -> np.ndarray:
     return arr
 
 
-class NumpyCompBackend(AbstractComputationalBackend[np.ndarray, NdArray]):
+class NumpyCompBackend(AbstractComputationalBackend[np.ndarray]):
     """
     Computational backend for Numpy.
     """
@@ -41,22 +40,8 @@ class NumpyCompBackend(AbstractComputationalBackend[np.ndarray, NdArray]):
     ) -> 'np.ndarray':
         return np.stack(tensors, axis=dim)
 
-    @overload
-    @staticmethod
-    def to_device(tensor: 'NdArray', device: str) -> 'NdArray':
-        """Move the tensor to the specified device."""
-        ...
-
-    @overload
     @staticmethod
     def to_device(tensor: 'np.ndarray', device: str) -> 'np.ndarray':
-        """Move the tensor to the specified device."""
-        ...
-
-    @staticmethod
-    def to_device(
-        tensor: Union['np.ndarray', 'NdArray'], device: str
-    ) -> Union['np.ndarray', 'NdArray']:
         """Move the tensor to the specified device."""
         raise NotImplementedError('Numpy does not support devices (GPU).')
 
@@ -82,36 +67,8 @@ class NumpyCompBackend(AbstractComputationalBackend[np.ndarray, NdArray]):
         """Get shape of array"""
         return array.shape
 
-    @overload
-    @staticmethod
-    def reshape(array: 'NdArray', shape: Tuple[int, ...]) -> 'NdArray':
-        """
-        Gives a new shape to array without changing its data.
-
-        :param array: array to be reshaped
-        :param shape: the new shape
-        :return: a array with the same data and number of elements as array
-            but with the specified shape.
-        """
-        ...
-
-    @overload
     @staticmethod
     def reshape(array: 'np.ndarray', shape: Tuple[int, ...]) -> 'np.ndarray':
-        """
-        Gives a new shape to array without changing its data.
-
-        :param array: array to be reshaped
-        :param shape: the new shape
-        :return: a array with the same data and number of elements as array
-            but with the specified shape.
-        """
-        ...
-
-    @staticmethod
-    def reshape(
-        array: Union['np.ndarray', 'NdArray'], shape: Tuple[int, ...]
-    ) -> Union['np.ndarray', 'NdArray']:
         """
         Gives a new shape to array without changing its data.
 

--- a/docarray/computation/torch_backend.py
+++ b/docarray/computation/torch_backend.py
@@ -1,12 +1,9 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, overload
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 
 from docarray.computation.abstract_comp_backend import AbstractComputationalBackend
-
-if TYPE_CHECKING:
-    from docarray.typing import TorchTensor
 
 
 def _unsqueeze_if_single_axis(*matrices: torch.Tensor) -> List[torch.Tensor]:
@@ -32,7 +29,7 @@ def _usqueeze_if_scalar(t: torch.Tensor):
     return t
 
 
-class TorchCompBackend(AbstractComputationalBackend[torch.Tensor, 'TorchTensor']):
+class TorchCompBackend(AbstractComputationalBackend[torch.Tensor]):
     """
     Computational backend for PyTorch.
     """
@@ -43,22 +40,9 @@ class TorchCompBackend(AbstractComputationalBackend[torch.Tensor, 'TorchTensor']
     ) -> 'torch.Tensor':
         return torch.stack(tensors, dim=dim)
 
-    @overload
-    @staticmethod
-    def to_device(tensor: 'TorchTensor', device: str) -> 'TorchTensor':
-        """Move the tensor to the specified device."""
-        ...
-
-    @overload
     @staticmethod
     def to_device(tensor: 'torch.Tensor', device: str) -> 'torch.Tensor':
         """Move the tensor to the specified device."""
-        ...
-
-    @staticmethod
-    def to_device(
-        tensor: Union['torch.Tensor', 'TorchTensor'], device: str
-    ) -> Union['torch.Tensor', 'TorchTensor']:
         return tensor.to(device)
 
     @staticmethod
@@ -82,36 +66,9 @@ class TorchCompBackend(AbstractComputationalBackend[torch.Tensor, 'TorchTensor']
     def shape(tensor: 'torch.Tensor') -> Tuple[int, ...]:
         return tuple(tensor.shape)
 
-    @overload
-    @staticmethod
-    def reshape(tensor: 'TorchTensor', shape: Tuple[int, ...]) -> 'TorchTensor':
-        """
-        Gives a new shape to tensor without changing its data.
-
-        :param tensor: tensor to be reshaped
-        :param shape: the new shape
-        :return: a tensor with the same data and number of elements as tensor
-            but with the specified shape.
-        """
-        ...
-
-    @overload
     @staticmethod
     def reshape(tensor: 'torch.Tensor', shape: Tuple[int, ...]) -> 'torch.Tensor':
-        """
-        Gives a new shape to tensor without changing its data.
 
-        :param tensor: tensor to be reshaped
-        :param shape: the new shape
-        :return: a tensor with the same data and number of elements as tensor
-            but with the specified shape.
-        """
-        ...
-
-    @staticmethod
-    def reshape(
-        tensor: Union['torch.Tensor', 'TorchTensor'], shape: Tuple[int, ...]
-    ) -> Union['torch.Tensor', 'TorchTensor']:
         """
         Gives a new shape to tensor without changing its data.
 

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -202,7 +202,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def get_comp_backend() -> AbstractComputationalBackend[TTensor, T]:
+    def get_comp_backend() -> AbstractComputationalBackend:
         """The computational backend compatible with this tensor type."""
         ...
 

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -88,7 +88,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
         :param shape: The shape to validate against.
         :return: The validated tensor.
         """
-        comp_be = t.get_comp_backend()()  # mypy Generics require instantiation
+        comp_be = t.get_comp_backend()  # mypy Generics require instantiation
         tshape = comp_be.shape(t)
         if tshape == shape:
             return t
@@ -202,7 +202,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def get_comp_backend() -> Type[AbstractComputationalBackend[TTensor, T]]:
+    def get_comp_backend() -> AbstractComputationalBackend[TTensor, T]:
         """The computational backend compatible with this tensor type."""
         ...
 

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -88,7 +88,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC):
         :param shape: The shape to validate against.
         :return: The validated tensor.
         """
-        comp_be = t.get_comp_backend()  # mypy Generics require instantiation
+        comp_be = t.get_comp_backend()
         tshape = comp_be.shape(t)
         if tshape == shape:
             return t

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -202,11 +202,11 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
         return nd_proto
 
     @staticmethod
-    def get_comp_backend() -> Type['NumpyCompBackend']:
+    def get_comp_backend() -> 'NumpyCompBackend':
         """Return the computational backend of the tensor"""
         from docarray.computation.numpy_backend import NumpyCompBackend
 
-        return NumpyCompBackend
+        return NumpyCompBackend()
 
     def __class_getitem__(cls, item: Any, *args, **kwargs):
         # see here for mypy bug: https://github.com/python/mypy/issues/14123

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -216,8 +216,8 @@ class TorchTensor(
         return nd_proto
 
     @staticmethod
-    def get_comp_backend() -> Type['TorchCompBackend']:
+    def get_comp_backend() -> 'TorchCompBackend':
         """Return the computational backend of the tensor"""
         from docarray.computation.torch_backend import TorchCompBackend
 
-        return TorchCompBackend
+        return TorchCompBackend()


### PR DESCRIPTION
# Context

Because of some type problem we need multiples times in the codebase to duplicate function definition in the Computional Backend part.

This PR fix this by doing a refactoring on the type part. The new one is less precise and correct that before but more flexible and easier to maintain.



Main difference are two folds:

* Use Instance instead of class in get_comp_backend (to fix the static method pb)
* The return type of the function in the computational backend is always np.ndarray or torch.Tensor. Therefore mypy cannot now that if you passed a TorchTensor (from us) the method will return a TorchTensor. This is a limitation but it allow us to remove the second TypeVar Generic in the Computational backend. This means in some case we need either to tell mypy we know the return type will be a TorchTensor by calling cast or TorchTensor._docarray_from_native()


