### PR TITLE
fix: remove setetiem in getiem

### DIFF
--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -211,6 +211,8 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
 
                 elif issubclass(field_type, BaseDocument):
                     doc_columns[field_name] = getattr(docs, field_name).stack()
+                    for i, doc in enumerate(docs):
+                        setattr(doc, field_name, doc_columns[field_name][i])
 
                 elif issubclass(field_type, DocumentArray):
                     for doc in docs:

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -271,10 +271,6 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
             return self._get_from_data_and_columns(item_)
         # single doc case
         doc = self._docs[item]
-        for field in self._doc_columns.keys():
-            setattr(doc, field, self._doc_columns[field][item])
-        for field in self._tensor_columns.keys():
-            setattr(doc, field, self._tensor_columns[field][item])
         return doc
 
     def __setitem__(self: T, key: Union[int, IndexIterType], value: Union[T, T_doc]):

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -253,9 +253,16 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
             values_ = cast(T, values)
             self._doc_columns[field] = values_
         elif field in self._tensor_columns.keys() and not isinstance(values, List):
-            values__ = parse_obj_as(
-                self.document_type._get_field_type(field).__unparametrizedcls__, values
+
+            type_ = cast(AbstractTensor, self.document_type._get_field_type(field))
+            shaped_type = (
+                type_.__unparametrizedcls__
+                if type_.__unparametrizedcls__ is not None
+                else type_
             )
+            values__ = parse_obj_as(shaped_type, values)  # type: ignore
+            # TODO: here we should validate that the shape is correct, maybe create a
+            # __unparametrizedcls__[len(self), X ,Y] ...
             self._tensor_columns[field] = values__
             for i, doc in enumerate(self):
                 setattr(doc, field, self._tensor_columns[field][i])

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -14,6 +14,8 @@ from typing import (
     overload,
 )
 
+from pydantic import parse_obj_as
+
 from docarray.array.abstract_array import AnyDocumentArray
 from docarray.array.array.array import DocumentArray
 from docarray.base_document import AnyDocument, BaseDocument
@@ -251,7 +253,9 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
             values_ = cast(T, values)
             self._doc_columns[field] = values_
         elif field in self._tensor_columns.keys() and not isinstance(values, List):
-            values__ = cast(AbstractTensor, values)
+            values__ = parse_obj_as(
+                self.document_type._get_field_type(field).__unparametrizedcls__, values
+            )
             self._tensor_columns[field] = values__
             for i, doc in enumerate(self):
                 setattr(doc, field, self._tensor_columns[field][i])

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -253,6 +253,8 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
         elif field in self._tensor_columns.keys() and not isinstance(values, List):
             values__ = cast(AbstractTensor, values)
             self._tensor_columns[field] = values__
+            for i, doc in enumerate(self):
+                setattr(doc, field, self._tensor_columns[field][i])
         else:
             setattr(self._docs, field, values)
 

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -75,6 +75,9 @@ def test_stack_setter(batch):
 
     assert (batch.tensor == torch.ones(10, 3, 224, 224)).all()
 
+    for i, doc in enumerate(batch):
+        assert (doc.tensor == batch.tensor[i]).all()
+
 
 def test_stack_optional(batch):
     assert (batch._tensor_columns['tensor'] == torch.zeros(10, 3, 224, 224)).all()

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -70,10 +70,35 @@ def test_iterator(batch):
         assert (doc.tensor == torch.zeros(3, 224, 224)).all()
 
 
-def test_stack_setter(batch):
+def test_stack_setter():
+    class Image(BaseDocument):
+        tensor: TorchTensor[3, 224, 224]
+
+    batch = DocumentArray[Image](
+        [Image(tensor=torch.zeros(3, 224, 224)) for _ in range(10)]
+    )
+
+    batch = batch.stack()
     batch.tensor = torch.ones(10, 3, 224, 224)
 
     assert (batch.tensor == torch.ones(10, 3, 224, 224)).all()
+
+    for i, doc in enumerate(batch):
+        assert (doc.tensor == batch.tensor[i]).all()
+
+
+def test_stack_setter_np():
+    class Image(BaseDocument):
+        tensor: NdArray[3, 224, 224]
+
+    batch = DocumentArray[Image](
+        [Image(tensor=np.zeros((3, 224, 224))) for _ in range(10)]
+    )
+
+    batch = batch.stack()
+    batch.tensor = np.ones((10, 3, 224, 224))
+
+    assert (batch.tensor == np.ones((10, 3, 224, 224))).all()
 
     for i, doc in enumerate(batch):
         assert (doc.tensor == batch.tensor[i]).all()

--- a/tests/units/array/test_array_stacked_tf.py
+++ b/tests/units/array/test_array_stacked_tf.py
@@ -97,9 +97,11 @@ def test_set_after_stacking(batch):
     )
 
     batch = batch.stack()
