### PR TITLE
fix: bytes type in `TextDoc` and `VideoDoc`

### DIFF
--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -98,9 +98,9 @@ class TextDoc(BaseDocument):
         doc == doc2  # False, their ids are not equivalent
     """
 
-    text: Optional[str] = None
-    url: Optional[TextUrl] = None
-    embedding: Optional[AnyEmbedding] = None
+    text: Optional[str]
+    url: Optional[TextUrl]
+    embedding: Optional[AnyEmbedding]
     bytes: Optional[bytes]
 
     def __init__(self, text: Optional[str] = None, **kwargs):

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -43,6 +43,7 @@ class TextDoc(BaseDocument):
         from docarray.typing import AnyEmbedding
         from typing import Optional
 
+
         # extend it
         class MyText(Text):
             second_embedding: Optional[AnyEmbedding]
@@ -61,6 +62,7 @@ class TextDoc(BaseDocument):
 
         from docarray import BaseDocument
         from docarray.documents import ImageDoc, TextDoc
+
 
         # compose it
         class MultiModalDoc(BaseDocument):
@@ -99,7 +101,7 @@ class TextDoc(BaseDocument):
     text: Optional[str] = None
     url: Optional[TextUrl] = None
     embedding: Optional[AnyEmbedding] = None
-    bytes: Optional[bytes] = None
+    bytes: Optional[bytes]
 
     def __init__(self, text: Optional[str] = None, **kwargs):
         if 'text' not in kwargs:

--- a/docarray/documents/video.py
+++ b/docarray/documents/video.py
@@ -102,7 +102,7 @@ class VideoDoc(BaseDocument):
     tensor: Optional[VideoTensor]
     key_frame_indices: Optional[AnyTensor]
     embedding: Optional[AnyEmbedding]
-    bytes: Optional[bytes] = None
+    bytes: Optional[bytes]
 
     @classmethod
     def validate(


### PR DESCRIPTION
There is a bug related to the type of the `bytes` field in the predefined Documents, such as TextDoc.
The bytes field is of type `Optional[bytes]`, but when looking at `TextDoc.__fields__['bytes'].type_` it equals 'None' instead of `Optional[bytes]`

Because of this, the following fails:
```python
from docarray import DocumentArray
from docarray.documents import TextDoc, VideoDoc

da = DocumentArray[TextDoc]([TextDoc()])
for name, value in TextDoc.__fields__.items():
    print(f"name, type = {name, value.type_}")
da.summary()  # fails

da = DocumentArray[VideoDoc]([VideoDoc()])
da.summary()  # fails
```

```
name, type = ('id', <class 'docarray.typing.id.ID'>)
name, type = ('text', <class 'str'>)
name, type = ('url', <class 'docarray.typing.url.text_url.TextUrl'>)
name, type = ('embedding', typing.Union[docarray.typing.tensor.embedding.ndarray.NdArrayEmbedding, docarray.typing.tensor.embedding.torch.TorchEmbedding, docarray.typing.tensor.embedding.tensorflow.TensorFlowEmbedding, NoneType])
name, type = ('bytes', <class 'NoneType'>)  # <----------------------- NoneType instead of bytes!

╭─────── DocumentArray Summary ────────╮
│                                      │
│   Type     DocumentArray[VideoDoc]   │
│   Length   1                         │
│                                      │
╰──────────────────────────────────────╯
Traceback (most recent call last):
  File "/Users/charlottegerhaher/Library/Application Support/JetBrains/PyCharm2022.2/scratches/scratch_71.py", line 66, in <module>
    da.summary()
  File "/Users/charlottegerhaher/Desktop/jina-ai/docarray_v2/docarray/docarray/array/abstract_array.py", line 276, in summary
    DocumentArraySummary(self).summary()
  File "/Users/charlottegerhaher/Desktop/jina-ai/docarray_v2/docarray/docarray/display/document_array_summary.py", line 54, in summary
    self.da.document_type.schema_summary()
  File "/Users/charlottegerhaher/Desktop/jina-ai/docarray_v2/docarray/docarray/base_document/document.py", line 71, in schema_summary
    DocumentSummary.schema_summary(cls)
  File "/Users/charlottegerhaher/Desktop/jina-ai/docarray_v2/docarray/docarray/display/document_summary.py", line 41, in schema_summary
    DocumentSummary._get_schema(cls),
  File "/Users/charlottegerhaher/Desktop/jina-ai/docarray_v2/docarray/docarray/display/document_summary.py", line 76, in _get_schema
    for arg in field_type.__args__:
AttributeError: type object 'NoneType' has no attribute '__args__'

```


This can be solved by removing the ` = None` default for `TextDoc` and `VideoDoc`. Since they are optional, there default stays None, even without explicitly stating it.

I removed all other `= None` defaults to to keep it coherent, since sometimes this was explicitly stated, sometimes not.
- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
