### PR TITLE
Fix: replaced ndarray with str

### DIFF
--- a/docarray/typing/url/audio_url.py
+++ b/docarray/typing/url/audio_url.py
@@ -26,7 +26,7 @@ class AudioUrl(AnyUrl):
     @classmethod
     def validate(
         cls: Type[T],
-        value: Union[T, np.ndarray, Any],
+        value: Union[T, str, Any],
         field: 'ModelField',
         config: 'BaseConfig',
     ) -> T:

--- a/docarray/typing/url/image_url.py
+++ b/docarray/typing/url/image_url.py
@@ -26,7 +26,7 @@ class ImageUrl(AnyUrl):
     @classmethod
     def validate(
         cls: Type[T],
-        value: Union[T, np.ndarray, Any],
+        value: Union[T, str, Any],
         field: 'ModelField',
         config: 'BaseConfig',
     ) -> T:

--- a/docarray/typing/url/url_3d/url_3d.py
+++ b/docarray/typing/url/url_3d/url_3d.py
@@ -1,8 +1,6 @@
 from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
 
-import numpy as np
-
 from docarray.typing.proto_register import _register_proto
 from docarray.typing.url.any_url import AnyUrl
 
@@ -26,7 +24,7 @@ class Url3D(AnyUrl, ABC):
     @classmethod
     def validate(
         cls: Type[T],
-        value: Union[T, np.ndarray, Any],
+        value: Union[T, str, Any],
         field: 'ModelField',
         config: 'BaseConfig',
     ) -> T:

--- a/docarray/typing/url/video_url.py
+++ b/docarray/typing/url/video_url.py
@@ -1,8 +1,6 @@
 import warnings
 from typing import TYPE_CHECKING, Any, Type, TypeVar, Union
 
-import numpy as np
-
 from docarray.typing.bytes.video_bytes import VideoLoadResult
 from docarray.typing.proto_register import _register_proto
 from docarray.typing.url.any_url import AnyUrl
@@ -27,7 +25,7 @@ class VideoUrl(AnyUrl):
     @classmethod
     def validate(
         cls: Type[T],
-        value: Union[T, np.ndarray, Any],
+        value: Union[T, str, Any],
         field: 'ModelField',
         config: 'BaseConfig',
     ) -> T:


### PR DESCRIPTION
Should fix #1195 

Changed `np.ndarray` to `str` in validation methods of URL types