### PR TITLE
refactor(v2): change access path separator from `.` to `__`

### DIFF
--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -133,13 +133,13 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
         access_path: str,
     ) -> Union[List[Any], 'AbstractTensor']:
         """
-        Return a List of the accessed objects when applying the access_path. If this
+        Return a List of the accessed objects when applying the `access_path`. If this
         results in a nested list or list of DocumentArrays, the list will be flattened
         on the first level. The access path is a string that consists of attribute
-        names, concatenated and dot-seperated. It describes the path from the first
-        level to an arbitrary one, e.g. 'doc_attr_x.sub_doc_attr_x.sub_sub_doc_attr_z'.
+        names, concatenated and "__"-separated. It describes the path from the first
+        level to an arbitrary one, e.g. 'content__image__url'.
 
-        :param access_path: a string that represents the access path.
+        :param access_path: a string that represents the access path ("__"-separated).
         :return: list of the accessed objects, flattened if nested.
 
         EXAMPLE USAGE
@@ -163,7 +163,7 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
 
             books = da.traverse_flat(access_path='content')  # list of 10 Text objs
 
-            authors = da.traverse_flat(access_path='author.name')  # list of 10 strings
+            authors = da.traverse_flat(access_path='author__name')  # list of 10 strings
 
         If the resulting list is a nested list, it will be flattened:
 
@@ -220,7 +220,7 @@ class AnyDocumentArray(Sequence[BaseDocument], Generic[T_doc], AbstractType):
     @staticmethod
     def _traverse(node: Any, access_path: str):
         if access_path:
-            curr_attr, _, path_attrs = access_path.partition('.')
+            curr_attr, _, path_attrs = access_path.partition('__')
 
             from docarray.array import DocumentArray
 

--- a/docarray/utils/filter.py
+++ b/docarray/utils/filter.py
@@ -68,6 +68,8 @@ def filter(
     if query:
         query = query if not isinstance(query, str) else json.loads(query)
         parser = QueryParser(query)
-        return DocumentArray[docs.document_type](d for d in docs if parser.evaluate(d))
+        return DocumentArray.__class_getitem__(docs.document_type)(
+            d for d in docs if parser.evaluate(d)
+        )
     else:
         return docs

--- a/docarray/utils/filter.py
+++ b/docarray/utils/filter.py
@@ -47,7 +47,7 @@ def filter(
         )
         query = {
             '$and': {
-                'image.url': {'$regex': 'photo'},
+                'image__url': {'$regex': 'photo'},
                 'price': {'$lte': 50},
             }
         }
@@ -68,6 +68,6 @@ def filter(
     if query:
         query = query if not isinstance(query, str) else json.loads(query)
         parser = QueryParser(query)
-        return DocumentArray(d for d in docs if parser.evaluate(d))
+        return DocumentArray[docs.document_type](d for d in docs if parser.evaluate(d))
     else:
         return docs

--- a/docarray/utils/query_language/lookup.py
+++ b/docarray/utils/query_language/lookup.py
@@ -27,22 +27,21 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
 import re
-from typing import List, Union, Any, Sequence, Callable, Tuple, Optional, Iterator
-
 from functools import partial
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Union
 
 PLACEHOLDER_PATTERN = re.compile(r'\{\s*([a-zA-Z0-9_]*)\s*}')
 
 
-def point_get(_dict: Any, key: str) -> Any:
-    """Returns value for a specified "dot separated key"
+def dunder_get(_dict: Any, key: str) -> Any:
+    """Returns value for a specified "dunder separated key"
 
-    A "dot separated key" is just a fieldname that may or may not contain
-    ".") for referencing nested keys in a dict or object. eg::
+    A "dunder separated key" is just a fieldname that may or may not contain "__"
+    for referencing nested keys in a dict or object. eg::
      >>> data = {'a': {'b': 1}}
-     >>> dunder_get(data, 'a.b')
+     >>> dunder_get(data, 'a__b')
 
-    key 'b' can be referrenced as 'a.b'
+    key 'b' can be referrenced as 'a__b'
 
     :param _dict: (dict, list, struct or object) which we want to index into
     :param key: (str) that represents a first level or nested key in the dict
@@ -55,7 +54,7 @@ def point_get(_dict: Any, key: str) -> Any:
 
     part1: Union[str, int]
     try:
-        part1, part2 = key.split('.', 1)
+        part1, part2 = key.split('__', 1)
     except ValueError:
         part1, part2 = key, ''
 
@@ -73,7 +72,7 @@ def point_get(_dict: Any, key: str) -> Any:
     else:
         result = getattr(_dict, part1)
 
-    return point_get(result, part2) if part2 else result
+    return dunder_get(result, part2) if part2 else result
 
 
 def lookup(key: str, val: Any, doc: Any) -> bool:
@@ -82,19 +81,19 @@ def lookup(key: str, val: Any, doc: Any) -> bool:
     The lookup types are derived from the `key` and then used to check
     if the lookup holds true for the document::
 
-        >>> lookup('text__exact', 'hello', doc)
+        >>> lookup('text.exact', 'hello', doc)
 
     The above will return True if doc.text == 'hello' else False. And
 
         >>> lookup('text_exact', '{tags__name}', doc)
 
-    will return True if doc.text == doc.tags['name'] else False
+    will return True if doc.text == doc.tags.name else False
 
     :param key: the field name to find
     :param val: object to match the value in the document against
     :param doc: the document to match
     """
