### PR TITLE
Fix dtype stack

### DIFF
--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -151,9 +151,12 @@ class DocumentArrayStacked(AnyDocumentArray):
                 column_shape = (
                     (len(docs), *tensor.shape) if tensor is not None else (len(docs),)
                 )
+
                 columns[field] = type_._docarray_from_native(
                     type_.get_comp_backend().empty(
-                        column_shape, dtype=tensor.dtype, device=tensor.device
+                        column_shape,
+                        dtype=tensor.dtype,
+                        device=tensor.device if hasattr(tensor, 'device') else None,
                     )
                 )
 

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -152,7 +152,9 @@ class DocumentArrayStacked(AnyDocumentArray):
                     (len(docs), *tensor.shape) if tensor is not None else (len(docs),)
                 )
                 columns[field] = type_._docarray_from_native(
-                    type_.get_comp_backend().empty(column_shape)
+                    type_.get_comp_backend().empty(
+                        column_shape, dtype=tensor.dtype, device=tensor.device
+                    )
                 )
 
                 for i, doc in enumerate(docs):

--- a/docarray/array/array_stacked.py
+++ b/docarray/array/array_stacked.py
@@ -151,11 +151,10 @@ class DocumentArrayStacked(AnyDocumentArray):
                 column_shape = (
                     (len(docs), *tensor.shape) if tensor is not None else (len(docs),)
                 )
-
                 columns[field] = type_._docarray_from_native(
                     type_.get_comp_backend().empty(
                         column_shape,
-                        dtype=tensor.dtype,
+                        dtype=tensor.dtype if hasattr(tensor, 'dtype') else None,
                         device=tensor.device if hasattr(tensor, 'device') else None,
                     )
                 )

--- a/docarray/computation/abstract_comp_backend.py
+++ b/docarray/computation/abstract_comp_backend.py
@@ -1,6 +1,6 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, TypeVar, Union, overload
 
 if TYPE_CHECKING:
     import numpy as np
