### PR TITLE
refactor(da): remove tensor type from `DocumentArray` init

### DIFF
--- a/docarray/array/abstract_array.py
+++ b/docarray/array/abstract_array.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from docarray.base_document import BaseDocument
 from docarray.display.document_array_summary import DocumentArraySummary
-from docarray.typing import NdArray
 from docarray.typing.abstract_type import AbstractType
 from docarray.utils._typing import change_cls_name
 
@@ -36,7 +35,6 @@ IndexIterType = Union[slice, Iterable[int], Iterable[bool], None]
 
 class AnyDocumentArray(Sequence[T_doc], Generic[T_doc], AbstractType):
     document_type: Type[BaseDocument]
-    tensor_type: Type['AbstractTensor'] = NdArray
     __typed_da__: Dict[Type['AnyDocumentArray'], Dict[Type[BaseDocument], Type]] = {}
 
     def __repr__(self):

--- a/docarray/array/array/array.py
+++ b/docarray/array/array/array.py
@@ -248,8 +248,8 @@ class DocumentArray(
         """
         Convert the DocumentArray into a DocumentArrayStacked. `Self` cannot be used
         afterwards
-        :param tensor_type: TensorClass used to wrap the tensors of the Documents when
-        stacked
+        :param tensor_type: Tensor Class used to wrap the stacked tensors. This is usefull
+        if the BaseDocument has some undefined tensor type like AnyTensor or Union of NdArray and TorchTensor
         :return: A DocumentArrayStacked of the same document type as self
         """
         from docarray.array.stacked.array_stacked import DocumentArrayStacked

--- a/docarray/array/array/array.py
+++ b/docarray/array/array/array.py
@@ -117,7 +117,6 @@ class DocumentArray(
         del da[0:5]  # remove elements for 0 to 5 from DocumentArray
 
     :param docs: iterable of Document
-    :param tensor_type: Class used to wrap the tensors of the Documents when stacked
 
     """
 
@@ -126,27 +125,22 @@ class DocumentArray(
     def __init__(
         self,
         docs: Optional[Iterable[T_doc]] = None,
-        tensor_type: Type['AbstractTensor'] = NdArray,
     ):
         self._data: List[T_doc] = list(self._validate_docs(docs)) if docs else []
-        self.tensor_type = tensor_type
 
     @classmethod
     def construct(
         cls: Type[T],
         docs: Sequence[T_doc],
-        tensor_type: Type['AbstractTensor'] = NdArray,
     ) -> T:
         """
         Create a DocumentArray without validation any data. The data must come from a
         trusted source
         :param docs: a Sequence (list) of Document with the same schema
-        :param tensor_type: Class used to wrap the tensors of the Documents when stacked
         :return:
         """
         da = cls.__new__(cls)
         da._data = docs if isinstance(docs, list) else list(docs)
-        da.tensor_type = tensor_type
         return da
 
     def _validate_docs(self, docs: Iterable[T_doc]) -> Iterable[T_doc]:
@@ -227,7 +221,7 @@ class DocumentArray(
             # most likely a bug in mypy though
             # bug reported here https://github.com/python/mypy/issues/14111
             return DocumentArray.__class_getitem__(field_type)(
-                (getattr(doc, field) for doc in self), tensor_type=self.tensor_type
+                (getattr(doc, field) for doc in self),
             )
         else:
             return [getattr(doc, field) for doc in self]
@@ -247,15 +241,21 @@ class DocumentArray(
         for doc, value in zip(self, values):
             setattr(doc, field, value)
 
-    def stack(self) -> 'DocumentArrayStacked':
+    def stack(
+        self,
+        tensor_type: Type['AbstractTensor'] = NdArray,
+    ) -> 'DocumentArrayStacked':
         """
         Convert the DocumentArray into a DocumentArrayStacked. `Self` cannot be used
         afterwards
+        :param tensor_type: TensorClass used to wrap the tensors of the Documents when
+        stacked
+        :return: A DocumentArrayStacked of the same document type as self
         """
         from docarray.array.stacked.array_stacked import DocumentArrayStacked
 
         return DocumentArrayStacked.__class_getitem__(self.document_type)(
-            self, tensor_type=self.tensor_type
+            self, tensor_type=tensor_type
         )
 
     @classmethod

--- a/docarray/array/array/array.py
+++ b/docarray/array/array/array.py
@@ -248,7 +248,7 @@ class DocumentArray(
         """
         Convert the DocumentArray into a DocumentArrayStacked. `Self` cannot be used
         afterwards
-        :param tensor_type: Tensor Class used to wrap the stacked tensors. This is usefull
+        :param tensor_type: Tensor Class used to wrap the stacked tensors. This is useful
         if the BaseDocument has some undefined tensor type like AnyTensor or Union of NdArray and TorchTensor
         :return: A DocumentArrayStacked of the same document type as self
         """

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -323,7 +323,9 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
                     f'{value} schema : {value.document_type} is not compatible with '
                     f'this DocumentArrayStacked schema : {self.document_type}'
                 )
-            processed_value = cast(T, value.stack())  # we need to copy data here
+            processed_value = cast(
+                T, value.stack(tensor_type=self.tensor_type)
+            )  # we need to copy data here
 
         elif isinstance(value, DocumentArrayStacked):
             if not issubclass(value.document_type, self.document_type):

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -158,12 +158,17 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
                         cast(AbstractTensor, tensor_columns[field_name])[i] = val
 
                 elif issubclass(field_type, BaseDocument):
-                    doc_columns[field_name] = getattr(docs, field_name).stack()
+                    doc_columns[field_name] = getattr(docs, field_name).stack(
+                        tensor_type=self.tensor_type
+                    )
 
-                elif issubclass(field_type, DocumentArray):
+                elif issubclass(field_type, AnyDocumentArray):
                     docs_list = list()
                     for doc in docs:
-                        docs_list.append(getattr(doc, field_name).stack())
+                        da = getattr(doc, field_name)
+                        if isinstance(da, DocumentArray):
+                            da = da.stack(tensor_type=self.tensor_type)
+                        docs_list.append(da)
                     da_columns[field_name] = ListAdvancedIndexing(docs_list)
                 else:
                     any_columns[field_name] = ListAdvancedIndexing(
@@ -507,9 +512,7 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
 
         del self._storage
 
-        return DocumentArray.__class_getitem__(self.document_type).construct(
-            docs, tensor_type=self.tensor_type
-        )
+        return DocumentArray.__class_getitem__(self.document_type).construct(docs)
 
     def traverse_flat(
         self,

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -82,7 +82,7 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
      numpy/PyTorch.
 
     :param docs: a DocumentArray
-    :param tensor_type: Tensor Class used to wrap the stacked tensors. This is usefull
+    :param tensor_type: Tensor Class used to wrap the stacked tensors. This is useful
     if the BaseDocument of this DocumentArrayStacked has some undefined tensor type like
     AnyTensor or Union of NdArray and TorchTensor
     """

--- a/docarray/array/stacked/array_stacked.py
+++ b/docarray/array/stacked/array_stacked.py
@@ -82,8 +82,9 @@ class DocumentArrayStacked(AnyDocumentArray[T_doc]):
      numpy/PyTorch.
 
     :param docs: a DocumentArray
-    :param tensor_type: Class used to wrap the stacked tensors
-
+    :param tensor_type: Tensor Class used to wrap the stacked tensors. This is usefull
+    if the BaseDocument of this DocumentArrayStacked has some undefined tensor type like
+    AnyTensor or Union of NdArray and TorchTensor
     """
 
     document_type: Type[T_doc]

--- a/docarray/data/torch_dataset.py
+++ b/docarray/data/torch_dataset.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, Generic, List, Optional, Type, TypeVar
 
 from torch.utils.data import Dataset
 
-from docarray import BaseDocument, DocumentArray
+from docarray import BaseDocument, DocumentArray, DocumentArrayStacked
 from docarray.typing import TorchTensor
 from docarray.utils._typing import change_cls_name
 
@@ -123,13 +123,13 @@ class MultiModalDataset(Dataset, Generic[T_doc]):
     def collate_fn(cls, batch: List[T_doc]):
         doc_type = cls.document_type
         if doc_type:
-            batch_da = DocumentArray[doc_type](  # type: ignore
+            batch_da = DocumentArrayStacked[doc_type](  # type: ignore
                 batch,
                 tensor_type=TorchTensor,
             )
         else:
-            batch_da = DocumentArray(batch, tensor_type=TorchTensor)
-        return batch_da.stack()
+            batch_da = DocumentArrayStacked(batch, tensor_type=TorchTensor)
+        return batch_da
 
     @classmethod
     def __class_getitem__(cls, item: Type[BaseDocument]) -> Type['MultiModalDataset']:

--- a/tests/units/array/test_indexing.py
+++ b/tests/units/array/test_indexing.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import torch
 
-from docarray import DocumentArray
+from docarray import DocumentArray, DocumentArrayStacked
 from docarray.documents import TextDoc
 from docarray.typing import TorchTensor
 
@@ -13,7 +13,6 @@ def da():
     tensors = [torch.ones((4,)) * i for i in range(10)]
     return DocumentArray[TextDoc](
         [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
-        tensor_type=TorchTensor,
     )
 
 
@@ -23,7 +22,6 @@ def da_to_set():
     tensors = [torch.ones((4,)) * i * 2 for i in range(5)]
     return DocumentArray[TextDoc](
         [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
-        tensor_type=TorchTensor,
     )
 
 
@@ -35,7 +33,7 @@ def da_to_set():
 @pytest.mark.parametrize('stack', [True, False])
 def test_simple_getitem(stack, da):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     assert torch.all(da[0].embedding == torch.zeros((4,)))
     assert da[0].text == 'hello 0'
@@ -44,7 +42,7 @@ def test_simple_getitem(stack, da):
 @pytest.mark.parametrize('stack', [True, False])
 def test_get_none(stack, da):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     assert da[None] is da
 
@@ -53,7 +51,7 @@ def test_get_none(stack, da):
 @pytest.mark.parametrize('index', [(1, 2, 3, 4, 6), [1, 2, 3, 4, 6]])
 def test_iterable_getitem(stack, da, index):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     indexed_da = da[index]
 
@@ -66,7 +64,7 @@ def test_iterable_getitem(stack, da, index):
 @pytest.mark.parametrize('index_dtype', [torch.int64])
 def test_torchtensor_getitem(stack, da, index_dtype):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     index = torch.tensor([1, 2, 3, 4, 6], dtype=index_dtype)
 
@@ -81,7 +79,7 @@ def test_torchtensor_getitem(stack, da, index_dtype):
 @pytest.mark.parametrize('index_dtype', [int, np.int_, np.int32, np.int64])
 def test_nparray_getitem(stack, da, index_dtype):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     index = np.array([1, 2, 3, 4, 6], dtype=index_dtype)
 
@@ -103,7 +101,7 @@ def test_nparray_getitem(stack, da, index_dtype):
 )
 def test_boolmask_getitem(stack, da, index):
     if stack:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     indexed_da = da[index]
 
@@ -122,7 +120,7 @@ def test_boolmask_getitem(stack, da, index):
 @pytest.mark.parametrize('stack_left', [True, False])
 def test_simple_setitem(stack_left, da, da_to_set):
     if stack_left:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
 
     da[0] = da_to_set[0]
 
@@ -135,9 +133,9 @@ def test_simple_setitem(stack_left, da, da_to_set):
 @pytest.mark.parametrize('index', [(1, 2, 3, 4, 6), [1, 2, 3, 4, 6]])
 def test_iterable_setitem(stack_left, stack_right, da, da_to_set, index):
     if stack_left:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
     if stack_right:
-        da_to_set = da_to_set.stack()
+        da_to_set = da_to_set.stack(tensor_type=TorchTensor)
 
     da[index] = da_to_set
 
@@ -158,9 +156,9 @@ def test_iterable_setitem(stack_left, stack_right, da, da_to_set, index):
 @pytest.mark.parametrize('index_dtype', [torch.int64])
 def test_torchtensor_setitem(stack_left, stack_right, da, da_to_set, index_dtype):
     if stack_left:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
     if stack_right:
-        da_to_set = da_to_set.stack()
+        da_to_set = da_to_set.stack(tensor_type=TorchTensor)
 
     index = torch.tensor([1, 2, 3, 4, 6], dtype=index_dtype)
 
@@ -183,9 +181,9 @@ def test_torchtensor_setitem(stack_left, stack_right, da, da_to_set, index_dtype
 @pytest.mark.parametrize('index_dtype', [int, np.int_, np.int32, np.int64])
 def test_nparray_setitem(stack_left, stack_right, da, da_to_set, index_dtype):
     if stack_left:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
     if stack_right:
-        da_to_set = da_to_set.stack()
+        da_to_set = da_to_set.stack(tensor_type=TorchTensor)
 
     index = np.array([1, 2, 3, 4, 6], dtype=index_dtype)
 
@@ -216,9 +214,9 @@ def test_nparray_setitem(stack_left, stack_right, da, da_to_set, index_dtype):
 )
 def test_boolmask_setitem(stack_left, stack_right, da, da_to_set, index):
     if stack_left:
-        da = da.stack()
+        da = da.stack(tensor_type=TorchTensor)
     if stack_right:
-        da_to_set = da_to_set.stack()
+        da_to_set = da_to_set.stack(tensor_type=TorchTensor)
 
     da[index] = da_to_set
 
@@ -238,10 +236,10 @@ def test_boolmask_setitem(stack_left, stack_right, da, da_to_set, index):
 def test_setitem_update_column():
     texts = [f'hello {i}' for i in range(10)]
     tensors = [torch.ones((4,)) * (i + 1) for i in range(10)]
-    da = DocumentArray[TextDoc](
+    da = DocumentArrayStacked[TextDoc](
         [TextDoc(text=text, embedding=tens) for text, tens in zip(texts, tensors)],
         tensor_type=TorchTensor,
-    ).stack()
+    )
 
     da[0] = TextDoc(text='hello', embedding=torch.zeros((4,)))
 


### PR DESCRIPTION
# Context


This pr removes the `tensor_type` argument from `DocumentArray` init and put it rather at the `da.stack(tensor_type=TorchTensor)` level.

Indeed this argument is only relevant for `DocumentArrayStacked` and was used inside `DocumentArray` only when the stack method was called
