### PR TITLE
feat(v2): add trimesh load args for `Url3D.load()`

### DIFF
--- a/docarray/typing/url/url_3d/mesh_url.py
+++ b/docarray/typing/url/url_3d/mesh_url.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, TypeVar
 
 import numpy as np
 from pydantic import parse_obj_as
@@ -20,7 +20,7 @@ class Mesh3DUrl(Url3D):
     Can be remote (web) URL, or a local file path.
     """
 
-    def load(self: T) -> 'VerticesAndFaces':
+    def load(self: T, trimesh_args: Dict[str, Any] = None) -> 'VerticesAndFaces':
         """
         Load the data from the url into a VerticesAndFaces object containing
         vertices and faces information.
@@ -45,25 +45,29 @@ class Mesh3DUrl(Url3D):
             assert isinstance(tensors.vertices, NdArray)
             assert isinstance(tensors.faces, NdArray)
 
-
+        :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
+            or `trimesh.load_remote()`.
         :return: VerticesAndFaces object containing vertices and faces information.
         """
         from docarray.documents.mesh.vertices_and_faces import VerticesAndFaces
 
-        mesh = self._load_trimesh_instance(force='mesh')
+        mesh = self._load_trimesh_instance(force='mesh', **trimesh_args)
 
         vertices = parse_obj_as(NdArray, mesh.vertices.view(np.ndarray))
         faces = parse_obj_as(NdArray, mesh.faces.view(np.ndarray))
 
         return VerticesAndFaces(vertices=vertices, faces=faces)
 
-    def display(self) -> None:
+    def display(self, trimesh_args: Dict[str, Any] = None) -> None:
         """
         Plot mesh from url.
         This loads the Trimesh instance of the 3D mesh, and then displays it.
         To use this you need to install trimesh[easy]: `pip install 'trimesh[easy]'`.
+
+        :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
+            or `trimesh.load_remote()`.
         """
         from IPython.display import display
 
-        mesh = self._load_trimesh_instance()
+        mesh = self._load_trimesh_instance(**trimesh_args)
         display(mesh.show())

--- a/docarray/typing/url/url_3d/mesh_url.py
+++ b/docarray/typing/url/url_3d/mesh_url.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
 import numpy as np
 from pydantic import parse_obj_as
@@ -20,7 +20,9 @@ class Mesh3DUrl(Url3D):
     Can be remote (web) URL, or a local file path.
     """
 
-    def load(self: T, trimesh_args: Dict[str, Any] = None) -> 'VerticesAndFaces':
+    def load(
+        self: T, trimesh_args: Optional[Dict[str, Any]] = None
+    ) -> 'VerticesAndFaces':
         """
         Load the data from the url into a VerticesAndFaces object containing
         vertices and faces information.
@@ -51,6 +53,8 @@ class Mesh3DUrl(Url3D):
         """
         from docarray.documents.mesh.vertices_and_faces import VerticesAndFaces
 
+        if not trimesh_args:
+            trimesh_args = {}
         mesh = self._load_trimesh_instance(force='mesh', **trimesh_args)
 
         vertices = parse_obj_as(NdArray, mesh.vertices.view(np.ndarray))
@@ -58,7 +62,7 @@ class Mesh3DUrl(Url3D):
 
         return VerticesAndFaces(vertices=vertices, faces=faces)
 
-    def display(self, trimesh_args: Dict[str, Any] = None) -> None:
+    def display(self, trimesh_args: Optional[Dict[str, Any]] = None) -> None:
         """
         Plot mesh from url.
         This loads the Trimesh instance of the 3D mesh, and then displays it.
@@ -69,5 +73,7 @@ class Mesh3DUrl(Url3D):
         """
         from IPython.display import display
 
+        if not trimesh_args:
+            trimesh_args = {}
         mesh = self._load_trimesh_instance(**trimesh_args)
         display(mesh.show())

--- a/docarray/typing/url/url_3d/mesh_url.py
+++ b/docarray/typing/url/url_3d/mesh_url.py
@@ -21,7 +21,9 @@ class Mesh3DUrl(Url3D):
     """
 
     def load(
-        self: T, trimesh_args: Optional[Dict[str, Any]] = None
+        self: T,
+        skip_materials: bool = True,
+        trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> 'VerticesAndFaces':
         """
         Load the data from the url into a VerticesAndFaces object containing
