### PR TITLE
fix: np deprecation warning

### DIFF
--- a/tests/units/array/test_indexing.py
+++ b/tests/units/array/test_indexing.py
@@ -78,7 +78,7 @@ def test_torchtensor_getitem(stack, da, index_dtype):
 
 
 @pytest.mark.parametrize('stack', [True, False])
-@pytest.mark.parametrize('index_dtype', [np.int, np.int_, np.int32, np.int64])
+@pytest.mark.parametrize('index_dtype', [int, np.int_, np.int32, np.int64])
 def test_nparray_getitem(stack, da, index_dtype):
     if stack:
         da = da.stack()
@@ -98,7 +98,7 @@ def test_nparray_getitem(stack, da, index_dtype):
         [False, True, True, True, True, False, True, False, False, False],
         (False, True, True, True, True, False, True, False, False, False),
         torch.tensor([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=torch.bool),
-        np.array([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=np.bool),
+        np.array([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=bool),
     ],
 )
 def test_boolmask_getitem(stack, da, index):
@@ -180,7 +180,7 @@ def test_torchtensor_setitem(stack_left, stack_right, da, da_to_set, index_dtype
 
 @pytest.mark.parametrize('stack_left', [True, False])
 @pytest.mark.parametrize('stack_right', [True, False])
-@pytest.mark.parametrize('index_dtype', [np.int, np.int_, np.int32, np.int64])
+@pytest.mark.parametrize('index_dtype', [int, np.int_, np.int32, np.int64])
 def test_nparray_setitem(stack_left, stack_right, da, da_to_set, index_dtype):
     if stack_left:
         da = da.stack()
@@ -211,7 +211,7 @@ def test_nparray_setitem(stack_left, stack_right, da, da_to_set, index_dtype):
         [False, True, True, True, True, False, True, False, False, False],
         (False, True, True, True, True, False, True, False, False, False),
         torch.tensor([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=torch.bool),
-        np.array([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=np.bool),
+        np.array([0, 1, 1, 1, 1, 0, 1, 0, 0, 0], dtype=bool),
     ],
 )
 def test_boolmask_setitem(stack_left, stack_right, da, da_to_set, index):

--- a/tests/units/computation_backends/numpy_backend/test_basics.py
+++ b/tests/units/computation_backends/numpy_backend/test_basics.py
@@ -43,7 +43,7 @@ def test_device():
     assert NumpyCompBackend.device(array) is None
 
 
-@pytest.mark.parametrize('dtype', [np.int64, np.float64, np.int, np.float])
+@pytest.mark.parametrize('dtype', [np.int64, np.float64, int, float])
 def test_dtype(dtype):
     array = np.array([1, 2, 3], dtype=dtype)
     assert NumpyCompBackend.dtype(array) == dtype

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import pytest
@@ -164,10 +164,10 @@ def test_list_set_dict_tuple_field():
         np.uint,
         np.uint8,
         np.uint64,
-        np.int,
+        int,
         np.int8,
         np.int64,
-        np.float,
+        float,
         np.float16,
         np.float128,
         np.double,


### PR DESCRIPTION

Goals:

Change all `np.int` to `int and all `no.float` to `float`, du to deprecation warning in tensorflow-tests:
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
```
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