@@ -48,7 +48,11 @@ class AbstractComputationalBackend(ABC, typing.Generic[TTensor, TAbstractTensor]
 
     @staticmethod
     @abstractmethod
-    def empty(shape: Tuple[int, ...]) -> 'TTensor':
+    def empty(
+        shape: Tuple[int, ...],
+        dtype: Optional[Any] = None,
+        device: Optional[Any] = None,
+    ) -> 'TTensor':
         ...
 
     @staticmethod

--- a/docarray/computation/numpy_backend.py
+++ b/docarray/computation/numpy_backend.py
@@ -69,8 +69,14 @@ class NumpyCompBackend(AbstractComputationalBackend[np.ndarray, NdArray]):
         return array
 
     @staticmethod
-    def empty(shape: Tuple[int, ...]) -> 'np.ndarray':
-        return np.empty(shape)
+    def empty(
+        shape: Tuple[int, ...],
+        dtype: Optional[Any] = None,
+        device: Optional[Any] = None,
+    ) -> 'np.ndarray':
+        if device is not None:
+            raise NotImplementedError('Numpy does not support devices (GPU).')
+        return np.empty(shape, dtype=dtype)
 
     @staticmethod
     def none_value() -> Any:

--- a/docarray/computation/torch_backend.py
+++ b/docarray/computation/torch_backend.py
@@ -62,8 +62,18 @@ class TorchCompBackend(AbstractComputationalBackend[torch.Tensor, 'TorchTensor']
         return tensor.to(device)
 
     @staticmethod
-    def empty(shape: Tuple[int, ...]) -> torch.Tensor:
-        return torch.empty(shape)
+    def empty(
+        shape: Tuple[int, ...],
+        dtype: Optional[Any] = None,
+        device: Optional[Any] = None,
+    ) -> torch.Tensor:
+        extra_param = {}
+        if dtype is not None:
+            extra_param['dtype'] = dtype
+        if device is not None:
+            extra_param['device'] = device
+
+        return torch.empty(shape, **extra_param)
 
     @staticmethod
     def n_dim(array: 'torch.Tensor') -> int:

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -338,3 +338,17 @@ def test_to_device_numpy():
     da = da.stack()
     with pytest.raises(NotImplementedError):
         da.to('meta')
+
+
+def test_keep_dtype_torch():
+    class MyDoc(BaseDocument):
+        tensor: TorchTensor
+
+    da = DocumentArray[MyDoc](
+        [MyDoc(tensor=torch.zeros([2, 4], dtype=torch.int32)) for _ in range(3)]
+    )
+    assert da[0].tensor.dtype == torch.int32
+
+    da.stack()
+    assert da[0].tensor.dtype == torch.int32
+    assert da.tensor.dtype == torch.int32

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -195,7 +195,7 @@ def test_context_manager():
 
 def test_stack_union():
     class Image(BaseDocument):
-        tensor: Union[TorchTensor[3, 224, 224], NdArray[3, 224, 224]]
+        tensor: Union[NdArray[3, 224, 224], TorchTensor[3, 224, 224]]
 
     batch = DocumentArray[Image](
         [Image(tensor=np.zeros((3, 224, 224))) for _ in range(10)]
@@ -334,7 +334,7 @@ def test_to_device_nested():
 
 
 def test_to_device_numpy():
-    da = DocumentArray[Image]([Image(tensor=torch.zeros(3, 5))], tensor_type=NdArray)
+    da = DocumentArray[Image]([Image(tensor=np.zeros((3, 5)))], tensor_type=NdArray)
     da = da.stack()
     with pytest.raises(NotImplementedError):
         da.to('meta')

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -352,3 +352,17 @@ def test_keep_dtype_torch():
     da = da.stack()
     assert da[0].tensor.dtype == torch.int32
     assert da.tensor.dtype == torch.int32
+
+
+def test_keep_dtype_np():
+    class MyDoc(BaseDocument):
+        tensor: NdArray
+
+    da = DocumentArray[MyDoc](
+        [MyDoc(tensor=np.zeros([2, 4], dtype=np.int32)) for _ in range(3)]
+    )
+    assert da[0].tensor.dtype == np.int32
+
+    da = da.stack()
+    assert da[0].tensor.dtype == np.int32
+    assert da.tensor.dtype == np.int32

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -349,6 +349,6 @@ def test_keep_dtype_torch():
     )
     assert da[0].tensor.dtype == torch.int32
 
-    da.stack()
+    da = da.stack()
     assert da[0].tensor.dtype == torch.int32
     assert da.tensor.dtype == torch.int32

--- a/tests/units/computation_backends/numpy_backend/test_basics.py
+++ b/tests/units/computation_backends/numpy_backend/test_basics.py
@@ -39,3 +39,14 @@ def test_shape(array, result):
 def test_empty():
     array = NumpyCompBackend.empty((10, 3))
     assert array.shape == (10, 3)
+
+
+def test_empty_dtype():
+    tensor = NumpyCompBackend.empty((10, 3), dtype=np.int32)
+    assert tensor.shape == (10, 3)
+    assert tensor.dtype == np.int32
+
+
+def test_empty_device():
+    with pytest.raises(NotImplementedError):
+        NumpyCompBackend.empty((10, 3), device='meta')

--- a/tests/units/computation_backends/torch_backend/test_basics.py
+++ b/tests/units/computation_backends/torch_backend/test_basics.py
@@ -41,3 +41,15 @@ def test_shape(array, result):
 def test_empty():
     tensor = TorchCompBackend.empty((10, 3))
     assert tensor.shape == (10, 3)
+
+
+def test_empty_dtype():
+    tensor = TorchCompBackend.empty((10, 3), dtype=torch.int32)
+    assert tensor.shape == (10, 3)
+    assert tensor.dtype == torch.int32
+
+
+def test_empty_device():
+    tensor = TorchCompBackend.empty((10, 3), device='meta')
+    assert tensor.shape == (10, 3)
+    assert tensor.device == torch.device('meta')


### PR DESCRIPTION
# Context

this pr check that dtype are respected when calling DocumentArray.stack()
