### PR TITLE
refactor: avoid shadowing filter

### DIFF
--- a/docarray/doc_index/backends/hnswlib_doc_index.py
+++ b/docarray/doc_index/backends/hnswlib_doc_index.py
@@ -30,7 +30,7 @@ from docarray.doc_index.abstract_doc_index import (
     _raise_not_supported,
 )
 from docarray.proto import DocumentProto
-from docarray.utils.filter import filter as da_filter
+from docarray.utils.filter import filter_docs
 from docarray.utils.find import _FindResult
 from docarray.utils.misc import is_np_int, torch_imported
 
@@ -201,7 +201,7 @@ class HnswDocumentIndex(BaseDocumentIndex, Generic[TSchema]):
             da_cls = DocumentArray.__class_getitem__(
                 cast(Type[BaseDocument], self._schema)
             )
-            docs_filtered = da_cls(da_filter(docs_filtered, cond))
+            docs_filtered = da_cls(filter_docs(docs_filtered, cond))
 
         docs_and_scores = zip(
             docs_filtered, (doc_to_score[doc.id] for doc in docs_filtered)

--- a/docarray/utils/filter.py
+++ b/docarray/utils/filter.py
@@ -5,7 +5,7 @@ from docarray.array.abstract_array import AnyDocumentArray
 from docarray.array.array.array import DocumentArray
 
 
-def filter(
+def filter_docs(
     docs: AnyDocumentArray,
     query: Union[str, Dict, List[Dict]],
 ) -> AnyDocumentArray:
@@ -19,7 +19,7 @@ def filter(
 
         from docarray import DocumentArray, BaseDocument
         from docarray.documents import Text, Image
-        from docarray.util.filter import filter
+        from docarray.util.filter import filter_docs
 
 
         class MyDocument(BaseDocument):
@@ -52,7 +52,7 @@ def filter(
             }
         }
 
-        results = filter(docs, query)
+        results = filter_docs(docs, query)
         assert len(results) == 1
         assert results[0].price == 30
         assert results[0].caption == 'A couple birdwatching with binoculars'

--- a/docarray/utils/map.py
+++ b/docarray/utils/map.py
@@ -138,6 +138,7 @@ def map_docs_batch(
 
         ['MY ORANGE CAT', 'MY ORANGE CAT', 'MY ORANGE CAT']
 
+    :param da: DocumentArray to apply function to
     :param batch_size: Size of each generated batch (except the last one, which might
         be smaller).
     :param shuffle: If set, shuffle the Documents before dividing into minibatches.

--- a/tests/units/util/test_filter.py
+++ b/tests/units/util/test_filter.py
@@ -5,7 +5,7 @@ import pytest
 
 from docarray import BaseDocument, DocumentArray
 from docarray.documents import ImageDoc, TextDoc
-from docarray.utils.filter import filter
+from docarray.utils.filter import filter_docs
 
 
 class MMDoc(BaseDocument):
@@ -53,16 +53,16 @@ def docs():
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_empty_filter(docs, dict_api):
     q = {} if dict_api else '{}'
-    result = filter(docs, q)
+    result = filter_docs(docs, q)
     assert len(result) == len(docs)
 
 
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_simple_filter(docs, dict_api):
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
 
     result = method({'text': {'$eq': 'Text of Document 1'}})
     assert len(result) == 1
@@ -130,9 +130,9 @@ def test_simple_filter(docs, dict_api):
 def test_nested_filter(docs, dict_api):
 
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
 
     result = method({'dictionary__a': {'$eq': 0}})
     assert len(result) == 2
@@ -159,9 +159,9 @@ def test_nested_filter(docs, dict_api):
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_array_simple_filters(docs, dict_api):
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
 
     # SIZE DOES NOT SEEM TO WORK
     result = method({'sub_docs': {'$size': 2}})
@@ -181,9 +181,9 @@ def test_placehold_filter(dict_api):
     )
 
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
 
     # DOES NOT SEEM TO WORK
     result = method({'text': {'$eq': '{text_doc}'}})
@@ -196,9 +196,9 @@ def test_placehold_filter(dict_api):
 @pytest.mark.parametrize('dict_api', [True, False])
 def test_logic_filter(docs, dict_api):
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
     result = method(
         {
             '$or': {
@@ -279,9 +279,9 @@ def test_from_docstring(dict_api):
     }
 
     if dict_api:
-        method = lambda query: filter(docs, query)  # noqa: E731
+        method = lambda query: filter_docs(docs, query)  # noqa: E731
     else:
-        method = lambda query: filter(docs, json.dumps(query))  # noqa: E731
+        method = lambda query: filter_docs(docs, json.dumps(query))  # noqa: E731
 
     results = method(query)
     assert len(results) == 1


### PR DESCRIPTION
Our `filter()` function shadows the built-in filter function. For map it was the same case, here we renamed it from `map()` to `map_docs()`. Same we want to do for `filter()`.

- [x] refactor to `filter_docs()`
- [x] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
