### PR TITLE
feat: helper method to transpose data

### DIFF
--- a/docarray/doc_index/abstract_doc_index.py
+++ b/docarray/doc_index/abstract_doc_index.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     Generator,
     Generic,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -545,11 +546,25 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
                 leaf_vals.append(getattr(doc, col_name))
         return leaf_vals
 
+    @staticmethod
+    def _transpose_col_value_dict(
+        col_value_dict: Dict[str, Iterable[Any]]
+    ) -> Generator[Dict[str, Any], None, None]:
+        """'Transpose' the output of `_get_col_value_dict()`: Yield rows of columns, where each row represent one Document.
+        Since a generator is returned, this process comes at negligible cost.
+
+        :param docs: The DocumentArray to get the values from
+        :return: The `docs` flattened out as rows. Each row is a dictionary mapping from column name to value
+        """
+        return (dict(zip(col_value_dict, row)) for row in zip(*col_value_dict.values()))
+
     def _get_col_value_dict(
         self, docs: Union[BaseDocument, Sequence[BaseDocument]]
     ) -> Dict[str, Generator[Any, None, None]]:
         """
         Get all data from a (sequence of) document(s), flattened out by column.
+        This can be seen as the transposed representation of `_get_rows()`.
+
         :param docs: The document(s) to get the data from
         :return: A dictionary mapping column names to a generator of values
         """

--- a/docs/tutorials/add_doc_index.md
+++ b/docs/tutorials/add_doc_index.md
@@ -305,8 +305,8 @@ To handle nested Documents, the public `index()` method already flattens every i
 This means that `_index()` already receives a flattened representation of the data, and you don't need to worry about that.
 
 Concretely, the `_index()` method takes as input a dictionary of column names to column data, flattened out.
-
-**Note:** It has been brought to my attention that passing a row-wise representation instead of a column-wise representation might be more natural for some (most) backends. This will be addressed shortly.
+**Note:** If you (or your backend) prefer to do bulk indexing on row-wise data, then you can use the `self._transpose_col_value_dict()`
+helper method. Inside of `_index()` you can use this to transform `column_to_data` into a row-wise view of the data.
 
 **If your backend has native nesting capabilities:** You can also ignore most of the above, and implement the public `index()` method directly.
 That way you have full control over whether the input data gets flattened or not.


### PR DESCRIPTION
Goals:

Give an additional helper method to the Document Index implementer.

Before this PR, we would help the `_index()` implementation by flattening and parsing incoming docs into all columns.

But some backends (e.g. ES) do their bulk indexing by row, not by column.
So this helper creates a generator that "transposes" the data from a column-wise view to a row-wise view
