### PR TITLE
feat: init text directly

### DIFF
--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -27,6 +27,14 @@ class Text(BaseDocument):
         model = MyEmbeddingModel()
         txt_doc.embedding = model(txt_doc.text)
 
+    You can initialize directly from a string:
+
+    .. code-block:: python
+
+        from docarray.documents import Text
+
+        txt_doc = Text('hello world')
+
     You can extend this Document:
 
     .. code-block:: python
@@ -86,6 +94,11 @@ class Text(BaseDocument):
     text: Optional[str] = None
     url: Optional[TextUrl] = None
     embedding: Optional[AnyEmbedding] = None
+
+    def __init__(self, text: Optional[str] = None, **kwargs):
+        if 'text' not in kwargs:
+            kwargs['text'] = text
+        super().__init__(**kwargs)
 
     @classmethod
     def validate(

--- a/tests/units/document/test_docs_operators.py
+++ b/tests/units/document/test_docs_operators.py
@@ -20,3 +20,7 @@ def test_text_document_operators():
     t = Text(text='this is my text document')
     assert 'text' in t
     assert 'docarray' not in t
+
+    text = Text()
+    assert text is not None
+    assert text.text is None

--- a/tests/units/document/test_text_document.py
+++ b/tests/units/document/test_text_document.py
@@ -1,0 +1,15 @@
+from docarray.documents import Text
+
+
+def test_text_document_init():
+    text = Text('hello world')
+    assert text.text == 'hello world'
+    assert text == 'hello world'
+
+    text = Text(text='hello world')
+    assert text.text == 'hello world'
+    assert text == 'hello world'
+
+    text = Text()
+    assert text is not None
+    assert text.text is None


### PR DESCRIPTION
Goals:
Solves #1056 


Allows to have a less-verbose `Text` initalization:

```python
from docarray.documents import Text
Text('hello world')
``` 
works