-    get_key, last = dunder_partition(key)
+    get_key, last = point_partition(key)
 
     if isinstance(val, str) and val.startswith('{'):
         r = PLACEHOLDER_PATTERN.findall(val)
@@ -105,8 +104,8 @@ def lookup(key: str, val: Any, doc: Any) -> bool:
 
     field_exists = True
     try:
-        if '.' in get_key:
-            value = point_get(doc, get_key)
+        if '__' in get_key:
+            value = dunder_get(doc, get_key)
         else:
             value = getattr(doc, get_key)
     except (AttributeError, KeyError):
@@ -201,8 +200,8 @@ class LookupNode(LookupTreeElem):
 
     Typically it's any object composed of two ``Q`` objects eg::
 
-        >>> Q(language__neq='Ruby') | Q(framework__startswith='S')
-        >>> ~Q(language__exact='PHP')
+        >>> Q(language.neq='Ruby') | Q(framework.startswith='S')
+        >>> ~Q(language.exact='PHP')
 
     """
 
@@ -218,7 +217,7 @@ class LookupNode(LookupTreeElem):
     def evaluate(self, doc: Any) -> bool:
         """Evaluates the expression represented by the object for the document
 
-        :param doc : the document to match
+        :param doc: the document to match
         :return: returns true if lookup passed
         """
         results = map(lambda x: x.evaluate(doc), self.children)
@@ -246,7 +245,7 @@ class LookupLeaf(LookupTreeElem):
     def evaluate(self, doc: Any) -> bool:
         """Evaluates the expression represented by the object for the document
 
-        :param doc : the document to match
+        :param doc: the document to match
         :return: returns true if lookup passed
         """
         result = all(lookup(k, v, doc) for k, v in self.lookups.items())
@@ -277,14 +276,14 @@ class LookupyError(Exception):
 ## utility functions
 
 
-def dunder_partition(key: str) -> Tuple[str, Optional[str]]:
-    """Splits a dunderkey into 2 parts
+def point_partition(key: str) -> Tuple[str, Optional[str]]:
+    """Splits a dot-separated key into 2 parts.
     The first part is everything before the final double underscore
     The second part is after the final double underscore
-        >>> dunder_partition('a__b__c')
-        >>> ('a__b', 'c')
+        >>> point_partition('a.b.c')
+        >>> ('a.b', 'c')
     """
-    parts = key.rsplit('__', 1)
+    parts = key.rsplit('.', 1)
     return (parts[0], parts[1]) if len(parts) > 1 else (parts[0], None)
 
 

--- a/docarray/utils/query_language/lookup.py
+++ b/docarray/utils/query_language/lookup.py
@@ -85,7 +85,7 @@ def lookup(key: str, val: Any, doc: Any) -> bool:
 
     The above will return True if doc.text == 'hello' else False. And
 
-        >>> lookup('text_exact', '{tags__name}', doc)
+        >>> lookup('text.exact', '{tags__name}', doc)
 
     will return True if doc.text == doc.tags.name else False
 

