### PR TITLE
fix: up arrow emoji display in readme on docarray.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <!-- start elevator-pitch -->
 
-> :arrow_up: **DocArray v2**: We are currently working on v2 of DocArray. Keep reading here if you are interested in the
+> ⬆️ **DocArray v2**: We are currently working on v2 of DocArray. Keep reading here if you are interested in the
 > current (stable) version, or check out the [v2 alpha branch](https://github.com/docarray/docarray/tree/feat-rewrite-v2#readme)
 > and [v2 roadmap](https://github.com/docarray/docarray/issues/780)!
 


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/4182659/213145663-55c70435-04ab-4bfa-8ed9-0a51e099d0df.png)

`:arrow_up:` renders as :arrow_up: on GitHub's markdown rendering, but seems whatever renders the emoji on docarray.org doesn't support `:foo:` emojis.

## Solution

This fix uses the emoji directly, not the `:foo:` notation.

It should look no different on GitHub (I tested with their rendering engine - looks fine), but should display well on docarray.org

Signed-off-by: Alex C-G <alexcg@outlook.com>