### PR TITLE
fix(v2): rich display min width instead of set width

### DIFF
--- a/docarray/display/document_summary.py
+++ b/docarray/display/document_summary.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class DocumentSummary:
-    table_width: int = 80
+    table_min_width: int = 40
 
     def __init__(
         self,
@@ -116,7 +116,7 @@ class DocumentSummary:
         table = Table(
             'Attribute',
             'Value',
-            width=self.table_width,
+            min_width=self.table_min_width,
             box=box.ROUNDED,
             highlight=True,
         )

--- a/docarray/display/tensor_display.py
+++ b/docarray/display/tensor_display.py
@@ -12,6 +12,8 @@ class TensorDisplay:
     Rich representation of a tensor.
     """
 
+    tensor_min_width: int = 30
+
     def __init__(self, tensor: 'AbstractTensor'):
         self.tensor = tensor
 
@@ -51,4 +53,17 @@ class TensorDisplay:
     ) -> 'Measurement':
         from rich.measure import Measurement
 
-        return Measurement(1, options.max_width)
+        width = self._compute_table_width(max_width=options.max_width)
+        return Measurement(1, width)
+
+    def _compute_table_width(self, max_width: int) -> int:
+        """
+        Compute the width of the table. Depending on the length of the tensor, the width
+        should be in the range of 30 (min) and a given `max_width`.
+        """
+        comp_be = self.tensor.get_comp_backend()
+        t_squeezed = comp_be.squeeze(comp_be.detach(self.tensor))
+
+        min_capped = max(comp_be.shape(t_squeezed)[0], self.tensor_min_width)
+        min_max_capped = min(min_capped, max_width)
+        return min_max_capped

--- a/docarray/display/tensor_display.py
+++ b/docarray/display/tensor_display.py
@@ -60,6 +60,7 @@ class TensorDisplay:
         """
         Compute the width of the table. Depending on the length of the tensor, the width
         should be in the range of 30 (min) and a given `max_width`.
+        :return: the width of the table
         """
         comp_be = self.tensor.get_comp_backend()
         t_squeezed = comp_be.squeeze(comp_be.detach(self.tensor))


### PR DESCRIPTION
Signed-off-by: anna-charlotte <charlotte.gerhaher@jina.ai>

Use min width in the rich display instead of a set width, so that the table adjusts more to the data.
This:
<img width="341" alt="image" src="https://user-images.githubusercontent.com/73693835/217847911-7cb6a5d3-ec4b-4f91-bf5c-f394d9f8b1c5.png">

Instead of this:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/73693835/217847764-29f9d918-f729-40cf-b718-4b4926b2afde.png">

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
