### PR TITLE
fix: tensor summary 

### DIFF
--- a/docarray/computation/tensorflow_backend.py
+++ b/docarray/computation/tensorflow_backend.py
@@ -93,7 +93,8 @@ class TensorFlowCompBackend(AbstractNumpyBasedBackend[TensorFlowTensor]):
     @classmethod
     def dtype(cls, tensor: 'TensorFlowTensor') -> tf.dtypes:
         """Get the data type of the tensor."""
-        return cls._get_tensor(tensor).dtype
+        d_type = cls._get_tensor(tensor).dtype
+        return d_type.name
 
     @classmethod
     def minmax_normalize(

--- a/docarray/display/tensor_display.py
+++ b/docarray/display/tensor_display.py
@@ -46,7 +46,11 @@ class TensorDisplay:
         else:
             from rich.text import Text
 
-            yield Text(f'{type(self.tensor)} of shape {comp_be.shape(self.tensor)}')
+            yield Text(
+                f'{self.tensor.__class__.__name__} of '
+                f'shape {comp_be.shape(self.tensor)}, '
+                f'dtype: {str(comp_be.dtype(self.tensor))}'
+            )
 
     def __rich_measure__(
         self, console: 'Console', options: 'ConsoleOptions'
@@ -64,7 +68,9 @@ class TensorDisplay:
         """
         comp_be = self.tensor.get_comp_backend()
         t_squeezed = comp_be.squeeze(comp_be.detach(self.tensor))
-
-        min_capped = max(comp_be.shape(t_squeezed)[0], self.tensor_min_width)
-        min_max_capped = min(min_capped, max_width)
-        return min_max_capped
+        if comp_be.n_dim(t_squeezed) == 1 and comp_be.shape(t_squeezed)[0] < max_width:
+            min_capped = max(comp_be.shape(t_squeezed)[0], self.tensor_min_width)
+            min_max_capped = min(min_capped, max_width)
+            return min_max_capped
+        else:
+            return max_width


### PR DESCRIPTION
Goals:
Fix tensor summary display from this:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/73693835/218148913-01b59522-9017-4f34-97ee-97ce067f73de.png">

to this:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/73693835/218148778-a3e65f5f-5c91-48fb-b7ed-92cb7289d2ad.png">

So, add dtype display, display the tensors class name instead of this '< ... >' and adjust the width if tensor is not displayed by those blocks.
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
