### PR TITLE
make default search field empty string

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     args:
       - -S
 -   repo: https://github.com/pycqa/isort
-    rev: 5.5.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/docarray/doc_index/abstract_doc_index.py
+++ b/docarray/doc_index/abstract_doc_index.py
@@ -201,14 +201,14 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
     def _find(
         self,
         query: np.ndarray,
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResult:
         """Find documents in the index
 
         :param query: query vector for KNN/ANN search. Has single axis.
-        :param search_field: name of the field to search on
         :param limit: maximum number of documents to return per query
+        :param search_field: name of the field to search on
         :return: a named tuple containing `documents` and `scores`
         """
         # NOTE: in standard implementations,
@@ -219,15 +219,15 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
     def _find_batched(
         self,
         query: np.ndarray,
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResultBatched:
         """Find documents in the index
 
         :param query: query vectors for KNN/ANN search.
             Has shape (batch_size, vector_dim)
-        :param search_field: name of the field to search on
         :param limit: maximum number of documents to return
+        :param search_field: name of the field to search on
         :return: a named tuple containing `documents` and `scores`
         """
         ...
@@ -266,14 +266,14 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
     def _text_search(
         self,
         query: str,
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResult:
         """Find documents in the index based on a text search query
 
         :param query: The text to search for
-        :param search_field: name of the field to search on
         :param limit: maximum number of documents to return
+        :param search_field: name of the field to search on
         :return: a named tuple containing `documents` and `scores`
         """
         # NOTE: in standard implementations,
@@ -284,14 +284,14 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
     def _text_search_batched(
         self,
         queries: Sequence[str],
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResultBatched:
         """Find documents in the index based on a text search query
 
         :param queries: The texts to search for
-        :param search_field: name of the field to search on
         :param limit: maximum number of documents to return per query
+        :param search_field: name of the field to search on
         :return: a named tuple containing `documents` and `scores`
         """
         # NOTE: in standard implementations,

--- a/docarray/doc_index/backends/hnswlib_doc_index.py
+++ b/docarray/doc_index/backends/hnswlib_doc_index.py
@@ -213,8 +213,8 @@ class HnswDocumentIndex(BaseDocumentIndex, Generic[TSchema]):
     def _find_batched(
         self,
         query: np.ndarray,
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResultBatched:
         index = self._hnsw_indices[search_field]
         labels, distances = index.knn_query(query, k=limit)
@@ -226,9 +226,13 @@ class HnswDocumentIndex(BaseDocumentIndex, Generic[TSchema]):
         ]
         return _FindResultBatched(documents=result_das, scores=distances)
 
-    def _find(self, query: np.ndarray, search_field: str, limit: int) -> _FindResult:
+    def _find(
+        self, query: np.ndarray, limit: int, search_field: str = ''
+    ) -> _FindResult:
         query_batched = np.expand_dims(query, axis=0)
-        docs, scores = self._find_batched(query_batched, search_field, limit)
+        docs, scores = self._find_batched(
+            query=query_batched, limit=limit, search_field=search_field
+        )
         return _FindResult(documents=docs[0], scores=scores[0])
 
     def _filter(
@@ -257,16 +261,16 @@ class HnswDocumentIndex(BaseDocumentIndex, Generic[TSchema]):
     def _text_search(
         self,
         query: str,
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResult:
         raise NotImplementedError(f'{type(self)} does not support text search.')
 
     def _text_search_batched(
         self,
         queries: Sequence[str],
-        search_field: str,
         limit: int,
+        search_field: str = '',
     ) -> _FindResultBatched:
         raise NotImplementedError(f'{type(self)} does not support text search.')
 


### PR DESCRIPTION
Goals:

- this PR closes https://github.com/docarray/docarray/issues/1243 by making default search_field to empty string
- this PR updates iSort version because I had issues with current version when checking recommit hooks
- 
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