--- a/docarray/utils/query_language/query_parser.py
+++ b/docarray/utils/query_language/query_parser.py
@@ -1,12 +1,11 @@
-from typing import Dict, Any, Optional, Union, List
+from typing import Any, Dict, List, Optional, Union
 
 from docarray.utils.query_language.lookup import (
-    Q,
-    LookupNode,
     LookupLeaf,
+    LookupNode,
     LookupTreeElem,
+    Q,
 )
-
 
 LOGICAL_OPERATORS: Dict[str, Union[str, bool]] = {
     '$and': 'and',
@@ -80,7 +79,7 @@ def _parse_lookups(
                             node = LookupNode(op=LOGICAL_OPERATORS[op])
                         node = _parse_lookups(val, root_node=node)
                     elif op in SUPPORTED_OPERATORS:
-                        node = Q(**{f'{key}__{SUPPORTED_OPERATORS[op]}': val})
+                        node = Q(**{f'{key}.{SUPPORTED_OPERATORS[op]}': val})
                     else:
                         raise ValueError(
                             f'The operator {op} is not supported yet, '

--- a/tests/units/array/test_traverse.py
+++ b/tests/units/array/test_traverse.py
@@ -63,7 +63,7 @@ def multi_model_docs():
         ('mm_da', num_docs * num_sub_docs),  # List of 5 * 2 SubDoc objs
         ('mm_da__sub_text', num_docs * num_sub_docs),  # List of 5 * 2 Text objs
         (
-            'mm_da.__sub_da',
+            'mm_da__sub_da',
             num_docs * num_sub_docs * num_sub_sub_docs,
         ),  # List of 5 * 2 * 3 SubSubDoc objs
         (

--- a/tests/units/array/test_traverse.py
+++ b/tests/units/array/test_traverse.py
@@ -59,15 +59,15 @@ def multi_model_docs():
     'access_path,len_result',
     [
         ('mm_text', num_docs),  # List of 5 Text objs
-        ('mm_text.text', num_docs),  # List of 5 strings
+        ('mm_text__text', num_docs),  # List of 5 strings
         ('mm_da', num_docs * num_sub_docs),  # List of 5 * 2 SubDoc objs
-        ('mm_da.sub_text', num_docs * num_sub_docs),  # List of 5 * 2 Text objs
+        ('mm_da__sub_text', num_docs * num_sub_docs),  # List of 5 * 2 Text objs
         (
-            'mm_da.sub_da',
+            'mm_da.__sub_da',
             num_docs * num_sub_docs * num_sub_sub_docs,
         ),  # List of 5 * 2 * 3 SubSubDoc objs
         (
-            'mm_da.sub_da.sub_sub_text',
+            'mm_da__sub_da__sub_sub_text',
             num_docs * num_sub_docs * num_sub_sub_docs,
         ),  # List of 5 * 2 * 3 Text objs
     ],

--- a/tests/units/util/query_language/test_lookup.py
+++ b/tests/units/util/query_language/test_lookup.py
@@ -1,5 +1,6 @@
 import pytest
-from docarray.utils.query_language.lookup import point_get, lookup
+
+from docarray.utils.query_language.lookup import dunder_get, lookup
 
 
 class A:
@@ -13,40 +14,40 @@ class A:
 
 
 @pytest.mark.parametrize('input', [A(), {'b': {'c': 0, 'd': 'docarray'}}])
-def test_point_get(input):
-    assert point_get(input, 'b.c') == 0
+def test_dunder_get(input):
+    assert dunder_get(input, 'b__c') == 0
 
     expected_exception = KeyError if isinstance(input, dict) else AttributeError
     with pytest.raises(expected_exception):
-        _ = point_get(input, 'z')
+        _ = dunder_get(input, 'z')
 
     with pytest.raises(expected_exception):
-        _ = point_get(input, 'b.z')
+        _ = dunder_get(input, 'b__z')
 
 
 @pytest.mark.parametrize(
     'input', [A(), {'b': {'c': 0, 'd': 'docarray', 'e': [0, 1], 'f': {}}}]
 )
 def test_lookup(input):
-    assert lookup('b.c__exact', 0, input)
-    assert not lookup('b.c__gt', 0, input)
-    assert lookup('b.c__gte', 0, input)
-    assert not lookup('b.c__lt', 0, input)
-    assert lookup('b.c__lte', 0, input)
-    assert lookup('b.d__regex', 'array*', input)
-    assert lookup('b.d__contains', 'array', input)
-    assert lookup('b.d__icontains', 'Array', input)
-    assert lookup('b.d__in', ['a', 'docarray'], input)
-    assert lookup('b.d__nin', ['a', 'b'], input)
-    assert lookup('b.d__startswith', 'doc', input)
-    assert lookup('b.d__istartswith', 'Doc', input)
-    assert lookup('b.d__endswith', 'array', input)
-    assert lookup('b.d__iendswith', 'Array', input)
-    assert lookup('b.e__size', 2, input)
-    assert not lookup('b.e__size', 3, input)
-    assert lookup('b.d__size', len('docarray'), input)
-    assert not lookup('b.e__size', len('docarray') + 1, input)
-    assert not lookup('b.z__exists', True, input)
-    assert lookup('b.z__exists', False, input)
-    assert not lookup('b.f.z__exists', True, input)
-    assert lookup('b.f.z__exists', False, input)
+    assert lookup('b__c.exact', 0, input)
+    assert not lookup('b__c.gt', 0, input)
+    assert lookup('b__c.gte', 0, input)
+    assert not lookup('b__c.lt', 0, input)
+    assert lookup('b__c.lte', 0, input)
+    assert lookup('b__d.regex', 'array*', input)
+    assert lookup('b__d.contains', 'array', input)
+    assert lookup('b__d.icontains', 'Array', input)
+    assert lookup('b__d.in', ['a', 'docarray'], input)
+    assert lookup('b__d.nin', ['a', 'b'], input)
+    assert lookup('b__d.startswith', 'doc', input)
+    assert lookup('b__d.istartswith', 'Doc', input)
+    assert lookup('b__d.endswith', 'array', input)
+    assert lookup('b__d.iendswith', 'Array', input)
+    assert lookup('b__e.size', 2, input)
+    assert not lookup('b__e.size', 3, input)
+    assert lookup('b__d.size', len('docarray'), input)
+    assert not lookup('b__e.size', len('docarray') + 1, input)
+    assert not lookup('b__z.exists', True, input)
+    assert lookup('b__z.exists', False, input)
+    assert not lookup('b__f__z.exists', True, input)
+    assert lookup('b__f__z.exists', False, input)

--- a/tests/units/util/test_filter.py
+++ b/tests/units/util/test_filter.py
@@ -128,29 +128,30 @@ def test_simple_filter(docs, dict_api):
 
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_nested_filter(docs, dict_api):
+
     if dict_api:
         method = lambda query: filter(docs, query)  # noqa: E731
     else:
         method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
 
-    result = method({'dictionary.a': {'$eq': 0}})
+    result = method({'dictionary__a': {'$eq': 0}})
     assert len(result) == 2
     for res in result:
         assert res.dictionary['a'] == 0
 
-    result = method({'dictionary.c': {'$exists': True}})
+    result = method({'dictionary__c': {'$exists': True}})
     assert len(result) == 1
     assert result[0].dictionary['c'] == 2
 
-    result = method({'dictionary.d.e': {'$exists': True}})
+    result = method({'dictionary__d__e': {'$exists': True}})
     assert len(result) == 1
     assert result[0].dictionary['d'] == {'e': 3}
 
-    result = method({'dictionary.d.e': {'$eq': 3}})
+    result = method({'dictionary__d__e': {'$eq': 3}})
     assert len(result) == 1
     assert result[0].dictionary['d'] == {'e': 3}
 
-    result = method({'image.url': {'$eq': 'exampleimage.jpg'}})
+    result = method({'image__url': {'$eq': 'exampleimage.jpg'}})
     assert len(result) == 1
     assert result[0].image.url == 'exampleimage.jpg'
 
@@ -270,7 +271,7 @@ def test_from_docstring(dict_api):
 
     query = {
         '$and': {
-            'image.url': {'$regex': 'photo'},
+            'image__url': {'$regex': 'photo'},
             'price': {'$lte': 50},
         }
     }


### PR DESCRIPTION
Goals:

Change all seperators in access paths from `.` to `__`
This affects:
- `.traverse()`
- `filter`, `lookup`, `queryparser`: Here, previously `.` was used as acceas path separator and the `__` was used to separate path an operator:  `{access.path}__{operator}`. 
This I wanted to change to: `{access__path}.{operator}`

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
