### PR TITLE
feat: ellipsis in tensor shape definition

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -130,6 +130,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
                         f'Cannot use Ellipsis (...) more than once for the shape {shape}'
                     )
                 ellipsis_pos = ellipsis_occurrences[0]
+                # Calculate how many dimensions to add. Should be at least 1.
                 dimensions_needed = max(len(tshape) - len(shape) + 1, 1)
                 shape = (
                     shape[:ellipsis_pos]

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -83,7 +83,6 @@ class _ParametrizedMeta(type):
 
 
 class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
-
     __parametrized_meta__: type = _ParametrizedMeta
     __unparametrizedcls__: Optional[Type['AbstractTensor']] = None
     __docarray_target_shape__: Optional[Tuple[int, ...]] = None
@@ -121,7 +120,25 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
         tshape = comp_be.shape(t)
         if tshape == shape:
             return t
-        elif any(isinstance(dim, str) for dim in shape):
+        elif any(isinstance(dim, str) or dim == Ellipsis for dim in shape):
+            ellipsis_occurrences = [
+                pos for pos, dim in enumerate(shape) if dim == Ellipsis
+            ]
+            if ellipsis_occurrences:
+                if len(ellipsis_occurrences) > 1:
+                    raise ValueError(
+                        f'Cannot use Ellipsis (...) more than once for the shape {shape}'
+                    )
+                ellipsis_pos = ellipsis_occurrences[0]
+                dimensions_needed = len(tshape) - len(shape) + 1
+                shape = (
+                    shape[:ellipsis_pos]
+                    + tuple(
+                        f'__dim_var_{index}__' for index in range(dimensions_needed)
+                    )
+                    + shape[ellipsis_pos + 1 :]
+                )
+
             if len(tshape) != len(shape):
                 raise ValueError(
                     f'Tensor shape mismatch. Expected {shape}, got {tshape}'

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -130,7 +130,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
                         f'Cannot use Ellipsis (...) more than once for the shape {shape}'
                     )
                 ellipsis_pos = ellipsis_occurrences[0]
-                dimensions_needed = len(tshape) - len(shape) + 1
+                dimensions_needed = max(len(tshape) - len(shape) + 1, 1)
                 shape = (
                     shape[:ellipsis_pos]
                     + tuple(

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -101,7 +101,7 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
         return NodeProto(ndarray=nd_proto, type=self._proto_type_name)
 
     @classmethod
-    def __docarray_validate_shape__(cls, t: T, shape: Tuple[Union[int, str]]) -> T:
+    def __docarray_validate_shape__(cls, t: T, shape: Tuple[Union[int, str], ...]) -> T:
         """Every tensor has to implement this method in order to
         enable syntax of the form AnyTensor[shape].
         It is called when a tensor is assigned to a field of this type.

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -59,13 +59,14 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
             arr: NdArray
             image_arr: NdArray[3, 224, 224]
             square_crop: NdArray[3, 'x', 'x']
-
+            random_image: NdArray[3, ...] # first dimension is fixed, can have arbitrary shape
 
         # create a document with tensors
         doc = MyDoc(
             arr=np.zeros((128,)),
             image_arr=np.zeros((3, 224, 224)),
             square_crop=np.zeros((3, 64, 64)),
+            random_image=np.zeros(3, 128, 256),
         )
         assert doc.image_arr.shape == (3, 224, 224)
 
@@ -74,6 +75,7 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
             arr=np.zeros((128,)),
             image_arr=np.zeros((224, 224, 3)),  # will reshape to (3, 224, 224)
             square_crop=np.zeros((3, 128, 128)),
+            random_image=np.zeros(3, 64, 128),
         )
         assert doc.image_arr.shape == (3, 224, 224)
 
@@ -82,6 +84,7 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
             arr=np.zeros((128,)),
             image_arr=np.zeros((224, 224)),  # this will fail validation
             square_crop=np.zeros((3, 128, 64)),  # this will also fail validation
+            random_image=np.zeros(4, 64, 128),  # this will also fail validation
         )
     """
 

--- a/docarray/typing/tensor/tensorflow_tensor.py
+++ b/docarray/typing/tensor/tensorflow_tensor.py
@@ -103,6 +103,7 @@ class TensorFlowTensor(AbstractTensor, Generic[ShapeT], metaclass=metaTensorFlow
             tensor: TensorFlowTensor
             image_tensor: TensorFlowTensor[3, 224, 224]
             square_crop: TensorFlowTensor[3, 'x', 'x']
+            random_image: TensorFlowTensor[3, ...] # first dimension is fixed, can have arbitrary shape
 
 
         # create a document with tensors
@@ -110,6 +111,7 @@ class TensorFlowTensor(AbstractTensor, Generic[ShapeT], metaclass=metaTensorFlow
             tensor=tf.zeros((128,)),
             image_tensor=tf.zeros((3, 224, 224)),
             square_crop=tf.zeros((3, 64, 64)),
+            random_image=tf.zeros(3, 128, 256),
         )
 
         # automatic shape conversion
@@ -117,6 +119,7 @@ class TensorFlowTensor(AbstractTensor, Generic[ShapeT], metaclass=metaTensorFlow
             tensor=tf.zeros((128,)),
             image_tensor=tf.zeros((224, 224, 3)),  # will reshape to (3, 224, 224)
             square_crop=tf.zeros((3, 128, 128)),
+            random_image=tf.zeros(3, 64, 128),
         )
 
         # !! The following will raise an error due to shape mismatch !!
@@ -124,6 +127,7 @@ class TensorFlowTensor(AbstractTensor, Generic[ShapeT], metaclass=metaTensorFlow
             tensor=tf.zeros((128,)),
             image_tensor=tf.zeros((224, 224)),  # this will fail validation
             square_crop=tf.zeros((3, 128, 64)),  # this will also fail validation
+            random_image=tf.zeros(4, 64, 128),  # this will also fail validation
         )
 
     """

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -59,6 +59,7 @@ class TorchTensor(
             tensor: TorchTensor
             image_tensor: TorchTensor[3, 224, 224]
             square_crop: TorchTensor[3, 'x', 'x']
+            random_image: TorchTensor[3, ...] # first dimension is fixed, can have arbitrary shape
 
 
         # create a document with tensors
@@ -66,6 +67,7 @@ class TorchTensor(
             tensor=torch.zeros(128),
             image_tensor=torch.zeros(3, 224, 224),
             square_crop=torch.zeros(3, 64, 64),
+            random_image=torch.zeros(3, 128, 256),
         )
 
         # automatic shape conversion
@@ -73,6 +75,7 @@ class TorchTensor(
             tensor=torch.zeros(128),
             image_tensor=torch.zeros(224, 224, 3),  # will reshape to (3, 224, 224)
             square_crop=torch.zeros(3, 128, 128),
+            random_image=torch.zeros(3, 64, 128),
         )
 
         # !! The following will raise an error due to shape mismatch !!
@@ -80,6 +83,7 @@ class TorchTensor(
             tensor=torch.zeros(128),
             image_tensor=torch.zeros(224, 224),  # this will fail validation
             square_crop=torch.zeros(3, 128, 64),  # this will also fail validation
+            random_image=torch.zeros(4, 64, 128),  # this will also fail validation
         )
     """
 

--- a/tests/units/typing/tensor/test_tensor.py
+++ b/tests/units/typing/tensor/test_tensor.py
@@ -1,10 +1,11 @@
 import numpy as np
 import orjson
 import pytest
+import torch
 from pydantic.tools import parse_obj_as, schema_json_of
 
 from docarray.base_document.io.json import orjson_dumps
-from docarray.typing import NdArray
+from docarray.typing import NdArray, TorchTensor
 from docarray.typing.tensor import NdArrayEmbedding
 
 
@@ -51,111 +52,105 @@ def test_unwrap():
     assert (ndarray == np.zeros((3, 224, 224))).all()
 
 
-def test_ellipsis_in_shape():
+@pytest.mark.parametrize(
+    'tensor_class, tensor_type, tensor_fn',
+    [(NdArray, np.ndarray, np.zeros), (TorchTensor, torch.Tensor, torch.zeros)],
+)
+def test_ellipsis_in_shape(tensor_class, tensor_type, tensor_fn):
     # ellipsis in the end, two extra dimensions needed
-    tensor = parse_obj_as(NdArray[3, ...], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, ...], tensor_fn((3, 128, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 128, 224)
 
-    # ellipsis in the end, no extra dimensions needed
-    tensor = parse_obj_as(NdArray[3, 128, 224, ...], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
-    assert tensor.shape == (3, 128, 224)
-
-    # ellipsis in the middle,  one extra dimension needed
-    tensor = parse_obj_as(NdArray[3, ..., 224], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
-    assert tensor.shape == (3, 128, 224)
-
-    # ellipsis in the middle, no extra dimensions needed
-    tensor = parse_obj_as(NdArray[3, ..., 128, 224], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    # ellipsis in the middle, one extra dimension needed
+    tensor = parse_obj_as(tensor_class[3, ..., 224], tensor_fn((3, 128, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 128, 224)
 
     # ellipsis in the beginning, two extra dimensions needed
-    tensor = parse_obj_as(NdArray[..., 224], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
-    assert tensor.shape == (3, 128, 224)
-
-    # ellipsis in the beginning, no extra dimensions needed
-    tensor = parse_obj_as(NdArray[..., 3, 128, 224], np.zeros((3, 128, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[..., 224], tensor_fn((3, 128, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 128, 224)
 
     # more than one ellipsis in the shape
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, ..., 128, ...], np.zeros((3, 128, 224)))
+        parse_obj_as(tensor_class[3, ..., 128, ...], tensor_fn((3, 128, 224)))
 
     # bigger dimension than expected
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, 128, 224, ...], np.zeros((3, 128)))
+        parse_obj_as(tensor_class[3, 128, 224, ...], tensor_fn((3, 128)))
+
+    # no extra dimension needed
+    with pytest.raises(ValueError):
+        parse_obj_as(tensor_class[3, 128, 224, ...], tensor_fn((3, 128, 224)))
 
     # wrong shape
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, 224, ...], np.zeros((3, 128, 224)))
+        parse_obj_as(tensor_class[3, 224, ...], tensor_fn((3, 128, 224)))
 
     # passing only ellipsis as a shape
     with pytest.raises(TypeError):
-        parse_obj_as(NdArray[...], np.zeros((3, 128, 224)))
+        parse_obj_as(tensor_class[...], tensor_fn((3, 128, 224)))
 
 
-def test_parametrized():
+@pytest.mark.parametrize(
+    'tensor_class, tensor_type, tensor_fn',
+    [(NdArray, np.ndarray, np.zeros), (TorchTensor, torch.Tensor, torch.zeros)],
+)
+def test_parametrized(tensor_class, tensor_type, tensor_fn):
     # correct shape, single axis
-    tensor = parse_obj_as(NdArray[128], np.zeros(128))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[128], tensor_fn(128))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (128,)
 
     # correct shape, multiple axis
-    tensor = parse_obj_as(NdArray[3, 224, 224], np.zeros((3, 224, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, 224, 224], tensor_fn((3, 224, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 224, 224)
 
     # wrong but reshapable shape
-    tensor = parse_obj_as(NdArray[3, 224, 224], np.zeros((3, 224, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, 224, 224], tensor_fn((3, 224, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 224, 224)
 
     # wrong and not reshapable shape
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, 224, 224], np.zeros((224, 224)))
+        parse_obj_as(tensor_class[3, 224, 224], tensor_fn((224, 224)))
 
     # test independent variable dimensions
-    tensor = parse_obj_as(NdArray[3, 'x', 'y'], np.zeros((3, 224, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, 'x', 'y'], tensor_fn((3, 224, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 224, 224)
 
-    tensor = parse_obj_as(NdArray[3, 'x', 'y'], np.zeros((3, 60, 128)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, 'x', 'y'], tensor_fn((3, 60, 128)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 60, 128)
 
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, 'x', 'y'], np.zeros((4, 224, 224)))
+        parse_obj_as(tensor_class[3, 'x', 'y'], tensor_fn((4, 224, 224)))
 
     with pytest.raises(ValueError):
-        parse_obj_as(NdArray[3, 'x', 'y'], np.zeros((100, 1)))
+        parse_obj_as(tensor_class[3, 'x', 'y'], tensor_fn((100, 1)))
 
     # test dependent variable dimensions
-    tensor = parse_obj_as(NdArray[3, 'x', 'x'], np.zeros((3, 224, 224)))
-    assert isinstance(tensor, NdArray)
-    assert isinstance(tensor, np.ndarray)
+    tensor = parse_obj_as(tensor_class[3, 'x', 'x'], tensor_fn((3, 224, 224)))
+    assert isinstance(tensor, tensor_class)
+    assert isinstance(tensor, tensor_type)
     assert tensor.shape == (3, 224, 224)
 
     with pytest.raises(ValueError):
-        tensor = parse_obj_as(NdArray[3, 'x', 'x'], np.zeros((3, 60, 128)))
+        tensor = parse_obj_as(tensor_class[3, 'x', 'x'], tensor_fn((3, 60, 128)))
 
     with pytest.raises(ValueError):
-        tensor = parse_obj_as(NdArray[3, 'x', 'x'], np.zeros((3, 60)))
+        tensor = parse_obj_as(tensor_class[3, 'x', 'x'], tensor_fn((3, 60)))
 
 
 def test_np_embedding():

--- a/tests/units/typing/tensor/test_tensor_flow_tensor.py
+++ b/tests/units/typing/tensor/test_tensor_flow_tensor.py
@@ -65,13 +65,13 @@ def test_ellipsis_in_shape():
     tf_tensor = parse_obj_as(TensorFlowTensor[3, ...], tf.zeros((3, 128, 224)))
     assert isinstance(tf_tensor, TensorFlowTensor)
     assert isinstance(tf_tensor.tensor, tf.Tensor)
-    assert tf_tensor.shape == (3, 128, 224)
+    assert tf_tensor.tensor.shape == (3, 128, 224)
 
     # ellipsis in the beginning, two extra dimensions needed
     tf_tensor = parse_obj_as(TensorFlowTensor[..., 224], tf.zeros((3, 128, 224)))
     assert isinstance(tf_tensor, TensorFlowTensor)
     assert isinstance(tf_tensor.tensor, tf.Tensor)
-    assert tf_tensor.shape == (3, 128, 224)
+    assert tf_tensor.tensor.shape == (3, 128, 224)
 
     # more than one ellipsis in the shape
     with pytest.raises(ValueError):

--- a/tests/units/typing/tensor/test_tensor_flow_tensor.py
+++ b/tests/units/typing/tensor/test_tensor_flow_tensor.py
@@ -60,6 +60,29 @@ def test_from_ndarray():
 
 
 @pytest.mark.tensorflow
+def test_ellipsis_in_shape():
+    # ellipsis in the end, two extra dimensions needed
+    tf_tensor = parse_obj_as(TensorFlowTensor[3, ...], tf.zeros((3, 128, 224)))
+    assert isinstance(tf_tensor, TensorFlowTensor)
+    assert isinstance(tf_tensor.tensor, tf.Tensor)
+    assert tf_tensor.shape == (3, 128, 224)
+
+    # ellipsis in the beginning, two extra dimensions needed
+    tf_tensor = parse_obj_as(TensorFlowTensor[..., 224], tf.zeros((3, 128, 224)))
+    assert isinstance(tf_tensor, TensorFlowTensor)
+    assert isinstance(tf_tensor.tensor, tf.Tensor)
+    assert tf_tensor.shape == (3, 128, 224)
+
+    # more than one ellipsis in the shape
+    with pytest.raises(ValueError):
+        parse_obj_as(TensorFlowTensor[3, ..., 128, ...], tf.zeros((3, 128, 224)))
+
+    # wrong shape
+    with pytest.raises(ValueError):
+        parse_obj_as(TensorFlowTensor[3, 224, ...], tf.zeros((3, 128, 224)))
+
+
+@pytest.mark.tensorflow
 def test_parametrized():
     # correct shape, single axis
     tf_tensor = parse_obj_as(TensorFlowTensor[128], tf.zeros(128))


### PR DESCRIPTION
Introduces the first feature proposed here https://github.com/docarray/docarray/issues/1185

**Generic behavior for tensor shapes**
It's now possible to use ellipsis when defining tensor shapes. 
Example:
```python
def fn(batch: NdArray[100, ...])
```
which means `batch` is expected to have first dimension of size 100, and can have other arbitrary dimensions which won't be checked while validating the shape.

Other examples:
```python
# ellipsis in the beginning
def fn(batch: NdArray[..., 100]):
    pass
# ellipsis in the middle
def fn(batch: NdArray[3, ..., 100]):
    pass
```

**How it works**
If ellipsis is detected in the shape, remove it, and replace by the amount independent variables needed to make the number of dimensions equal for the actual shape and the shape definition. Then, proceed to check if the two shapes are compatible. 

- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