-    batch.tensor.tensor = tf.ones((10, 3, 224, 224))
+    batch.tensor = tf.ones((10, 3, 224, 224))
     for i, doc in enumerate(batch):
-        assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
+        doc.tensor.tensor
+        batch.tensor.tensor[i]
+        # assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
 
 
 @pytest.mark.tensorflow

--- a/tests/units/array/test_array_stacked_tf.py
+++ b/tests/units/array/test_array_stacked_tf.py
@@ -97,7 +97,7 @@ def test_set_after_stacking(batch):
     )
 
     batch = batch.stack()
-    batch.tensor.tensor = tf.ones((10, 3, 224, 224))
+    batch.tensor = tf.ones((10, 3, 224, 224))
     for i, doc in enumerate(batch):
         assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
 

--- a/tests/units/array/test_array_stacked_tf.py
+++ b/tests/units/array/test_array_stacked_tf.py
@@ -97,7 +97,7 @@ def test_set_after_stacking(batch):
     )
 
     batch = batch.stack()
-    batch.tensor = tf.ones((10, 3, 224, 224))
+    batch.tensor.tensor = tf.ones((10, 3, 224, 224))
     for i, doc in enumerate(batch):
         assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
 

--- a/tests/units/array/test_array_stacked_tf.py
+++ b/tests/units/array/test_array_stacked_tf.py
@@ -80,15 +80,7 @@ def test_iterator(batch):
 
 
 @pytest.mark.tensorflow
-def test_stack_setter(batch):
-
-    batch.tensor = tf.ones((10, 3, 224, 224))
-
-    assert tnp.allclose(batch.tensor, tf.ones((10, 3, 224, 224)))
-
-
-@pytest.mark.tensorflow
-def test_set_after_stacking(batch):
+def test_set_after_stacking():
     class Image(BaseDocument):
         tensor: TensorFlowTensor[3, 224, 224]
 
@@ -98,10 +90,9 @@ def test_set_after_stacking(batch):
 
     batch = batch.stack()
     batch.tensor = tf.ones((10, 3, 224, 224))
+    assert tnp.allclose(batch.tensor.tensor, tf.ones((10, 3, 224, 224)))
     for i, doc in enumerate(batch):
-        doc.tensor.tensor
-        batch.tensor.tensor[i]
-        # assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
+        assert tnp.allclose(doc.tensor.tensor, batch.tensor.tensor[i])
 
 
 @pytest.mark.tensorflow

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -36,19 +36,23 @@ def test_unwrap():
     assert (ndarray == torch.zeros(3, 224, 224)).all()
 
 
-def test_parametrized():
+def test_parametrized_correct_axis_shape():
     # correct shape, single axis
     tensor = parse_obj_as(TorchTensor[128], torch.zeros(128))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (128,)
 
+
+def test_correct_shape_multiple_axis():
     # correct shape, multiple axis
     tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
+
+def test_wrong_but_reshapable():
     # wrong but reshapable shape
     tensor = parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 3, 224))
     assert isinstance(tensor, TorchTensor)
@@ -59,12 +63,16 @@ def test_parametrized():
     with pytest.raises(ValueError):
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
 
+
+def test_inependent_variable_dim():
     # test independent variable dimensions
     tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
+
+def test_param():
     tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 60, 128))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
@@ -76,6 +84,8 @@ def test_parametrized():
     with pytest.raises(ValueError):
         parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(100, 1))
 
+
+def test_dependent_variable_dim():
     # test dependent variable dimensions
     tensor = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)


### PR DESCRIPTION
# Context

we don't need the setitem when calling `da[0]` anymore. This is because we store the tensor in the document as a view of the column