### PR TITLE
feat: add schema map in protoload

### DIFF
--- a/docarray/array/array.py
+++ b/docarray/array/array.py
@@ -7,6 +7,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Mapping,
     Optional,
     Sequence,
     Type,
@@ -316,9 +317,25 @@ class DocumentArray(AnyDocumentArray, Generic[T_doc]):
 
     @classmethod
     def from_protobuf(cls: Type[T], pb_msg: 'DocumentArrayProto') -> T:
-        """create a Document from a protobuf message"""
+        """create a DocumentArray from a protobuf message"""
+        return cls.from_protobuf_field_map(pb_msg, None)
+
+    @classmethod
+    def from_protobuf_field_map(
+        cls: Type[T],
+        pb_msg: 'DocumentArrayProto',
+        field_map: Optional[Mapping[str, str]] = None,
+    ) -> T:
+        """
+        create a DocumentArray from a protobuf message with a field_map. Apply the same
+        behavior of {meth}`~docarray.BaseDocument.from_protobuf_field_map`
+        :param pb_msg:
+        :param field_map:
+        :return: a DocumentArray initialized from a proto message
+        """
         return cls(
-            cls.document_type.from_protobuf(doc_proto) for doc_proto in pb_msg.docs
+            cls.document_type.from_protobuf_field_map(doc_proto, field_map)
+            for doc_proto in pb_msg.docs
         )
 
     def to_protobuf(self) -> 'DocumentArrayProto':

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -84,14 +84,14 @@ class ProtoMixin(AbstractDocument, BaseNode):
 
                 value = pb_msg.data[field_name]
 
