### PR TITLE
fix: disable pycharm da property detection

### DIFF
--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -102,7 +102,7 @@ class AnyDocumentArray(Sequence[T_doc], Generic[T_doc], AbstractType):
     def __getattr__(self, item: str):
         # Needs to be explicitly defined here for the purpose to disable PyCharm's complaints
         # about not detected properties: https://youtrack.jetbrains.com/issue/PY-47991
-        return super().__getattr__(item)
+        return super().__getattribute__(item)
 
     @abstractmethod
     def _get_data_column(


### PR DESCRIPTION
Goals:

PyCharm does currently not detect properties from DocumentArray and complains with `Unresolved attribute reference 'title' for class 'DocumentArray'`:

<img width="652" alt="image" src="https://user-images.githubusercontent.com/73693835/226612171-3d57cf5a-5d57-4eea-a53b-777284d06f2c.png">


For now, we want to silence the error message from pycharm. This can be done by simply implementing `__getattr__()` in DocumentArray as described [here](https://youtrack.jetbrains.com/issue/PY-47991).

- [ ] add `__getattr__()`
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