@@ -47,6 +49,7 @@ class Mesh3DUrl(Url3D):
             assert isinstance(tensors.vertices, NdArray)
             assert isinstance(tensors.faces, NdArray)
 
+        :param skip_materials: Skip materials if True, else skip.
         :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
             or `trimesh.load_remote()`.
         :return: VerticesAndFaces object containing vertices and faces information.
@@ -55,25 +58,22 @@ class Mesh3DUrl(Url3D):
 
         if not trimesh_args:
             trimesh_args = {}
-        mesh = self._load_trimesh_instance(force='mesh', **trimesh_args)
+        mesh = self._load_trimesh_instance(
+            force='mesh', skip_materials=skip_materials, **trimesh_args
+        )
 
         vertices = parse_obj_as(NdArray, mesh.vertices.view(np.ndarray))
         faces = parse_obj_as(NdArray, mesh.faces.view(np.ndarray))
 
         return VerticesAndFaces(vertices=vertices, faces=faces)
 
-    def display(self, trimesh_args: Optional[Dict[str, Any]] = None) -> None:
+    def display(self) -> None:
         """
         Plot mesh from url.
         This loads the Trimesh instance of the 3D mesh, and then displays it.
         To use this you need to install trimesh[easy]: `pip install 'trimesh[easy]'`.
-
-        :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
-            or `trimesh.load_remote()`.
         """
         from IPython.display import display
 
-        if not trimesh_args:
-            trimesh_args = {}
-        mesh = self._load_trimesh_instance(**trimesh_args)
+        mesh = self._load_trimesh_instance(skip_materials=False)
         display(mesh.show())

--- a/docarray/typing/url/url_3d/point_cloud_url.py
+++ b/docarray/typing/url/url_3d/point_cloud_url.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
 import numpy as np
 from pydantic import parse_obj_as
@@ -25,7 +25,7 @@ class PointCloud3DUrl(Url3D):
         self: T,
         samples: int,
         multiple_geometries: bool = False,
-        trimesh_args: Dict[str, Any] = None,
+        trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> 'PointsAndColors':
         """
         Load the data from the url into an NdArray containing point cloud information.
@@ -61,6 +61,9 @@ class PointCloud3DUrl(Url3D):
         """
         from docarray.documents.point_cloud.points_and_colors import PointsAndColors
 
+        if not trimesh_args:
+            trimesh_args = {}
+
         if multiple_geometries:
             # try to coerce everything into a scene
             scene = self._load_trimesh_instance(force='scene', **trimesh_args)
