### PR TITLE
docs: fix urls to docs.docarray.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,7 +268,7 @@ Bonus: **Know when to break the rules**. Documentation writing is as much art as
 
 [MyST](https://myst-parser.readthedocs.io/en/latest/) Elements Usage
 
-1. Use the `{tab}` element to show multiple ways of doing one thing. [Example](https://docarray.jina.ai/fundamentals/document/#document) 
+1. Use the `{tab}` element to show multiple ways of doing one thing. [Example](https://docs.docarray.org/fundamentals/document/#document) 
 2. Use the `{admonition}` boxes with care.
 3. Use `{dropdown}` to hide optional content, such as long code snippets or console output.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -25,7 +25,7 @@ Currently core developers of DocArray are (in alphabetic order):  [Alaeddine Abd
 
 Contributors can become core developers by beeing nominated by at least one other core developers of DocArray. There will be a vote by the current core developers. While it is expected that most votes will be unanimous, a two-thirds majority of the cast votes is enough.
 
-If you want to become a core developers, reach out to docarray@jina.ai. 
+If you want to become a core developers, reach out to docs.docarray.org. 
 
 ## TSC members
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ DocArray is a library for nested, unstructured, multimodal data in transit, incl
 
 🛸 **IDE integration**: pretty-print and visualization on Jupyter notebook and Google Colab; comprehensive autocomplete and type hints in PyCharm and VS Code.
 
-Read more on [why should you use DocArray](https://docarray.jina.ai/get-started/what-is/) and [comparison to alternatives](https://docarray.jina.ai/get-started/what-is/#comparing-to-alternatives).
+Read more on [why should you use DocArray](https://docs.docarray.org/get-started/what-is/) and [comparison to alternatives](https://docs.docarray.org/get-started/what-is/#comparing-to-alternatives).
 
 <!-- end elevator-pitch -->
 
 DocArray was released under the open-source [Apache License 2.0](https://github.com/docarray/docarray/blob/main/LICENSE) in January 2022. It is currently a sandbox project under [LF AI & Data Foundation](https://lfaidata.foundation/).
 
-## [Documentation](https://docarray.jina.ai)
+## [Documentation](https://docs.docarray.org)
 
 ## Install 
 
@@ -52,7 +52,7 @@ or via Conda:
 ```shell
 conda install -c conda-forge docarray
 ```
-[Commonly used features](https://docarray.jina.ai/#install) can be enabled via `pip install "docarray[common]"`.
+[Commonly used features](https://docs.docarray.org/#install) can be enabled via `pip install "docarray[common]"`.
 
 
 ## Get Started
@@ -141,7 +141,7 @@ Here the feature embedding is done by simple [feature hashing](https://en.wikipe
 
 ### Example 3: external storage for out-of-memory data
 
-When your data is too big, storing in memory is not the best idea. DocArray supports [multiple storage backends](https://docarray.jina.ai/advanced/document-store/) such as SQLite, Weaviate, Qdrant and AnnLite. They're all unified under **the exact same user experience and API**. Take the above snippet: you only need to change one line to use SQLite:
+When your data is too big, storing in memory is not the best idea. DocArray supports [multiple storage backends](https://docs.docarray.org/advanced/document-store/) such as SQLite, Weaviate, Qdrant and AnnLite. They're all unified under **the exact same user experience and API**. Take the above snippet: you only need to change one line to use SQLite:
 
 ```python
 da = DocumentArray(
@@ -208,7 +208,7 @@ left_da.plot_image_sprites()
 ```
 
 <p align="center">
-<a href="https://docarray.jina.ai"><img src="https://github.com/docarray/docarray/blob/main/.github/README-img/sprite.png?raw=true" alt="Load totally looks like dataset with docarray API" width="60%"></a>
+<a href="https://docs.docarray.org"><img src="https://github.com/docarray/docarray/blob/main/.github/README-img/sprite.png?raw=true" alt="Load totally looks like dataset with docarray API" width="60%"></a>
 </p>
 
 ### Apply preprocessing
@@ -254,7 +254,7 @@ left_da.plot_embeddings(image_sprites=True)
 ```
 
 <p align="center">
-<a href="https://docarray.jina.ai"><img src="https://github.com/docarray/docarray/blob/main/.github/README-img/tsne.gif?raw=true" alt="Visualizing embedding via tSNE and embedding projector" width="90%"></a>
+<a href="https://docs.docarray.org"><img src="https://github.com/docarray/docarray/blob/main/.github/README-img/tsne.gif?raw=true" alt="Visualizing embedding via tSNE and embedding projector" width="90%"></a>
 </p>
 
 Fun is fun, but our goal is to match left images against right images, and so far we have only handled the left. Let's repeat the same procedure for the right:
@@ -334,8 +334,8 @@ Better see it.
 ```
 
 <p align="center">
-<a href="https://docarray.jina.ai"><img src="https://github.com/jina-ai/docarray/blob/main/.github/README-img/9nn-left.jpeg?raw=true" alt="Visualizing top-9 matches using DocArray API" height="250px"></a>
-<a href="https://docarray.jina.ai"><img src="https://github.com/jina-ai/docarray/blob/main/.github/README-img/9nn.png?raw=true" alt="Visualizing top-9 matches using DocArray API" height="250px"></a>
+<a href="https://docs.docarray.org"><img src="https://github.com/jina-ai/docarray/blob/main/.github/README-img/9nn-left.jpeg?raw=true" alt="Visualizing top-9 matches using DocArray API" height="250px"></a>
+<a href="https://docs.docarray.org"><img src="https://github.com/jina-ai/docarray/blob/main/.github/README-img/9nn.png?raw=true" alt="Visualizing top-9 matches using DocArray API" height="250px"></a>
 </p>
 
 Here we reversed the preprocessing steps (i.e. switching axis and normalizing) on the copied matches, so you can visualize them using image sprites.  
@@ -400,7 +400,7 @@ Now anyone who knows the token `my_shared_da` can pull and work on it.
 left_da = DocumentArray.pull('<username>/my_shared_da')
 ```
 
-Intrigued? That's only scratching the surface of what DocArray is capable of. [Read our docs to learn more](https://docarray.jina.ai).
+Intrigued? That's only scratching the surface of what DocArray is capable of. [Read our docs to learn more](https://docs.docarray.org).
 
 
 <!-- start support-pitch -->

--- a/docarray/array/mixins/traverse.py
+++ b/docarray/array/mixins/traverse.py
@@ -59,7 +59,7 @@ def _re_traversal_path_split(path: str) -> List[str]:
         m = TRAVERSAL_PATH_LIST_REGEX.match(remainder)
         if not m:
             raise ValueError(
-                f'`path`:{path} is invalid, please refer to https://docarray.jina.ai/fundamentals/documentarray/access-elements/#index-by-nested-structure'
+                f'`path`:{path} is invalid, please refer to https://docs.docarray.org/fundamentals/documentarray/access-elements/#index-by-nested-structure'
             )
         group_dict = m.groupdict()
         current, remainder = group_dict['traversal_path'], group_dict['paths_remainder']
@@ -144,7 +144,7 @@ class TraverseMixin:
                         )
             else:
                 raise ValueError(
-                    f'`path`:{path} is invalid, please refer to https://docarray.jina.ai/fundamentals/documentarray/access-elements/#index-by-nested-structure'
+                    f'`path`:{path} is invalid, please refer to https://docs.docarray.org/fundamentals/documentarray/access-elements/#index-by-nested-structure'
                 )
         elif filter_fn is None:
             yield docs

--- a/docarray/array/storage/qdrant/find.py
+++ b/docarray/array/storage/qdrant/find.py
@@ -135,7 +135,7 @@ class FindMixin:
         """Returns a subset of documents by filtering by the given filter (`Qdrant` filter)..
         :param limit: number of retrieved items
         :param filter: filter query used for filtering.
-        For more information: https://docarray.jina.ai/advanced/document-store/qdrant/#qdrant
+        For more information: https://docs.docarray.org/advanced/document-store/qdrant/#qdrant
         :return: a `DocumentArray` containing the `Document` objects that verify the filter.
         """
 

--- a/docarray/proto/build-proto.sh
+++ b/docarray/proto/build-proto.sh
@@ -22,7 +22,7 @@ VER_FILE=../__init__.py
 
 if [ "$#" -ne 1 ] && [ "$#" -ne 2 ]; then
     echo "Error: Please specify the [PATH_TO_GRPC_PYTHON_PLUGIN], refer more details at " \
-      "https://docarray.jina.ai/"
+      "https://docs.docarray.org/"
     printf "\n"
     echo "USAGE:"
     printf "\t"

--- a/docs/advanced/document-store/benchmark.md
+++ b/docs/advanced/document-store/benchmark.md
@@ -1,6 +1,6 @@
 # One Million Scale Benchmark
 
-```{figure} https://docarray.jina.ai/_images/benchmark-banner.gif
+```{figure} https://docs.docarray.org/_images/benchmark-banner.gif
 :width: 0 %
 :scale: 0 %
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ pygments_style = 'rainbow_dash'
 html_theme = 'furo'
 
 base_url = '/'
-html_baseurl = 'https://docarray.jina.ai'
+html_baseurl = 'https://docs.docarray.org'
 sitemap_url_scheme = '{link}'
 sitemap_locales = [None]
 sitemap_filename = "sitemap.xml"
@@ -161,8 +161,8 @@ linkcheck_timeout = 20
 linkcheck_retries = 2
 linkcheck_anchors = False
 
-ogp_site_url = 'https://docarray.jina.ai/'
-ogp_image = 'https://docarray.jina.ai/_static/banner.png'
+ogp_site_url = 'https://docs.docarray.org/'
+ogp_image = 'https://docs.docarray.org/_static/banner.png'
 ogp_use_first_image = True
 ogp_description_length = 300
 ogp_type = 'website'

--- a/docs/fundamentals/dataclass/access.md
+++ b/docs/fundamentals/dataclass/access.md
@@ -82,7 +82,7 @@ class InnerDoc:
 @dataclass
 class OuterDoc:
     feature_image: InnerDoc
-    website: str = 'https://docarray.jina.ai'
+    website: str = 'https://docs.docarray.org'
 
 
 doc = Document(OuterDoc(feature_image=InnerDoc(description='this is a description')))
@@ -381,7 +381,7 @@ class BannerDoc:
 class ColumnArticle:
     featured: BannerDoc
     description: Text = 'this is a column article'
-    website: str = 'https://docarray.jina.ai'
+    website: str = 'https://docs.docarray.org'
 
 
 c1 = ColumnArticle(featured=BannerDoc(banner='test-1.jpeg'))

--- a/docs/fundamentals/dataclass/construct.md
+++ b/docs/fundamentals/dataclass/construct.md
@@ -418,7 +418,7 @@ This section explains the behavior of field annotations in detail.
     class ColumnArticle:
         feature_image: BannerDoc
         description: Text = 'this is a column article'
-        website: str = 'https://docarray.jina.ai'
+        website: str = 'https://docs.docarray.org'
 
 
     Document(ColumnArticle(feature_image=BannerDoc())).summary()
@@ -431,7 +431,7 @@ This section explains the behavior of field annotations in detail.
     ╭────────────────────┬─────────────────────────────────────────────────────────╮
     │ Attribute          │ Value                                                   │
     ├────────────────────┼─────────────────────────────────────────────────────────┤
-    │ tags               │ {'website': 'https://docarray.jina.ai'}                          │
+    │ tags               │ {'website': 'https://docs.docarray.org'}                          │
     ╰────────────────────┴─────────────────────────────────────────────────────────╯
     └── 💠 Chunks
         ├── 📄 Document: cb1df29a384a6d39aa81e5af93316c4d

--- a/docs/fundamentals/dataclass/index.md
+++ b/docs/fundamentals/dataclass/index.md
@@ -1,7 +1,7 @@
 (dataclass)=
 # Dataclass
 
-```{figure} https://docarray.jina.ai/_images/dataclass-banner.png
+```{figure} https://docs.docarray.org/_images/dataclass-banner.png
 :width: 0 %
 :scale: 0 %
 ```

--- a/docs/fundamentals/document/construct.md
+++ b/docs/fundamentals/document/construct.md
@@ -42,7 +42,7 @@ d1 = Document(text='hello')
 d2 = Document(blob=b'\f1')
 d3 = Document(tensor=numpy.array([1, 2, 3]))
 d4 = Document(
-    uri='https://docarray.jina.ai',
+    uri='https://docs.docarray.org',
     mime_type='text/plain',
     granularity=1,
     adjacency=3,
@@ -82,12 +82,12 @@ You can also wrap keyword arguments into a `dict`. The following ways of initial
 
 ```python
 d1 = Document(
-    uri='https://docarray.jina.ai', mime_type='text/plain', granularity=1, adjacency=3
+    uri='https://docs.docarray.org', mime_type='text/plain', granularity=1, adjacency=3
 )
 
 d2 = Document(
     dict(
-        uri='https://docarray.jina.ai',
+        uri='https://docs.docarray.org',
         mime_type='text/plain',
         granularity=1,
         adjacency=3,
@@ -96,7 +96,7 @@ d2 = Document(
 
 d3 = Document(
     {
-        'uri': 'https://docarray.jina.ai',
+        'uri': 'https://docs.docarray.org',
         'mime_type': 'text/plain',
         'granularity': 1,
         'adjacency': 3,

--- a/docs/fundamentals/documentarray/subindex.md
+++ b/docs/fundamentals/documentarray/subindex.md
@@ -29,7 +29,7 @@ class MyDocument:
 _docs = [
     Document(
         MyDocument(
-            image='https://docarray.jina.ai/_images/apple.png', paragraph='hello world'
+            image='https://docs.docarray.org/_images/apple.png', paragraph='hello world'
         )
     )
     for _ in range(10)
@@ -85,7 +85,7 @@ _docs = [
         text='hello world',
         chunks=[
             Document(
-                uri='https://docarray.jina.ai/_images/apple.png'
+                uri='https://docs.docarray.org/_images/apple.png'
             ).load_uri_to_image_tensor()
         ],
     )

--- a/docs/html_extra/robots.txt
+++ b/docs/html_extra/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-sitemap: https://docarray.jina.ai/sitemap.xml
+sitemap: https://docs.docarray.org/sitemap.xml

--- a/scripts/docstrings_lint.sh
+++ b/scripts/docstrings_lint.sh
@@ -36,7 +36,7 @@ if [[ -z "$PYDOCSTYLE_OUTPUT" ]] && [[ -z "$DARGLINT_OUTPUT" ]]; then
   echo 'OK'
   exit 0
 else
-  echo 'failure. make sure to check the guide for docstrings: https://docarray.jina.ai/chapters/docstring.html'
+  echo 'failure. make sure to check the guide for docstrings: https://docs.docarray.org/chapters/docstring.html'
   echo $DARGLINT_OUTPUT
   echo $PYDOCSTYLE_OUTPUT
   exit 1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     zip_safe=False,
     install_requires=['numpy', 'rich>=12.0.0', 'jina-hubble-sdk>=0.24.0'],
     extras_require={
-        # req usage, please see https://docarray.jina.ai/#install
+        # req usage, please see https://docs.docarray.org/#install
         'common': [
             'protobuf>=3.13.0',
             'lz4',
@@ -149,7 +149,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     project_urls={
-        'Documentation': 'https://docarray.jina.ai',
+        'Documentation': 'https://docs.docarray.org',
         'Source': 'https://github.com/jina-ai/docarray/',
         'Tracker': 'https://github.com/jina-ai/docarray/issues',
     },

--- a/tests/unit/array/mixins/test_pushpull.py
+++ b/tests/unit/array/mixins/test_pushpull.py
@@ -191,7 +191,7 @@ class MyDocument:
             [
                 Document(
                     MyDocument(
-                        image='https://docarray.jina.ai/_images/apple.png',
+                        image='https://docs.docarray.org/_images/apple.png',
                         paragraph='hello world',
                     )
                 )


### PR DESCRIPTION
WIP. Replacing all occurrences of docarray.jina.ai with docs.docarray.org

Signed-off-by: Alex C-G <alexcg@outlook.com>

Goals:

- ...
- ...
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