-                fields[field_name_mapped] = cls._proto_get_content_from_node_proto(
+                fields[field_name_mapped] = cls._get_content_from_node_proto(
                     value, field_name_mapped
                 )
 
         return cls(**fields)
 
     @classmethod
-    def _proto_get_content_from_node_proto(cls, value: 'NodeProto', field_name):
+    def _get_content_from_node_proto(cls, value: 'NodeProto', field_name):
         """
         load the proto data from a node proto
 

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -70,8 +70,6 @@ class ProtoMixin(AbstractDocument, BaseNode):
             value.type if value.WhichOneof('docarray_type') is not None else None
         )
 
-        return_field = None
-
         if content_type in content_type_dict:
             return_field = content_type_dict[content_type].from_protobuf(
                 getattr(value, content_key)

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -4,7 +4,6 @@ from docarray.base_document.abstract_document import AbstractDocument
 from docarray.base_document.base_node import BaseNode
 from docarray.typing.proto_register import _PROTO_TYPE_NAME_TO_CLASS
 
-
 if TYPE_CHECKING:
     from docarray.proto import DocumentProto, NodeProto
 
@@ -83,7 +82,7 @@ class ProtoMixin(AbstractDocument, BaseNode):
                     f' deserialization'
                 )
 
-        return cls.construct(**fields)
+        return cls(**fields)
 
     def to_protobuf(self) -> 'DocumentProto':
         """Convert Document into a Protobuf message.

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -50,7 +50,7 @@ class ProtoMixin(AbstractDocument, BaseNode):
 
             a = A(url='hello', tensor=torch.zeros(3))
 
-            b = B.from_protobuf_with_schema_map(
+            b = B.from_protobuf_field_map(
                 a.to_protobuf(), field_map={'url': 'link', 'tensor': 'array'}
             )
 

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -70,6 +70,8 @@ class ProtoMixin(AbstractDocument, BaseNode):
             value.type if value.WhichOneof('docarray_type') is not None else None
         )
 
+        return_field: Any
+
         if content_type in content_type_dict:
             return_field = content_type_dict[content_type].from_protobuf(
                 getattr(value, content_key)

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Type, TypeVar
 
 from docarray.base_document.abstract_document import AbstractDocument
 from docarray.base_document.base_node import BaseNode
@@ -14,7 +14,30 @@ T = TypeVar('T', bound='ProtoMixin')
 class ProtoMixin(AbstractDocument, BaseNode):
     @classmethod
     def from_protobuf(cls: Type[T], pb_msg: 'DocumentProto') -> T:
-        """create a Document from a protobuf message"""
+        """create a Document from a protobuf message
+
+        :param pb_msg: the proto message of the Document
+        :return: a Document initialize with the proto data
+        """
+
+        return cls.from_protobuf_with_schema_map(pb_msg)
+
+    @classmethod
+    def from_protobuf_with_schema_map(
+        cls: Type[T],
+        pb_msg: 'DocumentProto',
+        schema_map: Optional[Mapping[str, str]] = None,
+    ) -> T:
+        """create a Document from a protobuf message
+
+        :param pb_msg: the proto message of the Document
+        :param schema_map: map proto key to schema key
+        :return: a Document initialize with the proto data
+        """
+
+        schema_map = schema_map or {field: field for field in cls.__fields__.keys()}
+
+        content_type_dict = _PROTO_TYPE_NAME_TO_CLASS
 
         fields: Dict[str, Any] = {}
 

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -28,9 +28,8 @@ class ProtoMixin(AbstractDocument, BaseNode):
         pb_msg: 'DocumentProto',
         field_map: Optional[Mapping[str, str]] = None,
     ) -> T:
-        """create a Document from a protobuf message. You can specify a mapping
-        that will be used to convert key name from the proto to the class fields field
-        name by using the `field_map` field.
+        """Create a Document from a protobuf message. You can optionally specify a mapping
+        that will be used to map keys in the protobuf definition to keys (names) of the Document fields.
 
         .. code-block:: python
             from docarray import BaseDocument
@@ -58,9 +57,9 @@ class ProtoMixin(AbstractDocument, BaseNode):
             assert b.link == a.url
             assert (b.array == a.tensor).all()
 
-        :param pb_msg: the proto message of the Document
-        :param field_map: map proto key to schema key
-        :return: a Document initialize with the proto data
+        :param pb_msg: The proto message representing the Document
+        :param field_map: Optional mapping from proto fields to Document fields
+        :return: A new Document initialized with the data from `pb_msg`
         """
 
         fields: Dict[str, Any] = {}

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -68,25 +68,20 @@ class ProtoMixin(AbstractDocument, BaseNode):
 
         for field_name in pb_msg.data:
 
-            do_pass_loop = False
             if field_name not in cls.__fields__.keys():
                 if field_name in field_map.keys():
                     field_name_mapped = field_map[field_name]
                 else:
-                    do_pass_loop = True  # optimization we don't even load the data if the key does not
+                    continue  # optimization we don't even load the data if the key does not
                     # match any field in the cls or in the mapping
             else:
                 field_name_mapped = field_name
 
-            if do_pass_loop:
-                pass
-            else:
+            value = pb_msg.data[field_name]
 
-                value = pb_msg.data[field_name]
-
-                fields[field_name_mapped] = cls._get_content_from_node_proto(
-                    value, field_name_mapped
-                )
+            fields[field_name_mapped] = cls._get_content_from_node_proto(
+                value, field_name_mapped
+            )
 
         return cls(**fields)
 

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -103,14 +103,14 @@ class ProtoMixin(AbstractDocument, BaseNode):
         }
 
         content_key = value.WhichOneof('content')
-        content_type = (
+        docarray_type = (
             value.type if value.WhichOneof('docarray_type') is not None else None
         )
 
         return_field: Any
 
-        if content_type in content_type_dict:
-            return_field = content_type_dict[content_type].from_protobuf(
+        if docarray_type in content_type_dict:
+            return_field = content_type_dict[docarray_type].from_protobuf(
                 getattr(value, content_key)
             )
         elif content_key in ['document', 'document_array']:
@@ -119,7 +119,7 @@ class ProtoMixin(AbstractDocument, BaseNode):
             )  # we get to the parent class
         elif content_key is None:
             return_field = None
-        elif content_type is None:
+        elif docarray_type is None:
 
             if content_key in ['text', 'blob', 'integer', 'float', 'boolean']:
                 return_field = getattr(value, content_key)
@@ -138,7 +138,7 @@ class ProtoMixin(AbstractDocument, BaseNode):
 
         else:
             raise ValueError(
-                f'type {content_type}, with key {content_key} is not supported for'
+                f'type {docarray_type}, with key {content_key} is not supported for'
                 f' deserialization'
             )
 

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -35,15 +35,21 @@ class ProtoMixin(AbstractDocument, BaseNode):
         :return: a Document initialize with the proto data
         """
 
-        schema_map = schema_map or {field: field for field in cls.__fields__.keys()}
-
         fields: Dict[str, Any] = {}
 
         for field_name in pb_msg.data:
+
+            if schema_map and field_name not in schema_map.keys():
+                pass
+
+            final_name_mapped = (
+                field_name if schema_map is None else schema_map[field_name]
+            )
+
             value = pb_msg.data[field_name]
 
-            fields[field_name] = cls._proto_get_content_from_node_proto(
-                value, field_name
+            fields[final_name_mapped] = cls._proto_get_content_from_node_proto(
+                value, final_name_mapped
             )
 
         return cls(**fields)

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -39,17 +39,17 @@ class ProtoMixin(AbstractDocument, BaseNode):
 
         for field_name in pb_msg.data:
 
-            if schema_map and field_name not in schema_map.keys():
-                pass
-
-            final_name_mapped = (
+            field_name_mapped = (
                 field_name if schema_map is None else schema_map[field_name]
             )
 
+            if field_name_mapped not in cls.__fields__.keys():
+                pass  # optimization we don't even load the data if the key does not match
+
             value = pb_msg.data[field_name]
 
-            fields[final_name_mapped] = cls._proto_get_content_from_node_proto(
-                value, final_name_mapped
+            fields[field_name_mapped] = cls._proto_get_content_from_node_proto(
+                value, field_name_mapped
             )
 
         return cls(**fields)

--- a/docarray/base_document/mixins/proto.py
+++ b/docarray/base_document/mixins/proto.py
@@ -113,15 +113,9 @@ class ProtoMixin(AbstractDocument, BaseNode):
             return_field = content_type_dict[content_type].from_protobuf(
                 getattr(value, content_key)
             )
-        elif content_key == 'document':
+        elif content_key in ['document', 'document_array']:
             return_field = cls._get_field_type(field_name).from_protobuf(
-                value.document
-            )  # we get to the parent class
-        elif content_key == 'document_array':
-            from docarray import DocumentArray
-
-            return_field = DocumentArray.from_protobuf(
-                value.document_array
+                getattr(value, content_key)
             )  # we get to the parent class
         elif content_key is None:
             return_field = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ skip_glob= ['docarray/proto/pb2/*', 'docarray/proto/pb/*']
 
 [tool.ruff]
 exclude = ['docarray/proto/pb2/*', 'docarray/proto/pb/*', 'docs/*']
-ignore = ["E501"]
+ignore = ["E501"] # line too long, handled by black
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ skip_glob= ['docarray/proto/pb2/*', 'docarray/proto/pb/*']
 
 [tool.ruff]
 exclude = ['docarray/proto/pb2/*', 'docarray/proto/pb/*', 'docs/*']
+ignore = ["E501"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
# Context

This pr allow loading from protobuf with a field mapping.

## what this pr do

```python
from docarray import BaseDocument
from docarray.typing import AnyUrl, TorchTensor

import torch


class A(BaseDocument):
    url: AnyUrl
    tensor: TorchTensor


class B(BaseDocument):
    link: AnyUrl
    array: TorchTensor


a = A(url='hello', tensor=torch.zeros(3))

b = B.from_protobuf_with_schema_map(
    a.to_protobuf(), field_map={'url': 'link', 'tensor': 'array'}
)

assert b.link == a.url
assert (b.array == a.tensor).all()
```