@@ -79,7 +82,7 @@ class PointCloud3DUrl(Url3D):
     def display(
         self,
         samples: int = 10000,
-        trimesh_args: Dict[str, Any] = None,
+        trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Plot point cloud from url.
@@ -107,4 +110,6 @@ class PointCloud3DUrl(Url3D):
         :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
             or `trimesh.load_remote()`.
         """
+        if not trimesh_args:
+            trimesh_args = {}
         self.load(samples=samples, **trimesh_args).display()

--- a/docarray/typing/url/url_3d/point_cloud_url.py
+++ b/docarray/typing/url/url_3d/point_cloud_url.py
@@ -25,6 +25,7 @@ class PointCloud3DUrl(Url3D):
         self: T,
         samples: int,
         multiple_geometries: bool = False,
+        skip_materials: bool = True,
         trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> 'PointsAndColors':
         """
@@ -54,6 +55,7 @@ class PointCloud3DUrl(Url3D):
         :param samples: number of points to sample from the mesh
         :param multiple_geometries: if False, store point cloud in 2D np.ndarray.
             If True, store point clouds from multiple geometries in 3D np.ndarray.
+        :param skip_materials: Skip materials if True, else load.
         :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
             or `trimesh.load_remote()`.
 
@@ -66,7 +68,9 @@ class PointCloud3DUrl(Url3D):
 
         if multiple_geometries:
             # try to coerce everything into a scene
-            scene = self._load_trimesh_instance(force='scene', **trimesh_args)
+            scene = self._load_trimesh_instance(
+                force='scene', skip_materials=skip_materials, **trimesh_args
+            )
             point_cloud = np.stack(
                 [np.array(geo.sample(samples)) for geo in scene.geometry.values()],
                 axis=0,
@@ -82,7 +86,6 @@ class PointCloud3DUrl(Url3D):
     def display(
         self,
         samples: int = 10000,
-        trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Plot point cloud from url.
@@ -107,9 +110,5 @@ class PointCloud3DUrl(Url3D):
             pc.url.load(samples=10000).display()
 
         :param samples: number of points to sample from the mesh.
-        :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
-            or `trimesh.load_remote()`.
         """
-        if not trimesh_args:
-            trimesh_args = {}
-        self.load(samples=samples, **trimesh_args).display()
+        self.load(samples=samples, skip_materials=False).display()

--- a/docarray/typing/url/url_3d/url_3d.py
+++ b/docarray/typing/url/url_3d/url_3d.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
 
 import numpy as np
 
@@ -40,14 +40,17 @@ class Url3D(AnyUrl, ABC):
         return cls(str(url), scheme=None)
 
     def _load_trimesh_instance(
-        self: T, force: Optional[str] = None
+        self: T,
+        force: Optional[str] = None,
+        trimesh_args: Dict[str, Any] = None,
     ) -> Union['trimesh.Trimesh', 'trimesh.Scene']:
         """
         Load the data from the url into a trimesh.Mesh or trimesh.Scene object.
 
-        :param url: url to load data from
         :param force: str or None. For 'mesh' try to coerce scenes into a single mesh.
             For 'scene' try to coerce everything into a scene.
+        :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
+            or `trimesh.load_remote()`.
         :return: trimesh.Mesh or trimesh.Scene object
         """
         import urllib.parse
@@ -57,6 +60,6 @@ class Url3D(AnyUrl, ABC):
         scheme = urllib.parse.urlparse(self).scheme
         loader = trimesh.load_remote if scheme in ['http', 'https'] else trimesh.load
 
-        mesh = loader(self, force=force)
+        mesh = loader(self, force=force, **trimesh_args)
 
         return mesh

--- a/docarray/typing/url/url_3d/url_3d.py
+++ b/docarray/typing/url/url_3d/url_3d.py
@@ -42,7 +42,7 @@ class Url3D(AnyUrl, ABC):
     def _load_trimesh_instance(
         self: T,
         force: Optional[str] = None,
-        trimesh_args: Dict[str, Any] = None,
+        trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> Union['trimesh.Trimesh', 'trimesh.Scene']:
         """
         Load the data from the url into a trimesh.Mesh or trimesh.Scene object.
@@ -56,6 +56,9 @@ class Url3D(AnyUrl, ABC):
         import urllib.parse
 
         import trimesh
+
+        if not trimesh_args:
+            trimesh_args = {}
 
         scheme = urllib.parse.urlparse(self).scheme
         loader = trimesh.load_remote if scheme in ['http', 'https'] else trimesh.load

--- a/docarray/typing/url/url_3d/url_3d.py
+++ b/docarray/typing/url/url_3d/url_3d.py
@@ -42,6 +42,7 @@ class Url3D(AnyUrl, ABC):
     def _load_trimesh_instance(
         self: T,
         force: Optional[str] = None,
+        skip_materials: bool = True,
         trimesh_args: Optional[Dict[str, Any]] = None,
     ) -> Union['trimesh.Trimesh', 'trimesh.Scene']:
         """
@@ -49,6 +50,7 @@ class Url3D(AnyUrl, ABC):
 
         :param force: str or None. For 'mesh' try to coerce scenes into a single mesh.
             For 'scene' try to coerce everything into a scene.
+        :param skip_materials: Skip materials if True, else skip.
         :param trimesh_args: dictionary of additional arguments for `trimesh.load()`
             or `trimesh.load_remote()`.
         :return: trimesh.Mesh or trimesh.Scene object
@@ -63,6 +65,6 @@ class Url3D(AnyUrl, ABC):
         scheme = urllib.parse.urlparse(self).scheme
         loader = trimesh.load_remote if scheme in ['http', 'https'] else trimesh.load
 
-        mesh = loader(self, force=force, **trimesh_args)
+        mesh = loader(self, force=force, skip_materials=skip_materials, **trimesh_args)
 
         return mesh


### PR DESCRIPTION
Goals:

Add argument that are allowed by trimesh to Url3D.load(), such as skip_materials=True to skip the materials and textures during loading, to safe time.
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
