### PR TITLE
refactor: rename predefined documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ print(doc.embedding.shape)
 ### Use pre-defined `Document`s for common use cases:
 
 ```python
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 
-doc = Image(
+doc = ImageDoc(
     url="https://upload.wikimedia.org/wikipedia/commons/2/2f/Alpamayo.jpg",
 )
 doc.tensor = doc.url.load()  # load image tensor from URL
@@ -62,17 +62,17 @@ doc.embedding = clip_image_encoder(
 
 ```python
 from docarray import BaseDocument
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 import numpy as np
 
 
 class MultiModalDocument(BaseDocument):
-    image_doc: Image
+    image_doc: ImageDoc
     text_doc: Text
 
 
 doc = MultiModalDocument(
-    image_doc=Image(tensor=np.zeros((3, 224, 224))), text_doc=Text(text='hi!')
+    image_doc=ImageDoc(tensor=np.zeros((3, 224, 224))), text_doc=Text(text='hi!')
 )
 ```
 
@@ -127,11 +127,11 @@ print(da.tensor.shape)
 - Integrate seamlessly with **FastAPI** and **Jina**
 
 ```python
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from httpx import AsyncClient
 import numpy as np
 
-doc = Image(tensor=np.zeros((3, 224, 224)))
+doc = ImageDoc(tensor=np.zeros((3, 224, 224)))
 
 # JSON over HTTP
 async with AsyncClient(app=app, base_url="http://test") as ac:
@@ -151,17 +151,17 @@ Image.from_protobuf(doc.to_protobuf())
 ```python
 # NOTE: DocumentStores are not yet implemented in version 2
 from docarray import DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.stores import DocumentStore
 import numpy as np
 
-da = DocumentArray([Image(embedding=np.zeros((128,))) for _ in range(1000)])
-store = DocumentStore[Image](
+da = DocumentArray([ImageDoc(embedding=np.zeros((128,))) for _ in range(1000)])
+store = DocumentStore[ImageDoc](
     storage='qdrant'
 )  # create a DocumentStore with Qdrant as backend
 store.insert(da)  # insert the DocumentArray into the DocumentStore
 # find the 10 most similar images based on the 'embedding' field
-match = store.find(Image(embedding=np.zeros((128,))), field='embedding', top_k=10)
+match = store.find(ImageDoc(embedding=np.zeros((128,))), field='embedding', top_k=10)
 ```
 
 If you want to get a deeper understanding of DocArray v2, it is best to do so on the basis of your
@@ -234,7 +234,7 @@ So now let's see what the same code looks like with DocArray:
 
 ```python
 from docarray import DocumentArray, BaseDocument
-from docarray.documents import Image, Text, Audio
+from docarray.documents import ImageDoc, Text, Audio
 from docarray.typing import TorchTensor
 
 import torch
@@ -242,7 +242,7 @@ import torch
 
 class Podcast(BaseDocument):
     text: Text
-    image: Image
+    image: ImageDoc
     audio: Audio
 
 
@@ -331,13 +331,13 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 
 from docarray import BaseDocument
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
 from docarray.base_document import DocumentResponse
 
 
 class InputDoc(BaseDocument):
-    img: Image
+    img: ImageDoc
 
 
 class OutputDoc(BaseDocument):
@@ -345,7 +345,7 @@ class OutputDoc(BaseDocument):
     embedding_bert: NdArray
 
 
-input_doc = InputDoc(img=Image(tensor=np.zeros((3, 224, 224))))
+input_doc = InputDoc(img=ImageDoc(tensor=np.zeros((3, 224, 224))))
 
 app = FastAPI()
 
@@ -410,19 +410,19 @@ store it there, and thus make it searchable:
 # NOTE: DocumentStores are not yet implemented in version 2
 from docarray import DocumentArray, BaseDocument
 from docarray.stores import DocumentStore
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 import numpy as np
 
 
 class MyDoc(BaseDocument):
-    image: Image
+    image: ImageDoc
     text: Text
     description: str
 
 
 def _random_my_doc():
     return MyDoc(
-        image=Image(embedding=np.random.random((256,))),
+        image=ImageDoc(embedding=np.random.random((256,))),
         text=Text(embedding=np.random.random((128,))),
         description='this is a random document',
     )
@@ -436,10 +436,12 @@ store.insert(da)  # insert the DocumentArray into the DocumentStore
 
 # find the 10 most similar images based on the image embedding field
 match = store.find(
-    Image(embedding=np.zeros((256,))), field='image__embedding', top_k=10
+    ImageDoc(embedding=np.zeros((256,))), field='image__embedding', top_k=10
 )
 # find the 10 most similar images based on the image embedding field
-match = store.find(Image(embedding=np.zeros((128,))), field='text__embedding', top_k=10)
+match = store.find(
+    ImageDoc(embedding=np.zeros((128,))), field='text__embedding', top_k=10
+)
 ```
 
 ## Install the alpha

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ So now let's see what the same code looks like with DocArray:
 
 ```python
 from docarray import DocumentArray, BaseDocument
-from docarray.documents import ImageDoc, TextDoc, Audio
+from docarray.documents import ImageDoc, TextDoc, AudioDoc
 from docarray.typing import TorchTensor
 
 import torch
@@ -243,7 +243,7 @@ import torch
 class Podcast(BaseDocument):
     text: TextDoc
     image: ImageDoc
-    audio: Audio
+    audio: AudioDoc
 
 
 class PairPodcast(BaseDocument):

--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ doc.embedding = clip_image_encoder(
 
 ```python
 from docarray import BaseDocument
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 import numpy as np
 
 
 class MultiModalDocument(BaseDocument):
     image_doc: ImageDoc
-    text_doc: Text
+    text_doc: TextDoc
 
 
 doc = MultiModalDocument(
-    image_doc=ImageDoc(tensor=np.zeros((3, 224, 224))), text_doc=Text(text='hi!')
+    image_doc=ImageDoc(tensor=np.zeros((3, 224, 224))), text_doc=TextDoc(text='hi!')
 )
 ```
 
@@ -234,14 +234,14 @@ So now let's see what the same code looks like with DocArray:
 
 ```python
 from docarray import DocumentArray, BaseDocument
-from docarray.documents import ImageDoc, Text, Audio
+from docarray.documents import ImageDoc, TextDoc, Audio
 from docarray.typing import TorchTensor
 
 import torch
 
 
 class Podcast(BaseDocument):
-    text: Text
+    text: TextDoc
     image: ImageDoc
     audio: Audio
 
@@ -410,20 +410,20 @@ store it there, and thus make it searchable:
 # NOTE: DocumentStores are not yet implemented in version 2
 from docarray import DocumentArray, BaseDocument
 from docarray.stores import DocumentStore
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 import numpy as np
 
 
 class MyDoc(BaseDocument):
     image: ImageDoc
-    text: Text
+    text: TextDoc
     description: str
 
 
 def _random_my_doc():
     return MyDoc(
         image=ImageDoc(embedding=np.random.random((256,))),
-        text=Text(embedding=np.random.random((128,))),
+        text=TextDoc(embedding=np.random.random((128,))),
         description='this is a random document',
     )
 

--- a/docarray/documents/__init__.py
+++ b/docarray/documents/__init__.py
@@ -2,7 +2,7 @@ from docarray.documents.audio import Audio
 from docarray.documents.image import ImageDoc
 from docarray.documents.mesh import Mesh3D
 from docarray.documents.point_cloud import PointCloud3D
-from docarray.documents.text import Text
+from docarray.documents.text import TextDoc
 from docarray.documents.video import Video
 
-__all__ = ['Text', 'ImageDoc', 'Audio', 'Mesh3D', 'PointCloud3D', 'Video']
+__all__ = ['TextDoc', 'ImageDoc', 'Audio', 'Mesh3D', 'PointCloud3D', 'Video']

--- a/docarray/documents/__init__.py
+++ b/docarray/documents/__init__.py
@@ -1,8 +1,8 @@
-from docarray.documents.audio import Audio
+from docarray.documents.audio import AudioDoc
 from docarray.documents.image import ImageDoc
 from docarray.documents.mesh import Mesh3D
 from docarray.documents.point_cloud import PointCloud3D
 from docarray.documents.text import TextDoc
 from docarray.documents.video import Video
 
-__all__ = ['TextDoc', 'ImageDoc', 'Audio', 'Mesh3D', 'PointCloud3D', 'Video']
+__all__ = ['TextDoc', 'ImageDoc', 'AudioDoc', 'Mesh3D', 'PointCloud3D', 'Video']

--- a/docarray/documents/__init__.py
+++ b/docarray/documents/__init__.py
@@ -1,8 +1,8 @@
 from docarray.documents.audio import Audio
-from docarray.documents.image import Image
+from docarray.documents.image import ImageDoc
 from docarray.documents.mesh import Mesh3D
 from docarray.documents.point_cloud import PointCloud3D
 from docarray.documents.text import Text
 from docarray.documents.video import Video
 
