### PR TITLE
feat: add default value to docs in da init

### DIFF
--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -76,7 +76,7 @@ class DocumentArray(AnyDocumentArray):
 
     def __init__(
         self,
-        docs: Iterable[BaseDocument],
+        docs: Iterable[BaseDocument] = list(),
         tensor_type: Type['AbstractTensor'] = NdArray,
     ):
         self._data = [doc_ for doc_ in docs]

--- a/tests/units/array/test_array.py
+++ b/tests/units/array/test_array.py
@@ -61,6 +61,11 @@ def test_document_array():
     assert len(da) == 10
 
 
+def test_empty_array():
+    da = DocumentArray()
+    len(da) == 0
+
+
 def test_document_array_fixed_type():
     class Text(BaseDocument):
         text: str


### PR DESCRIPTION
Signed-off-by: samsja <sami.jaghouar@hotmail.fr>

# Context

allow to do 

```python
da = DocumentArray()
```

before you had to do 

```python
da = DocumentArray([])
```