### PR TITLE
chore: uncap dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,36 @@ jobs:
 #          fail_ci_if_error: false
 #          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
+
+
+  docarray-test-uncaped: # do test without using poetry lock. This does not block ci passing
+    needs: [lint-ruff, check-black, import-test]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7]
+        test-path: [tests/integrations, tests/units]
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Prepare environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          rm poetry.lock
+          poetry install --all-extras
+
+      - name: Test
+        id: test
+        run: |
+          poetry run pytest ${{ matrix.test-path }}
+        timeout-minutes: 30
+
+
   docarray-test-proto3:
     needs: [lint-ruff, check-black, import-test]
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,20 @@ authors=['DocArray']
 license='Apache 2.0'
 
 [tool.poetry.dependencies]
-python = "^3.7"
-pydantic = "^1.10.2"
-numpy = "^1.17.3"
+python = ">=3.7"
+pydantic = ">=1.10.2"
+numpy = ">=1.17.3"
 protobuf = { version = ">=3.19.0", optional = true }
-torch = { version = "^1.0.0", optional = true }
-orjson = "^3.8.2"
-pillow = {version = "^9.3.0", optional = true }
-types-pillow = {version = "^9.3.0.1", optional = true }
-trimesh = {version = "^3.17.1", optional = true}
-typing-inspect = "^0.8.0"
-types-requests = "^2.28.11.6"
-av = {version = "^10.0.0", optional = true}
-fastapi = {version = "^0.87.0", optional = true }
-rich = "^13.1.0"
+torch = { version = ">=1.0.0", optional = true }
+orjson = ">=3.8.2"
+pillow = {version = ">=9.3.0", optional = true }
+types-pillow = {version = ">=9.3.0.1", optional = true }
+trimesh = {version = ">=3.17.1", optional = true}
+typing-inspect = ">=0.8.0"
+types-requests = ">=2.28.11.6"
+av = {version = ">=10.0.0", optional = true}
+fastapi = {version = ">=0.87.0", optional = true }
+rich = ">=13.1.0"
 
 [tool.poetry.extras]
 common = ["protobuf"]
@@ -30,19 +30,19 @@ mesh = ["trimesh"]
 web = ["fastapi"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.1"
-pre-commit = "^2.20.0"
-jupyterlab = "^3.5.0"
-mypy = "^0.990"
-types-protobuf = "^3.20.4"
-black = "^22.10.0"
-isort = "^5.10.1"
-ruff = "^0.0.165"
+pytest = ">=6.1"
+pre-commit = ">=2.20.0"
+jupyterlab = ">=3.5.0"
+mypy = ">=0.990"
+types-protobuf = ">=3.20.4"
+black = ">=22.10.0"
+isort = ">=5.10.1"
+ruff = ">=0.0.165"
 
 [tool.poetry.group.dev.dependencies]
-uvicorn = "^0.19.0"
-httpx = "^0.23.0"
-pytest-asyncio = "^0.20.2"
+uvicorn = ">=0.19.0"
+httpx = ">=0.23.0"
+pytest-asyncio = ">=0.20.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
# Context

* remove the dependency cap from poetry
* add CI to test code against latest code version but does not block ci

justification here https://iscinumpy.dev/post/bound-version-constraints/