-__all__ = ['Text', 'Image', 'Audio', 'Mesh3D', 'PointCloud3D', 'Video']
+__all__ = ['Text', 'ImageDoc', 'Audio', 'Mesh3D', 'PointCloud3D', 'Video']

--- a/docarray/documents/__init__.py
+++ b/docarray/documents/__init__.py
@@ -3,6 +3,6 @@ from docarray.documents.image import ImageDoc
 from docarray.documents.mesh import Mesh3D
 from docarray.documents.point_cloud import PointCloud3D
 from docarray.documents.text import TextDoc
-from docarray.documents.video import Video
+from docarray.documents.video import VideoDoc
 
-__all__ = ['TextDoc', 'ImageDoc', 'AudioDoc', 'Mesh3D', 'PointCloud3D', 'Video']
+__all__ = ['TextDoc', 'ImageDoc', 'AudioDoc', 'Mesh3D', 'PointCloud3D', 'VideoDoc']

--- a/docarray/documents/audio.py
+++ b/docarray/documents/audio.py
@@ -18,15 +18,15 @@ if tf_available:
     import tensorflow as tf  # type: ignore
 
 
-T = TypeVar('T', bound='Audio')
+T = TypeVar('T', bound='AudioDoc')
 
 
-class Audio(BaseDocument):
+class AudioDoc(BaseDocument):
     """
     Document for handling audios.
 
-    The Audio Document can contain an AudioUrl (`Audio.url`), an AudioTensor
-    (`Audio.tensor`), and an AnyEmbedding (`Audio.embedding`).
+    The Audio Document can contain an AudioUrl (`AudioDoc.url`), an AudioTensor
+    (`AudioDoc.tensor`), and an AnyEmbedding (`AudioDoc.embedding`).
 
     EXAMPLE USAGE:
 
@@ -34,7 +34,7 @@ class Audio(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Audio
+        from docarray.documents import AudioDoc
 
         # use it directly
         audio = Audio(
@@ -48,7 +48,7 @@ class Audio(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Audio, Text
+        from docarray.documents import AudioDoc, TextDoc
         from typing import Optional
 
 
@@ -71,7 +71,7 @@ class Audio(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import Audio, Text
+        from docarray.documents import AudioDoc, TextDoc
 
 
         # compose it

--- a/docarray/documents/image.py
+++ b/docarray/documents/image.py
@@ -64,7 +64,7 @@ class ImageDoc(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import ImageDoc, Text
+        from docarray.documents import ImageDoc, TextDoc
 
         # compose it
         class MultiModalDoc(BaseDocument):

--- a/docarray/documents/image.py
+++ b/docarray/documents/image.py
@@ -8,7 +8,7 @@ from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.image.image_tensor import ImageTensor
 from docarray.utils.misc import is_tf_available, is_torch_available
 
-T = TypeVar('T', bound='Image')
+T = TypeVar('T', bound='ImageDoc')
 
 torch_available = is_torch_available()
 if torch_available:
@@ -19,7 +19,7 @@ if tf_available:
     import tensorflow as tf  # type: ignore
 
 
-class Image(BaseDocument):
+class ImageDoc(BaseDocument):
     """
     Document for handling images.
     It can contain an ImageUrl (`Image.url`), an AnyTensor (`Image.tensor`),
@@ -31,10 +31,10 @@ class Image(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Image
+        from docarray.documents import ImageDoc
 
         # use it directly
-        image = Image(url='http://www.jina.ai/image.jpg')
+        image = ImageDoc(url='http://www.jina.ai/image.jpg')
         image.tensor = image.url.load()
         model = MyEmbeddingModel()
         image.embedding = model(image.tensor)
@@ -43,12 +43,12 @@ class Image(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Image
+        from docarray.documents import ImageDoc
         from docarray.typing import AnyEmbedding
         from typing import Optional
 
         # extend it
-        class MyImage(Image):
+        class MyImage(ImageDoc):
             second_embedding: Optional[AnyEmbedding]
 
 
@@ -64,7 +64,7 @@ class Image(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import Image, Text
+        from docarray.documents import ImageDoc, Text
 
         # compose it
         class MultiModalDoc(BaseDocument):

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -60,7 +60,7 @@ class Text(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import Image, Text
+        from docarray.documents import ImageDoc, Text
 
         # compose it
         class MultiModalDoc(BaseDocument):

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -4,14 +4,14 @@ from docarray.base_document import BaseDocument
 from docarray.typing import TextUrl
 from docarray.typing.tensor.embedding import AnyEmbedding
 
-T = TypeVar('T', bound='Text')
+T = TypeVar('T', bound='TextDoc')
 
 
-class Text(BaseDocument):
+class TextDoc(BaseDocument):
     """
     Document for handling text.
-    It can contain a TextUrl (`Text.url`), a str (`Text.text`),
-    and an AnyEmbedding (`Text.embedding`).
+    It can contain a TextUrl (`TextDoc.url`), a str (`TextDoc.text`),
+    and an AnyEmbedding (`TextDoc.embedding`).
 
     EXAMPLE USAGE:
 
@@ -19,7 +19,7 @@ class Text(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Text
+        from docarray.documents import TextDoc
 
         # use it directly
         txt_doc = Text(url='http://www.jina.ai/')
@@ -31,7 +31,7 @@ class Text(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Text
+        from docarray.documents import TextDoc
 
         txt_doc = Text('hello world')
 
@@ -39,7 +39,7 @@ class Text(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Text
+        from docarray.documents import TextDoc
         from docarray.typing import AnyEmbedding
         from typing import Optional
 
@@ -60,7 +60,7 @@ class Text(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import ImageDoc, Text
+        from docarray.documents import ImageDoc, TextDoc
 
         # compose it
         class MultiModalDoc(BaseDocument):
@@ -87,7 +87,7 @@ class Text(BaseDocument):
 
     .. code-block:: python
 
-        from docarray.documents import Text
+        from docarray.documents import TextDoc
 
         doc = Text(text='This is the main text', url='exampleurl.com')
         doc2 = Text(text='This is the main text', url='exampleurl.com')

--- a/docarray/documents/video.py
+++ b/docarray/documents/video.py
@@ -20,16 +20,16 @@ if tf_available:
     import tensorflow as tf  # type: ignore
 
 
-T = TypeVar('T', bound='Video')
+T = TypeVar('T', bound='VideoDoc')
 
 
-class Video(BaseDocument):
+class VideoDoc(BaseDocument):
     """
     Document for handling video.
-    The Video Document can contain a VideoUrl (`Video.url`), an Audio Document
-    (`Video.audio`), a VideoTensor (`Video.tensor`), an AnyTensor representing
-    the indices of the video's key frames (`Video.key_frame_indices`) and an
-    AnyEmbedding (`Video.embedding`).
+    The Video Document can contain a VideoUrl (`VideoDoc.url`), an Audio Document
+    (`VideoDoc.audio`), a VideoTensor (`VideoDoc.tensor`), an AnyTensor representing
+    the indices of the video's key frames (`VideoDoc.key_frame_indices`) and an
+    AnyEmbedding (`VideoDoc.embedding`).
 
     EXAMPLE USAGE:
 
@@ -53,7 +53,7 @@ class Video(BaseDocument):
 
         from typing import Optional
 
-        from docarray.documents import Text, Video
+        from docarray.documents import TextDoc, VideoDoc
 
 
         # extend it
@@ -74,7 +74,7 @@ class Video(BaseDocument):
     .. code-block:: python
 
         from docarray import BaseDocument
-        from docarray.documents import Text, Video
+        from docarray.documents import TextDoc, VideoDoc
 
 
         # compose it

--- a/docarray/documents/video.py
+++ b/docarray/documents/video.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Type, TypeVar, Union
 import numpy as np
 
 from docarray.base_document import BaseDocument
-from docarray.documents import Audio
+from docarray.documents import AudioDoc
 from docarray.typing import AnyEmbedding, AnyTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.video.video_tensor import VideoTensor
@@ -98,7 +98,7 @@ class Video(BaseDocument):
     """
 
     url: Optional[VideoUrl]
-    audio: Optional[Audio] = Audio()
+    audio: Optional[AudioDoc] = AudioDoc()
     tensor: Optional[VideoTensor]
     key_frame_indices: Optional[AnyTensor]
     embedding: Optional[AnyEmbedding]

--- a/docs/tutorials/multimodal_training_and_serving.md
+++ b/docs/tutorials/multimodal_training_and_serving.md
@@ -109,7 +109,7 @@ hint and even enforce the desired shape of any tensor!
 To represent our image data, we use the `Image` Document that is included in DocArray:
 
 ```python
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 ```
 
 Under the hood, an `Image` looks something like this (with the only main difference that it can take tensors from any

--- a/docs/tutorials/multimodal_training_and_serving.md
+++ b/docs/tutorials/multimodal_training_and_serving.md
@@ -90,7 +90,7 @@ from docarray.typing import TorchTensor, ImageUrl
 Let's first create a Document for our Text modality. It will contain a number of `Tokens`, which we also define:
 
 ```python
-from docarray.documents import Text as BaseText
+from docarray.documents import TextDoc as BaseText
 
 
 class Tokens(BaseDocument):

--- a/tests/benchmark_tests/test_map.py
+++ b/tests/benchmark_tests/test_map.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
 from docarray.utils.map import map_docs, map_docs_batch
 from tests.units.typing.test_bytes import IMAGE_PATHS
@@ -82,7 +82,7 @@ def test_map_docs_batch_multiprocessing():
         assert time_2_cpu < time_1_cpu
 
 
-def io_intensive(img: Image) -> Image:
+def io_intensive(img: ImageDoc) -> ImageDoc:
     # some io intensive function: load and set image url
     img.tensor = img.url.load()
     return img
@@ -91,8 +91,8 @@ def io_intensive(img: Image) -> Image:
 def test_map_docs_multithreading():
     def time_multithreading(num_workers: int) -> float:
         n_docs = 100
-        da = DocumentArray[Image](
-            [Image(url=IMAGE_PATHS['png']) for _ in range(n_docs)]
+        da = DocumentArray[ImageDoc](
+            [ImageDoc(url=IMAGE_PATHS['png']) for _ in range(n_docs)]
         )
         start_time = time()
         list(
@@ -106,7 +106,7 @@ def test_map_docs_multithreading():
     assert time_2_thread < time_1_thread
 
 
-def io_intensive_batch(da: DocumentArray[Image]) -> DocumentArray[Image]:
+def io_intensive_batch(da: DocumentArray[ImageDoc]) -> DocumentArray[ImageDoc]:
     # some io intensive function: load and set image url
     for doc in da:
         doc.tensor = doc.url.load()
@@ -116,8 +116,8 @@ def io_intensive_batch(da: DocumentArray[Image]) -> DocumentArray[Image]:
 def test_map_docs_batch_multithreading():
     def time_multithreading_batch(num_workers: int) -> float:
         n_docs = 100
-        da = DocumentArray[Image](
-            [Image(url=IMAGE_PATHS['png']) for _ in range(n_docs)]
+        da = DocumentArray[ImageDoc](
+            [ImageDoc(url=IMAGE_PATHS['png']) for _ in range(n_docs)]
         )
         start_time = time()
         list(

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -6,21 +6,21 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 
 
 def test_multi_modal_doc():
     class MyMultiModalDoc(BaseDocument):
         image: ImageDoc
-        text: Text
+        text: TextDoc
 
     doc = MyMultiModalDoc(
-        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
+        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=TextDoc(text='hello')
     )
 
     assert isinstance(doc.image, BaseDocument)
     assert isinstance(doc.image, ImageDoc)
-    assert isinstance(doc.text, Text)
+    assert isinstance(doc.text, TextDoc)
 
     assert doc.text.text == 'hello'
     assert (doc.image.tensor == np.zeros((3, 224, 224))).all()

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -6,7 +6,9 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import ImageDoc, TextDoc
+from docarray.documents import AudioDoc, ImageDoc, TextDoc
+from docarray.documents.helper import create_doc, create_from_typeddict
+from docarray.typing import AudioNdArray
 
 
 def test_multi_modal_doc():
@@ -42,41 +44,44 @@ def test_nested_chunks_document():
 def test_create_doc():
     with pytest.raises(ValueError):
         _ = create_doc(
-            'MyMultiModalDoc', __base__=BaseModel, image=(Image, ...), text=(Text, ...)
+            'MyMultiModalDoc',
+            __base__=BaseModel,
+            image=(ImageDoc, ...),
+            text=(TextDoc, ...),
         )
 
     MyMultiModalDoc = create_doc(
-        'MyMultiModalDoc', image=(Image, ...), text=(Text, ...)
+        'MyMultiModalDoc', image=(ImageDoc, ...), text=(TextDoc, ...)
     )
 
     assert issubclass(MyMultiModalDoc, BaseDocument)
 
     doc = MyMultiModalDoc(
-        image=Image(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
+        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=TextDoc(text='hello')
     )
 
     assert isinstance(doc.image, BaseDocument)
-    assert isinstance(doc.image, Image)
-    assert isinstance(doc.text, Text)
+    assert isinstance(doc.image, ImageDoc)
+    assert isinstance(doc.text, TextDoc)
 
     assert doc.text.text == 'hello'
     assert (doc.image.tensor == np.zeros((3, 224, 224))).all()
 
     MyAudio = create_doc(
         'MyAudio',
-        __base__=Audio,
+        __base__=AudioDoc,
         title=(str, ...),
         tensor=(Optional[AudioNdArray], ...),
     )
 
     assert issubclass(MyAudio, BaseDocument)
-    assert issubclass(MyAudio, Audio)
+    assert issubclass(MyAudio, AudioDoc)
 
 
 def test_create_from_typeddict():
     class MyMultiModalDoc(TypedDict):
-        image: Image
-        text: Text
+        image: ImageDoc
+        text: TextDoc
 
     with pytest.raises(ValueError):
         _ = create_from_typeddict(MyMultiModalDoc, __base__=BaseModel)
@@ -89,7 +94,7 @@ def test_create_from_typeddict():
         title: str
         tensor: Optional[AudioNdArray]
 
-    Doc = create_from_typeddict(MyAudio, __base__=Audio)
+    Doc = create_from_typeddict(MyAudio, __base__=AudioDoc)
 
     assert issubclass(Doc, BaseDocument)
-    assert issubclass(Doc, Audio)
+    assert issubclass(Doc, AudioDoc)

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -6,22 +6,20 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Audio, Image, Text
-from docarray.documents.helper import create_doc, create_from_typeddict
-from docarray.typing.tensor.audio import AudioNdArray
+from docarray.documents import ImageDoc, Text
 
 
 def test_multi_modal_doc():
     class MyMultiModalDoc(BaseDocument):
-        image: Image
+        image: ImageDoc
         text: Text
 
     doc = MyMultiModalDoc(
-        image=Image(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
+        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
     )
 
     assert isinstance(doc.image, BaseDocument)
-    assert isinstance(doc.image, Image)
+    assert isinstance(doc.image, ImageDoc)
     assert isinstance(doc.text, Text)
 
     assert doc.text.text == 'hello'
@@ -31,11 +29,11 @@ def test_multi_modal_doc():
 def test_nested_chunks_document():
     class ChunksDocument(BaseDocument):
         text: str
-        images: DocumentArray[Image]
+        images: DocumentArray[ImageDoc]
 
     doc = ChunksDocument(
         text='hello',
-        images=DocumentArray[Image]([Image() for _ in range(10)]),
+        images=DocumentArray[ImageDoc]([ImageDoc() for _ in range(10)]),
     )
 
     assert isinstance(doc.images, DocumentArray)

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 from docarray.typing import (
     AnyEmbedding,
     AnyTensor,
@@ -32,10 +32,10 @@ if tf_available:
 def test_multi_modal_doc_proto():
     class MyMultiModalDoc(BaseDocument):
         image: ImageDoc
-        text: Text
+        text: TextDoc
 
     doc = MyMultiModalDoc(
-        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
+        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=TextDoc(text='hello')
     )
 
     MyMultiModalDoc.from_protobuf(doc.to_protobuf())

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 from docarray.typing import (
     AnyEmbedding,
     AnyTensor,
@@ -31,11 +31,11 @@ if tf_available:
 @pytest.mark.proto
 def test_multi_modal_doc_proto():
     class MyMultiModalDoc(BaseDocument):
-        image: Image
+        image: ImageDoc
         text: Text
 
     doc = MyMultiModalDoc(
-        image=Image(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
+        image=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(text='hello')
     )
 
     MyMultiModalDoc.from_protobuf(doc.to_protobuf())

--- a/tests/integrations/externals/test_fastapi.py
+++ b/tests/integrations/externals/test_fastapi.py
@@ -5,19 +5,19 @@ from httpx import AsyncClient
 
 from docarray import BaseDocument
 from docarray.base_document import DocumentResponse
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 from docarray.typing import NdArray
 
 
 @pytest.mark.asyncio
 async def test_fast_api():
     class Mmdoc(BaseDocument):
-        img: Image
+        img: ImageDoc
         text: Text
         title: str
 
     input_doc = Mmdoc(
-        img=Image(tensor=np.zeros((3, 224, 224))), text=Text(), title='hello'
+        img=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(), title='hello'
     )
 
     app = FastAPI()
@@ -39,13 +39,13 @@ async def test_fast_api():
 @pytest.mark.asyncio
 async def test_image():
     class InputDoc(BaseDocument):
-        img: Image
+        img: ImageDoc
 
     class OutputDoc(BaseDocument):
         embedding_clip: NdArray
         embedding_bert: NdArray
 
-    input_doc = InputDoc(img=Image(tensor=np.zeros((3, 224, 224))))
+    input_doc = InputDoc(img=ImageDoc(tensor=np.zeros((3, 224, 224))))
 
     app = FastAPI()
 

--- a/tests/integrations/externals/test_fastapi.py
+++ b/tests/integrations/externals/test_fastapi.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 
 from docarray import BaseDocument
 from docarray.base_document import DocumentResponse
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 from docarray.typing import NdArray
 
 
@@ -13,11 +13,11 @@ from docarray.typing import NdArray
 async def test_fast_api():
     class Mmdoc(BaseDocument):
         img: ImageDoc
-        text: Text
+        text: TextDoc
         title: str
 
     input_doc = Mmdoc(
-        img=ImageDoc(tensor=np.zeros((3, 224, 224))), text=Text(), title='hello'
+        img=ImageDoc(tensor=np.zeros((3, 224, 224))), text=TextDoc(), title='hello'
     )
 
     app = FastAPI()

--- a/tests/integrations/predefined_document/test_audio.py
+++ b/tests/integrations/predefined_document/test_audio.py
@@ -7,7 +7,7 @@ import torch
 from pydantic import parse_obj_as
 
 from docarray import BaseDocument
-from docarray.documents import Audio
+from docarray.documents import AudioDoc
 from docarray.typing import AudioUrl
 from docarray.typing.tensor.audio import AudioNdArray, AudioTorchTensor
 from docarray.utils.misc import is_tf_available
@@ -57,7 +57,7 @@ NON_AUDIO_FILES = [
 @pytest.mark.internet
 @pytest.mark.parametrize('file_url', LOCAL_AUDIO_FILES)
 def test_audio(file_url):
-    audio = Audio(url=file_url)
+    audio = AudioDoc(url=file_url)
     audio.tensor, _ = audio.url.load()
     assert isinstance(audio.tensor, np.ndarray)
 
@@ -67,7 +67,7 @@ def test_audio(file_url):
 @pytest.mark.parametrize('file_url', NON_AUDIO_FILES)
 def test_non_audio(file_url):
     with pytest.raises(Exception):
-        audio = Audio(url=file_url)
+        audio = AudioDoc(url=file_url)
         _, _ = audio.url.load()
 
 
@@ -78,7 +78,7 @@ def test_save_audio_ndarray(file_url, format, tmpdir):
     filename = os.path.basename(file_url)
     tmp_file = str(tmpdir / filename)
 
-    audio = Audio(url=file_url)
+    audio = AudioDoc(url=file_url)
     audio.tensor, audio.frame_rate = audio.url.load()
     assert isinstance(audio.tensor, np.ndarray)
     assert isinstance(audio.tensor, AudioNdArray)
@@ -86,7 +86,7 @@ def test_save_audio_ndarray(file_url, format, tmpdir):
     audio.tensor.save(tmp_file, format=format, frame_rate=audio.frame_rate)
     assert os.path.isfile(tmp_file)
 
-    audio_from_file = Audio(url=tmp_file)
+    audio_from_file = AudioDoc(url=tmp_file)
     audio_from_file.tensor, _ = audio_from_file.url.load()
     if format in ['wav', 'flac']:
         # lossless formats (wav, flac) can be loaded back exactly
@@ -105,7 +105,7 @@ def test_save_audio_ndarray(file_url, format, tmpdir):
 def test_save_audio_torch_tensor(file_url, format, tmpdir):
     tmp_file = str(tmpdir / 'tmp.wav')
 
-    audio = Audio(url=file_url)
+    audio = AudioDoc(url=file_url)
     tensor, frame_rate = audio.url.load()
 
     audio.tensor = parse_obj_as(AudioTorchTensor, torch.from_numpy(tensor))
@@ -116,7 +116,7 @@ def test_save_audio_torch_tensor(file_url, format, tmpdir):
 
     assert os.path.isfile(tmp_file)
 
-    audio_from_file = Audio(url=tmp_file)
+    audio_from_file = AudioDoc(url=tmp_file)
     tensor, _ = audio_from_file.url.load()
     audio_from_file.tensor = parse_obj_as(AudioTorchTensor, torch.from_numpy(tensor))
     if format in ['wav', 'flac']:
@@ -137,7 +137,7 @@ def test_save_audio_torch_tensor(file_url, format, tmpdir):
 def test_save_audio_tensorflow(file_url, format, tmpdir):
     tmp_file = str(tmpdir / 'tmp.wav')
 
-    audio = Audio(url=file_url)
+    audio = AudioDoc(url=file_url)
     tensor, frame_rate = audio.url.load()
     audio.tensor = AudioTensorFlowTensor(tensor=tf.constant(tensor))
     assert isinstance(audio.tensor, TensorFlowTensor)
@@ -147,7 +147,7 @@ def test_save_audio_tensorflow(file_url, format, tmpdir):
     audio.tensor.save(tmp_file, format=format, frame_rate=frame_rate)
     assert os.path.isfile(tmp_file)
 
-    audio_from_file = Audio(url=tmp_file)
+    audio_from_file = AudioDoc(url=tmp_file)
     tensor, _ = audio_from_file.url.load()
     audio_from_file.tensor = AudioTensorFlowTensor(tensor=tf.constant(tensor))
     if format in ['wav', 'flac']:
@@ -168,7 +168,7 @@ def test_save_audio_tensorflow(file_url, format, tmpdir):
     LOCAL_AUDIO_FILES,
 )
 def test_extend_audio(file_url):
-    class MyAudio(Audio):
+    class MyAudio(AudioDoc):
         title: str
         tensor: Optional[AudioNdArray]
 
@@ -181,31 +181,31 @@ def test_extend_audio(file_url):
 
 
 def test_audio_np():
-    audio = parse_obj_as(Audio, np.zeros((10, 10, 3)))
+    audio = parse_obj_as(AudioDoc, np.zeros((10, 10, 3)))
     assert (audio.tensor == np.zeros((10, 10, 3))).all()
 
 
 def test_audio_torch():
-    audio = parse_obj_as(Audio, torch.zeros(10, 10, 3))
+    audio = parse_obj_as(AudioDoc, torch.zeros(10, 10, 3))
     assert (audio.tensor == torch.zeros(10, 10, 3)).all()
 
 
 @pytest.mark.tensorflow
 def test_audio_tensorflow():
-    audio = parse_obj_as(Audio, tf.zeros((10, 10, 3)))
+    audio = parse_obj_as(AudioDoc, tf.zeros((10, 10, 3)))
     assert tnp.allclose(audio.tensor.tensor, tf.zeros((10, 10, 3)))
 
 
 def test_audio_bytes():
-    audio = parse_obj_as(Audio, torch.zeros(10, 10, 3))
+    audio = parse_obj_as(AudioDoc, torch.zeros(10, 10, 3))
     audio.bytes = audio.tensor.to_bytes()
 
 
 def test_audio_shortcut_doc():
     class MyDoc(BaseDocument):
-        audio: Audio
-        audio2: Audio
-        audio3: Audio
+        audio: AudioDoc
+        audio2: AudioDoc
+        audio3: AudioDoc
 
     doc = MyDoc(
         audio='http://myurl.wav',

--- a/tests/integrations/predefined_document/test_image.py
+++ b/tests/integrations/predefined_document/test_image.py
@@ -4,7 +4,7 @@ import torch
 from pydantic import parse_obj_as
 
 from docarray import BaseDocument
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.utils.misc import is_tf_available
 
 tf_available = is_tf_available()
@@ -21,7 +21,7 @@ REMOTE_JPG = (
 @pytest.mark.slow
 @pytest.mark.internet
 def test_image():
-    image = Image(url=REMOTE_JPG)
+    image = ImageDoc(url=REMOTE_JPG)
 
     image.tensor = image.url.load()
 
@@ -29,31 +29,31 @@ def test_image():
 
 
 def test_image_str():
-    image = parse_obj_as(Image, 'http://myurl.jpg')
+    image = parse_obj_as(ImageDoc, 'http://myurl.jpg')
     assert image.url == 'http://myurl.jpg'
 
 
 def test_image_np():
-    image = parse_obj_as(Image, np.zeros((10, 10, 3)))
+    image = parse_obj_as(ImageDoc, np.zeros((10, 10, 3)))
     assert (image.tensor == np.zeros((10, 10, 3))).all()
 
 
 def test_image_torch():
-    image = parse_obj_as(Image, torch.zeros(10, 10, 3))
+    image = parse_obj_as(ImageDoc, torch.zeros(10, 10, 3))
     assert (image.tensor == torch.zeros(10, 10, 3)).all()
 
 
 @pytest.mark.tensorflow
 def test_image_tensorflow():
-    image = Image(tensor=tf.zeros((10, 10, 3)))
+    image = ImageDoc(tensor=tf.zeros((10, 10, 3)))
     assert tnp.allclose(image.tensor.tensor, tf.zeros((10, 10, 3)))
 
 
 def test_image_shortcut_doc():
     class MyDoc(BaseDocument):
-        image: Image
-        image2: Image
-        image3: Image
+        image: ImageDoc
+        image2: ImageDoc
+        image3: ImageDoc
 
     doc = MyDoc(
         image='http://myurl.jpg',
@@ -69,7 +69,7 @@ def test_image_shortcut_doc():
 @pytest.mark.internet
 def test_byte():
 
-    img = Image(url=REMOTE_JPG)
+    img = ImageDoc(url=REMOTE_JPG)
     img.bytes = img.url.load_bytes()
 
 
@@ -77,7 +77,7 @@ def test_byte():
 @pytest.mark.internet
 def test_byte_from_tensor():
 
-    img = Image(url=REMOTE_JPG)
+    img = ImageDoc(url=REMOTE_JPG)
     img.tensor = img.url.load()
     img.bytes = img.tensor.to_bytes()
 

--- a/tests/integrations/predefined_document/test_text.py
+++ b/tests/integrations/predefined_document/test_text.py
@@ -1,25 +1,25 @@
 from pydantic import parse_obj_as
 
 from docarray import BaseDocument
-from docarray.documents import Text
+from docarray.documents import TextDoc
 
 
 def test_simple_init():
-    t = Text(text='hello')
+    t = TextDoc(text='hello')
     assert t.text == 'hello'
 
 
 def test_str_init():
-    t = parse_obj_as(Text, 'hello')
+    t = parse_obj_as(TextDoc, 'hello')
     assert t.text == 'hello'
 
 
 def test_doc():
     class MyDoc(BaseDocument):
-        text1: Text
-        text2: Text
+        text1: TextDoc
+        text2: TextDoc
 
-    doc = MyDoc(text1='hello', text2=Text(text='world'))
+    doc = MyDoc(text1='hello', text2=TextDoc(text='world'))
 
     assert doc.text1.text == 'hello'
     assert doc.text2.text == 'world'

--- a/tests/integrations/predefined_document/test_video.py
+++ b/tests/integrations/predefined_document/test_video.py
@@ -4,7 +4,7 @@ import torch
 from pydantic import parse_obj_as
 
 from docarray import BaseDocument
-from docarray.documents import Video
+from docarray.documents import VideoDoc
 from docarray.typing import AudioNdArray, NdArray, VideoNdArray
 from docarray.utils.misc import is_tf_available
 from tests import TOYDATA_DIR
@@ -23,7 +23,7 @@ REMOTE_VIDEO_FILE = 'https://github.com/docarray/docarray/blob/feat-rewrite-v2/t
 @pytest.mark.internet
 @pytest.mark.parametrize('file_url', [LOCAL_VIDEO_FILE, REMOTE_VIDEO_FILE])
 def test_video(file_url):
-    vid = Video(url=file_url)
+    vid = VideoDoc(url=file_url)
     vid.tensor, vid.audio.tensor, vid.key_frame_indices = vid.url.load()
 
     assert isinstance(vid.tensor, VideoNdArray)
@@ -32,26 +32,26 @@ def test_video(file_url):
 
 
 def test_video_np():
-    video = parse_obj_as(Video, np.zeros((10, 10, 3)))
+    video = parse_obj_as(VideoDoc, np.zeros((10, 10, 3)))
     assert (video.tensor == np.zeros((10, 10, 3))).all()
 
 
 def test_video_torch():
-    video = parse_obj_as(Video, torch.zeros(10, 10, 3))
+    video = parse_obj_as(VideoDoc, torch.zeros(10, 10, 3))
     assert (video.tensor == torch.zeros(10, 10, 3)).all()
 
 
 @pytest.mark.tensorflow
 def test_video_tensorflow():
-    video = parse_obj_as(Video, tf.zeros((10, 10, 3)))
+    video = parse_obj_as(VideoDoc, tf.zeros((10, 10, 3)))
     assert tnp.allclose(video.tensor.tensor, tf.zeros((10, 10, 3)))
 
 
 def test_video_shortcut_doc():
     class MyDoc(BaseDocument):
-        video: Video
-        video2: Video
-        video3: Video
+        video: VideoDoc
+        video2: VideoDoc
+        video3: VideoDoc
 
     doc = MyDoc(
         video='http://myurl.mp4',

--- a/tests/integrations/torch/data/test_torch_dataset.py
+++ b/tests/integrations/torch/data/test_torch_dataset.py
@@ -4,11 +4,11 @@ from torch.utils.data import DataLoader
 
 from docarray import BaseDocument, DocumentArray
 from docarray.data import MultiModalDataset
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 
 
 class PairTextImage(BaseDocument):
-    text: Text
+    text: TextDoc
     image: ImageDoc
 
 
@@ -19,8 +19,8 @@ class ImagePreprocess:
 
 
 class TextPreprocess:
-    def __call__(self, text: Text) -> None:
-        assert isinstance(text, Text)
+    def __call__(self, text: TextDoc) -> None:
+        assert isinstance(text, TextDoc)
         if text.text.endswith(' meow'):
             text.embedding = torch.randn(42)
         else:
@@ -39,7 +39,7 @@ def captions_da() -> DocumentArray[PairTextImage]:
         f.readline()
         da = DocumentArray[PairTextImage](
             PairTextImage(
-                text=Text(text=i[1]),
+                text=TextDoc(text=i[1]),
                 image=ImageDoc(url=f"tests/toydata/image-data/{i[0]}"),
             )
             for i in map(lambda x: x.strip().split(","), f.readlines())
@@ -69,7 +69,7 @@ def test_primitives(captions_da: DocumentArray[PairTextImage]):
     BATCH_SIZE = 32
 
     preprocessing = {"text": Meowification()}
-    dataset = MultiModalDataset[Text](captions_da.text, preprocessing)
+    dataset = MultiModalDataset[TextDoc](captions_da.text, preprocessing)
     loader = DataLoader(
         dataset, batch_size=BATCH_SIZE, collate_fn=dataset.collate_fn, shuffle=True
     )
@@ -78,11 +78,11 @@ def test_primitives(captions_da: DocumentArray[PairTextImage]):
     assert all(t.endswith(' meow') for t in batch.text)
 
 
-def test_root_field(captions_da: DocumentArray[Text]):
+def test_root_field(captions_da: DocumentArray[TextDoc]):
     BATCH_SIZE = 32
 
     preprocessing = {"": TextPreprocess()}
-    dataset = MultiModalDataset[Text](captions_da.text, preprocessing)
+    dataset = MultiModalDataset[TextDoc](captions_da.text, preprocessing)
     loader = DataLoader(
         dataset, batch_size=BATCH_SIZE, collate_fn=dataset.collate_fn, shuffle=True
     )

--- a/tests/integrations/torch/data/test_torch_dataset.py
+++ b/tests/integrations/torch/data/test_torch_dataset.py
@@ -4,17 +4,17 @@ from torch.utils.data import DataLoader
 
 from docarray import BaseDocument, DocumentArray
 from docarray.data import MultiModalDataset
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 
 
 class PairTextImage(BaseDocument):
     text: Text
-    image: Image
+    image: ImageDoc
 
 
 class ImagePreprocess:
-    def __call__(self, image: Image) -> None:
-        assert isinstance(image, Image)
+    def __call__(self, image: ImageDoc) -> None:
+        assert isinstance(image, ImageDoc)
         image.tensor = torch.randn(3, 32, 32)
 
 
@@ -40,7 +40,7 @@ def captions_da() -> DocumentArray[PairTextImage]:
         da = DocumentArray[PairTextImage](
             PairTextImage(
                 text=Text(text=i[1]),
-                image=Image(url=f"tests/toydata/image-data/{i[0]}"),
+                image=ImageDoc(url=f"tests/toydata/image-data/{i[0]}"),
             )
             for i in map(lambda x: x.strip().split(","), f.readlines())
         )

--- a/tests/units/array/test_array_from_to_bytes.py
+++ b/tests/units/array/test_array_from_to_bytes.py
@@ -1,15 +1,14 @@
 import pytest
 
-from docarray import BaseDocument
+from docarray import BaseDocument, DocumentArray
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
-from docarray.documents import Image
-from docarray import DocumentArray
 
 
 class MyDoc(BaseDocument):
     embedding: NdArray
     text: str
-    image: Image
+    image: ImageDoc
 
 
 @pytest.mark.parametrize(
@@ -20,8 +19,10 @@ class MyDoc(BaseDocument):
 def test_from_to_bytes(protocol, compress, show_progress):
     da = DocumentArray[MyDoc](
         [
-            MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png')),
-            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=Image()),
+            MyDoc(
+                embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png')
+            ),
+            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=ImageDoc()),
         ]
     )
     bytes_da = da.to_bytes(
@@ -48,8 +49,10 @@ def test_from_to_bytes(protocol, compress, show_progress):
 def test_from_to_base64(protocol, compress, show_progress):
     da = DocumentArray[MyDoc](
         [
-            MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png')),
-            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=Image()),
+            MyDoc(
+                embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png')
+            ),
+            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=ImageDoc()),
         ]
     )
     bytes_da = da.to_base64(

--- a/tests/units/array/test_array_from_to_csv.py
+++ b/tests/units/array/test_array_from_to_csv.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from tests import TOYDATA_DIR
 
 
@@ -15,8 +15,8 @@ def nested_doc_cls():
         text: str
 
     class MyDocNested(MyDoc):
-        image: Image
-        image2: Image
+        image: ImageDoc
+        image2: ImageDoc
 
     return MyDocNested
 
@@ -27,10 +27,10 @@ def test_to_from_csv(tmpdir, nested_doc_cls):
             nested_doc_cls(
                 count=0,
                 text='hello',
-                image=Image(url='aux.png'),
-                image2=Image(url='aux.png'),
+                image=ImageDoc(url='aux.png'),
+                image2=ImageDoc(url='aux.png'),
             ),
-            nested_doc_cls(text='hello world', image=Image(), image2=Image()),
+            nested_doc_cls(text='hello world', image=ImageDoc(), image2=ImageDoc()),
         ]
     )
     tmp_file = str(tmpdir / 'tmp.csv')
@@ -55,12 +55,12 @@ def test_from_csv_nested(nested_doc_cls):
         assert doc.text.__class__ == str
         assert doc.text == f'hello {i}'
 
-        assert doc.image.__class__ == Image
+        assert doc.image.__class__ == ImageDoc
         assert doc.image.tensor is None
         assert doc.image.embedding is None
         assert doc.image.bytes is None
 
-        assert doc.image2.__class__ == Image
+        assert doc.image2.__class__ == ImageDoc
         assert doc.image2.tensor is None
         assert doc.image2.embedding is None
         assert doc.image2.bytes is None
@@ -73,17 +73,19 @@ def test_from_csv_nested(nested_doc_cls):
 @pytest.fixture()
 def nested_doc():
     class Inner(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
 
     class Middle(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         inner: Optional[Inner]
 
     class Outer(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         middle: Optional[Middle]
 
-    doc = Outer(img=Image(), middle=Middle(img=Image(), inner=Inner(img=Image())))
+    doc = Outer(
+        img=ImageDoc(), middle=Middle(img=ImageDoc(), inner=Inner(img=ImageDoc()))
+    )
     return doc
 
 

--- a/tests/units/array/test_array_from_to_json.py
+++ b/tests/units/array/test_array_from_to_json.py
@@ -1,19 +1,21 @@
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
 
 
 class MyDoc(BaseDocument):
     embedding: NdArray
     text: str
-    image: Image
+    image: ImageDoc
 
 
 def test_from_to_json():
     da = DocumentArray[MyDoc](
         [
-            MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png')),
-            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=Image()),
+            MyDoc(
+                embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png')
+            ),
+            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=ImageDoc()),
         ]
     )
     json_da = da.to_json()

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 
 
 @pytest.fixture()
@@ -14,7 +14,7 @@ def nested_doc_cls():
         text: str
 
     class MyDocNested(MyDoc):
-        image: Image
+        image: ImageDoc
 
     return MyDocNested
 
@@ -25,9 +25,9 @@ def test_to_from_pandas_df(nested_doc_cls):
             nested_doc_cls(
                 count=0,
                 text='hello',
-                image=Image(url='aux.png'),
+                image=ImageDoc(url='aux.png'),
             ),
-            nested_doc_cls(text='hello world', image=Image()),
+            nested_doc_cls(text='hello world', image=ImageDoc()),
         ]
     )
     df = da.to_pandas()
@@ -55,17 +55,19 @@ def test_to_from_pandas_df(nested_doc_cls):
 @pytest.fixture()
 def nested_doc():
     class Inner(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
 
     class Middle(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         inner: Optional[Inner]
 
     class Outer(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         middle: Optional[Middle]
 
-    doc = Outer(img=Image(), middle=Middle(img=Image(), inner=Inner(img=Image())))
+    doc = Outer(
+        img=ImageDoc(), middle=Middle(img=ImageDoc(), inner=Inner(img=ImageDoc()))
+    )
     return doc
 
 

--- a/tests/units/array/test_array_proto.py
+++ b/tests/units/array/test_array_proto.py
@@ -3,7 +3,7 @@ import pytest
 
 from docarray import BaseDocument, DocumentArray
 from docarray.array.stacked.array_stacked import DocumentArrayStacked
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 from docarray.typing import NdArray
 
 
@@ -27,13 +27,14 @@ def test_simple_proto():
 @pytest.mark.proto
 def test_nested_proto():
     class CustomDocument(BaseDocument):
-        text: Text
+        text: TextDoc
         image: ImageDoc
 
     da = DocumentArray[CustomDocument](
         [
             CustomDocument(
-                text=Text(text='hello'), image=ImageDoc(tensor=np.zeros((3, 224, 224)))
+                text=TextDoc(text='hello'),
+                image=ImageDoc(tensor=np.zeros((3, 224, 224))),
             )
             for _ in range(10)
         ]
@@ -45,13 +46,14 @@ def test_nested_proto():
 @pytest.mark.proto
 def test_nested_proto_any_doc():
     class CustomDocument(BaseDocument):
-        text: Text
+        text: TextDoc
         image: ImageDoc
 
     da = DocumentArray[CustomDocument](
         [
             CustomDocument(
-                text=Text(text='hello'), image=ImageDoc(tensor=np.zeros((3, 224, 224)))
+                text=TextDoc(text='hello'),
+                image=ImageDoc(tensor=np.zeros((3, 224, 224))),
             )
             for _ in range(10)
         ]

--- a/tests/units/array/test_array_proto.py
+++ b/tests/units/array/test_array_proto.py
@@ -3,7 +3,7 @@ import pytest
 
 from docarray import BaseDocument, DocumentArray
 from docarray.array.stacked.array_stacked import DocumentArrayStacked
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 from docarray.typing import NdArray
 
 
@@ -28,12 +28,12 @@ def test_simple_proto():
 def test_nested_proto():
     class CustomDocument(BaseDocument):
         text: Text
-        image: Image
+        image: ImageDoc
 
     da = DocumentArray[CustomDocument](
         [
             CustomDocument(
-                text=Text(text='hello'), image=Image(tensor=np.zeros((3, 224, 224)))
+                text=Text(text='hello'), image=ImageDoc(tensor=np.zeros((3, 224, 224)))
             )
             for _ in range(10)
         ]
@@ -46,12 +46,12 @@ def test_nested_proto():
 def test_nested_proto_any_doc():
     class CustomDocument(BaseDocument):
         text: Text
-        image: Image
+        image: ImageDoc
 
     da = DocumentArray[CustomDocument](
         [
             CustomDocument(
-                text=Text(text='hello'), image=Image(tensor=np.zeros((3, 224, 224)))
+                text=Text(text='hello'), image=ImageDoc(tensor=np.zeros((3, 224, 224)))
             )
             for _ in range(10)
         ]

--- a/tests/units/array/test_array_save_load.py
+++ b/tests/units/array/test_array_save_load.py
@@ -1,17 +1,17 @@
-import pytest
 import os
-import numpy as np
 
-from docarray import BaseDocument
+import numpy as np
+import pytest
+
+from docarray import BaseDocument, DocumentArray
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
-from docarray.documents import Image
-from docarray import DocumentArray
 
 
 class MyDoc(BaseDocument):
     embedding: NdArray
     text: str
-    image: Image
+    image: ImageDoc
 
 
 @pytest.mark.slow
@@ -25,8 +25,10 @@ def test_array_save_load_binary(protocol, compress, tmp_path, show_progress):
 
     da = DocumentArray[MyDoc](
         [
-            MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png')),
-            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=Image()),
+            MyDoc(
+                embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png')
+            ),
+            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=ImageDoc()),
         ]
     )
 
@@ -66,7 +68,7 @@ def test_array_save_load_binary_streaming(protocol, compress, tmp_path, show_pro
                     MyDoc(
                         embedding=np.random.rand(3, 2),
                         text='hello',
-                        image=Image(url='aux.png'),
+                        image=ImageDoc(url='aux.png'),
                     ),
                 ]
             )

--- a/tests/units/array/test_array_stacked.py
+++ b/tests/units/array/test_array_stacked.py
@@ -6,7 +6,7 @@ import torch
 
 from docarray import BaseDocument, DocumentArray
 from docarray.array import DocumentArrayStacked
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.typing import AnyEmbedding, AnyTensor, NdArray, TorchTensor
 
 
@@ -45,14 +45,14 @@ def nested_batch():
 
 
 def test_create_from_list_docs():
-    list_ = [Image(tensor=torch.zeros(3, 224, 224)) for _ in range(10)]
-    da_stacked = DocumentArrayStacked[Image](docs=list_, tensor_type=TorchTensor)
+    list_ = [ImageDoc(tensor=torch.zeros(3, 224, 224)) for _ in range(10)]
+    da_stacked = DocumentArrayStacked[ImageDoc](docs=list_, tensor_type=TorchTensor)
     assert len(da_stacked) == 10
     assert da_stacked.tensor.shape == tuple([10, 3, 224, 224])
 
 
 def test_create_from_None():
-    da_stacked = DocumentArrayStacked[Image]()
+    da_stacked = DocumentArrayStacked[ImageDoc]()
     assert len(da_stacked) == 0
 
 
@@ -389,8 +389,8 @@ def test_stack_none(tensor_backend):
 
 
 def test_to_device():
-    da = DocumentArray[Image](
-        [Image(tensor=torch.zeros(3, 5))], tensor_type=TorchTensor
+    da = DocumentArray[ImageDoc](
+        [ImageDoc(tensor=torch.zeros(3, 5))], tensor_type=TorchTensor
     )
     da = da.stack()
     assert da.tensor.device == torch.device('cpu')
@@ -401,10 +401,10 @@ def test_to_device():
 def test_to_device_nested():
     class MyDoc(BaseDocument):
         tensor: TorchTensor
-        docs: Image
+        docs: ImageDoc
 
     da = DocumentArray[MyDoc](
-        [MyDoc(tensor=torch.zeros(3, 5), docs=Image(tensor=torch.zeros(3, 5)))],
+        [MyDoc(tensor=torch.zeros(3, 5), docs=ImageDoc(tensor=torch.zeros(3, 5)))],
         tensor_type=TorchTensor,
     )
     da = da.stack()
@@ -416,7 +416,9 @@ def test_to_device_nested():
 
 
 def test_to_device_numpy():
-    da = DocumentArray[Image]([Image(tensor=np.zeros((3, 5)))], tensor_type=NdArray)
+    da = DocumentArray[ImageDoc](
+        [ImageDoc(tensor=np.zeros((3, 5)))], tensor_type=NdArray
+    )
     da = da.stack()
     with pytest.raises(NotImplementedError):
         da.to('meta')

--- a/tests/units/array/test_indexing.py
+++ b/tests/units/array/test_indexing.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from docarray import DocumentArray
-from docarray.documents import Text
+from docarray.documents import TextDoc
 from docarray.typing import TorchTensor
 
 
@@ -11,8 +11,8 @@ from docarray.typing import TorchTensor
 def da():
     texts = [f'hello {i}' for i in range(10)]
     tensors = [torch.ones((4,)) * i for i in range(10)]
-    return DocumentArray[Text](
-        [Text(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
+    return DocumentArray[TextDoc](
+        [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
         tensor_type=TorchTensor,
     )
 
@@ -21,8 +21,8 @@ def da():
 def da_to_set():
     texts = [f'hello {2*i}' for i in range(5)]
     tensors = [torch.ones((4,)) * i * 2 for i in range(5)]
-    return DocumentArray[Text](
-        [Text(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
+    return DocumentArray[TextDoc](
+        [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
         tensor_type=TorchTensor,
     )
 
@@ -238,12 +238,12 @@ def test_boolmask_setitem(stack_left, stack_right, da, da_to_set, index):
 def test_setitem_update_column():
     texts = [f'hello {i}' for i in range(10)]
     tensors = [torch.ones((4,)) * (i + 1) for i in range(10)]
-    da = DocumentArray[Text](
-        [Text(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
+    da = DocumentArray[TextDoc](
+        [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
         tensor_type=TorchTensor,
     ).stack()
 
-    da[0] = Text(text='hello', embedding=torch.zeros((4,)))
+    da[0] = TextDoc(text='hello', embedding=torch.zeros((4,)))
 
     assert da[0].text == 'hello'
     assert (da[0].embedding == torch.zeros((4,))).all()

--- a/tests/units/array/test_traverse.py
+++ b/tests/units/array/test_traverse.py
@@ -5,7 +5,7 @@ import torch
 
 from docarray import BaseDocument, DocumentArray
 from docarray.array.abstract_array import AnyDocumentArray
-from docarray.documents import Text
+from docarray.documents import TextDoc
 from docarray.typing import TorchTensor
 
 num_docs = 5
@@ -16,29 +16,29 @@ num_sub_sub_docs = 3
 @pytest.fixture
 def multi_model_docs():
     class SubSubDoc(BaseDocument):
-        sub_sub_text: Text
+        sub_sub_text: TextDoc
         sub_sub_tensor: TorchTensor[2]
 
     class SubDoc(BaseDocument):
-        sub_text: Text
+        sub_text: TextDoc
         sub_da: DocumentArray[SubSubDoc]
 
     class MultiModalDoc(BaseDocument):
-        mm_text: Text
+        mm_text: TextDoc
         mm_tensor: Optional[TorchTensor[3, 2, 2]]
         mm_da: DocumentArray[SubDoc]
 
     docs = DocumentArray[MultiModalDoc](
         [
             MultiModalDoc(
-                mm_text=Text(text=f'hello{i}'),
+                mm_text=TextDoc(text=f'hello{i}'),
                 mm_da=[
                     SubDoc(
-                        sub_text=Text(text=f'sub_{i}_1'),
+                        sub_text=TextDoc(text=f'sub_{i}_1'),
                         sub_da=DocumentArray[SubSubDoc](
                             [
                                 SubSubDoc(
-                                    sub_sub_text=Text(text='subsub'),
+                                    sub_sub_text=TextDoc(text='subsub'),
                                     sub_sub_tensor=torch.zeros(2),
                                 )
                                 for _ in range(num_sub_sub_docs)

--- a/tests/units/document/test_docs_operators.py
+++ b/tests/units/document/test_docs_operators.py
@@ -1,26 +1,26 @@
-from docarray.documents.text import Text
+from docarray.documents.text import TextDoc
 
 
 def test_text_document_operators():
 
-    doc = Text(text='text', url='url.com')
+    doc = TextDoc(text='text', url='url.com')
 
     assert doc == 'text'
     assert doc != 'url.com'
 
-    doc2 = Text(id=doc.id, text='text', url='url.com')
+    doc2 = TextDoc(id=doc.id, text='text', url='url.com')
     assert doc == doc2
 
-    doc3 = Text(id='other-id', text='text', url='url.com')
+    doc3 = TextDoc(id='other-id', text='text', url='url.com')
     assert doc != doc3
 
     assert 't' in doc
     assert 'a' not in doc
 
-    t = Text(text='this is my text document')
+    t = TextDoc(text='this is my text document')
     assert 'text' in t
     assert 'docarray' not in t
 
-    text = Text()
+    text = TextDoc()
     assert text is not None
     assert text.text is None

--- a/tests/units/document/test_from_to_bytes.py
+++ b/tests/units/document/test_from_to_bytes.py
@@ -1,20 +1,20 @@
 import pytest
 
 from docarray import BaseDocument
+from docarray.documents import ImageDoc
 from docarray.typing import NdArray
-from docarray.documents import Image
 
 
 class MyDoc(BaseDocument):
     embedding: NdArray
     text: str
-    image: Image
+    image: ImageDoc
 
 
 @pytest.mark.parametrize('protocol', ['protobuf', 'pickle'])
 @pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip', None])
 def test_to_from_bytes(protocol, compress):
-    d = MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png'))
+    d = MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png'))
 
     assert d.text == 'hello'
     assert d.embedding.tolist() == [1, 2, 3, 4, 5]
@@ -29,7 +29,7 @@ def test_to_from_bytes(protocol, compress):
 @pytest.mark.parametrize('protocol', ['protobuf', 'pickle'])
 @pytest.mark.parametrize('compress', ['lz4', 'bz2', 'lzma', 'zlib', 'gzip', None])
 def test_to_from_base64(protocol, compress):
-    d = MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=Image(url='aux.png'))
+    d = MyDoc(embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png'))
 
     assert d.text == 'hello'
     assert d.embedding.tolist() == [1, 2, 3, 4, 5]

--- a/tests/units/document/test_text_document.py
+++ b/tests/units/document/test_text_document.py
@@ -1,15 +1,15 @@
-from docarray.documents import Text
+from docarray.documents import TextDoc
 
 
 def test_text_document_init():
-    text = Text('hello world')
+    text = TextDoc('hello world')
     assert text.text == 'hello world'
     assert text == 'hello world'
 
-    text = Text(text='hello world')
+    text = TextDoc(text='hello world')
     assert text.text == 'hello world'
     assert text == 'hello world'
 
-    text = Text()
+    text = TextDoc()
     assert text is not None
     assert text.text is None

--- a/tests/units/document/test_update.py
+++ b/tests/units/document/test_update.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Set
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 
 
 class InnerDoc(BaseDocument):
@@ -15,7 +15,7 @@ class MMDoc(BaseDocument):
     text: str = ''
     price: int = 0
     categories: Optional[List[str]] = None
-    image: Optional[Image] = None
+    image: Optional[ImageDoc] = None
     matches: Optional[DocumentArray] = None
     matches_with_same_id: Optional[DocumentArray] = None
     opt_int: Optional[int] = None
@@ -96,7 +96,7 @@ def test_update_different_schema_fails():
         content: str
 
     class DocB(BaseDocument):
-        image: Optional[Image] = None
+        image: Optional[ImageDoc] = None
 
     docA = DocA(content='haha')
     docB = DocB()

--- a/tests/units/test_helper.py
+++ b/tests/units/test_helper.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 import pytest
 
-from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray import BaseDocument
+from docarray.documents import ImageDoc
 from docarray.helper import (
     _access_path_dict_to_nested_dict,
     _access_path_to_dict,
@@ -16,21 +16,19 @@ from docarray.helper import (
 @pytest.fixture()
 def nested_doc():
     class Inner(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
 
     class Middle(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         inner: Optional[Inner]
 
     class Outer(BaseDocument):
-        img: Optional[Image]
+        img: Optional[ImageDoc]
         middle: Optional[Middle]
         da: DocumentArray[Inner]
 
     doc = Outer(
-        img=Image(),
-        middle=Middle(img=Image(), inner=Inner(img=Image())),
-        da=DocumentArray[Inner]([Inner(img=Image(url='test.png'))]),
+        img=ImageDoc(), middle=Middle(img=ImageDoc(), inner=Inner(img=ImageDoc()))
     )
     return doc
 
@@ -52,7 +50,7 @@ def test_is_access_path_not_valid(nested_doc):
 def test_get_access_paths():
     class Painting(BaseDocument):
         title: str
-        img: Image
+        img: ImageDoc
 
     access_paths = Painting._get_access_paths()
     assert access_paths == [

--- a/tests/units/test_helper.py
+++ b/tests/units/test_helper.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pytest
 
-from docarray import BaseDocument
+from docarray import BaseDocument, DocumentArray
 from docarray.documents import ImageDoc
 from docarray.helper import (
     _access_path_dict_to_nested_dict,
@@ -28,7 +28,9 @@ def nested_doc():
         da: DocumentArray[Inner]
 
     doc = Outer(
-        img=ImageDoc(), middle=Middle(img=ImageDoc(), inner=Inner(img=ImageDoc()))
+        img=ImageDoc(),
+        middle=Middle(img=ImageDoc(), inner=Inner(img=ImageDoc())),
+        da=DocumentArray[Inner]([Inner(img=ImageDoc(url='test.png'))]),
     )
     return doc
 

--- a/tests/units/util/test_filter.py
+++ b/tests/units/util/test_filter.py
@@ -4,44 +4,44 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import ImageDoc, Text
+from docarray.documents import ImageDoc, TextDoc
 from docarray.utils.filter import filter
 
 
 class MMDoc(BaseDocument):
-    text_doc: Text
+    text_doc: TextDoc
     text: str = ''
     image: Optional[ImageDoc] = None
     price: int = 0
     optional_num: Optional[int] = None
     boolean: bool = False
     categories: Optional[List[str]] = None
-    sub_docs: Optional[List[Text]] = None
+    sub_docs: Optional[List[TextDoc]] = None
     dictionary: Optional[Dict[str, Any]] = None
 
 
 @pytest.fixture
 def docs():
     mmdoc1 = MMDoc(
-        text_doc=Text(text='Text Doc of Document 1'),
+        text_doc=TextDoc(text='Text Doc of Document 1'),
         text='Text of Document 1',
-        sub_docs=[Text(text='subtext1'), Text(text='subtext2')],
+        sub_docs=[TextDoc(text='subtext1'), TextDoc(text='subtext2')],
         dictionary={},
     )
     mmdoc2 = MMDoc(
-        text_doc=Text(text='Text Doc of Document 2'),
+        text_doc=TextDoc(text='Text Doc of Document 2'),
         text='Text of Document 2',
         image=ImageDoc(url='exampleimage.jpg'),
         price=3,
         dictionary={'a': 0, 'b': 1, 'c': 2, 'd': {'e': 3}},
     )
     mmdoc3 = MMDoc(
-        text_doc=Text(text='Text Doc of Document 3'),
+        text_doc=TextDoc(text='Text Doc of Document 3'),
         text='Text of Document 3',
         price=1000,
         boolean=True,
         categories=['cat1', 'cat2'],
-        sub_docs=[Text(text='subtext1'), Text(text='subtext2')],
+        sub_docs=[TextDoc(text='subtext1'), TextDoc(text='subtext2')],
         optional_num=30,
         dictionary={'a': 0, 'b': 1},
     )
@@ -175,8 +175,8 @@ def test_array_simple_filters(docs, dict_api):
 def test_placehold_filter(dict_api):
     docs = DocumentArray[MMDoc](
         [
-            MMDoc(text='A', text_doc=Text(text='A')),
-            MMDoc(text='A', text_doc=Text(text='B')),
+            MMDoc(text='A', text_doc=TextDoc(text='A')),
+            MMDoc(text='A', text_doc=TextDoc(text='B')),
         ]
     )
 
@@ -247,7 +247,7 @@ def test_logic_filter(docs, dict_api):
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_from_docstring(dict_api):
     class MyDocument(BaseDocument):
-        caption: Text
+        caption: TextDoc
         image: ImageDoc
         price: int
 

--- a/tests/units/util/test_filter.py
+++ b/tests/units/util/test_filter.py
@@ -4,14 +4,14 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image, Text
+from docarray.documents import ImageDoc, Text
 from docarray.utils.filter import filter
 
 
 class MMDoc(BaseDocument):
     text_doc: Text
     text: str = ''
-    image: Optional[Image] = None
+    image: Optional[ImageDoc] = None
     price: int = 0
     optional_num: Optional[int] = None
     boolean: bool = False
@@ -31,7 +31,7 @@ def docs():
     mmdoc2 = MMDoc(
         text_doc=Text(text='Text Doc of Document 2'),
         text='Text of Document 2',
-        image=Image(url='exampleimage.jpg'),
+        image=ImageDoc(url='exampleimage.jpg'),
         price=3,
         dictionary={'a': 0, 'b': 1, 'c': 2, 'd': {'e': 3}},
     )
@@ -248,22 +248,24 @@ def test_logic_filter(docs, dict_api):
 def test_from_docstring(dict_api):
     class MyDocument(BaseDocument):
         caption: Text
-        image: Image
+        image: ImageDoc
         price: int
 
     docs = DocumentArray[MyDocument](
         [
             MyDocument(
                 caption='A tiger in the jungle',
-                image=Image(url='tigerphoto.png'),
+                image=ImageDoc(url='tigerphoto.png'),
                 price=100,
             ),
             MyDocument(
-                caption='A swimming turtle', image=Image(url='turtlepic.png'), price=50
+                caption='A swimming turtle',
+                image=ImageDoc(url='turtlepic.png'),
+                price=50,
             ),
             MyDocument(
                 caption='A couple birdwatching with binoculars',
-                image=Image(url='binocularsphoto.png'),
+                image=ImageDoc(url='binocularsphoto.png'),
                 price=30,
             ),
         ]

--- a/tests/units/util/test_map.py
+++ b/tests/units/util/test_map.py
@@ -3,7 +3,7 @@ from typing import Generator, Optional
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.typing import ImageUrl, NdArray
 from docarray.utils.map import map_docs, map_docs_batch
 from tests.units.typing.test_bytes import IMAGE_PATHS
@@ -11,7 +11,7 @@ from tests.units.typing.test_bytes import IMAGE_PATHS
 N_DOCS = 2
 
 
-def load_from_doc(d: Image) -> Image:
+def load_from_doc(d: ImageDoc) -> ImageDoc:
     if d.url is not None:
         d.tensor = d.url.load()
     return d
@@ -19,7 +19,9 @@ def load_from_doc(d: Image) -> Image:
 
 @pytest.fixture()
 def da():
-    da = DocumentArray[Image]([Image(url=IMAGE_PATHS['png']) for _ in range(N_DOCS)])
+    da = DocumentArray[ImageDoc](
+        [ImageDoc(url=IMAGE_PATHS['png']) for _ in range(N_DOCS)]
+    )
     return da
 
 
@@ -50,7 +52,7 @@ def test_map_multiprocessing_local_func_raise_exception(da):
 
 @pytest.mark.parametrize('backend', ['thread', 'process'])
 def test_check_order(backend):
-    da = DocumentArray[Image]([Image(id=i) for i in range(N_DOCS)])
+    da = DocumentArray[ImageDoc]([ImageDoc(id=i) for i in range(N_DOCS)])
 
     docs = list(map_docs(da=da, func=load_from_doc, backend=backend))
 

--- a/tests/units/util/test_reduce.py
+++ b/tests/units/util/test_reduce.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Set
 import pytest
 
 from docarray import BaseDocument, DocumentArray
-from docarray.documents import Image
+from docarray.documents import ImageDoc
 from docarray.utils.reduce import reduce, reduce_all
 
 
@@ -16,7 +16,7 @@ class MMDoc(BaseDocument):
     text: str = ''
     price: int = 0
     categories: Optional[List[str]] = None
-    image: Optional[Image] = None
+    image: Optional[ImageDoc] = None
     matches: Optional[DocumentArray] = None
     matches_with_same_id: Optional[DocumentArray] = None
     opt_int: Optional[int] = None


### PR DESCRIPTION
# Context

Rename every predefined documents from `XXX`  to `XXXDoc`

The main argument is that otherwise there is no distinction in the naming between predefined documents and DocArray type