### PR TITLE
fix: hnswlib doc index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Test
         id: test
         run: |
-          poetry run pytest -m 'index' tests
+          poetry run pytest -m 'index and (not tensorflow)' tests
         timeout-minutes: 30
 
   docarray-test-tensorflow:

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -37,7 +37,7 @@ if torch_imported:
     import torch
 
 if is_tf_available():
-    import tensorflow as tf
+    import tensorflow as tf  # type: ignore
 
     from docarray.typing import TensorFlowTensor
 

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -844,7 +844,7 @@ class BaseDocumentIndex(ABC, Generic[TSchema]):
         """
 
         for field_name, _ in schema.__fields__.items():
-            t_ = schema._get_field_type(field_name)
+            t_ = unwrap_optional_type(schema._get_field_type(field_name))
             if issubclass(t_, BaseDocument):
                 inner_dict = {}
 

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -43,7 +43,7 @@ if is_torch_available():
     HNSWLIB_PY_VEC_TYPES.append(torch.Tensor)
 
 if is_tf_available():
-    import tensorflow as tf
+    import tensorflow as tf  # type: ignore
 
     from docarray.typing import TensorFlowTensor
 

--- a/docarray/utils/_typing.py
+++ b/docarray/utils/_typing.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from typing_inspect import get_args, is_union_type
+from typing_inspect import get_args, is_optional_type, is_union_type
 
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
@@ -32,3 +32,17 @@ def change_cls_name(cls: type, new_name: str, scope: Optional[dict] = None) -> N
         scope[new_name] = cls
     cls.__qualname__ = cls.__qualname__[: -len(cls.__name__)] + new_name
     cls.__name__ = new_name
+
+
+def unwrap_optional_type(type_: Any) -> Any:
+    """Return the type of an Optional type, e.g. `unwrap_optional(Optional[str]) == str`;
+    `unwrap_optional(Union[None, int, None]) == int`.
+
+    :param type_: the type to unwrap
+    :return: the "core" type of an Optional type
+    """
+    if not is_optional_type(type_):
+        return type_
+    for arg in get_args(type_):
+        if arg is not type(None):
+            return arg

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -80,7 +80,7 @@ def test_find_torch(tmp_path, space):
 
 
 @pytest.mark.tensorflow
-def test_find_tensorflow(tmp_path, space):
+def test_find_tensorflow(tmp_path):
     from docarray.typing import TensorFlowTensor
 
     class TfDoc(BaseDocument):

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -79,8 +79,8 @@ def test_find_torch(tmp_path, space):
         assert torch.allclose(result.tens, torch.zeros(10, dtype=torch.float64))
 
 
-@pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
 @pytest.mark.tensorflow
+@pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
 def test_find_tensorflow(tmp_path, space):
     from docarray.typing import TensorFlowTensor
 

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -80,7 +80,6 @@ def test_find_torch(tmp_path, space):
 
 
 @pytest.mark.tensorflow
-@pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
 def test_find_tensorflow(tmp_path, space):
     from docarray.typing import TensorFlowTensor
 

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
+import torch
 from pydantic import Field
 
 from docarray import BaseDocument
 from docarray.index import HnswDocumentIndex
-from docarray.typing import NdArray
+from docarray.typing import NdArray, TensorFlowTensor, TorchTensor
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -24,6 +25,14 @@ class NestedDoc(BaseDocument):
 
 class DeepNestedDoc(BaseDocument):
     d: NestedDoc
+
+
+class TorchDoc(BaseDocument):
+    tens: TorchTensor[10]
+
+
+class TfDoc(BaseDocument):
+    tens: TensorFlowTensor[10]
 
 
 @pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
@@ -47,6 +56,58 @@ def test_find_simple_schema(tmp_path, space):
     assert np.allclose(docs[0].tens, index_docs[-1].tens)
     for result in docs[1:]:
         assert np.allclose(result.tens, np.zeros(10))
+
+
+@pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
+def test_find_torch(tmp_path, space):
+    store = HnswDocumentIndex[TorchDoc](work_dir=str(tmp_path))
+
+    index_docs = [TorchDoc(tens=np.zeros(10)) for _ in range(10)]
+    index_docs.append(TorchDoc(tens=np.ones(10)))
+    store.index(index_docs)
+
+    for doc in index_docs:
+        assert isinstance(doc.tens, TorchTensor)
+
+    query = TorchDoc(tens=np.ones(10))
+
+    result_docs, scores = store.find(query, search_field='tens', limit=5)
+
+    assert len(result_docs) == 5
+    assert len(scores) == 5
+    for doc in result_docs:
+        assert isinstance(doc.tens, TorchTensor)
+    assert result_docs[0].id == index_docs[-1].id
+    assert torch.allclose(result_docs[0].tens, index_docs[-1].tens)
+    for result in result_docs[1:]:
+        assert torch.allclose(result.tens, torch.zeros(10, dtype=torch.float64))
+
+
+@pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
+def test_find_tensorflow(tmp_path, space):
+    store = HnswDocumentIndex[TfDoc](work_dir=str(tmp_path))
+
+    index_docs = [TfDoc(tens=np.zeros(10)) for _ in range(10)]
+    index_docs.append(TfDoc(tens=np.ones(10)))
+    store.index(index_docs)
+
+    for doc in index_docs:
+        assert isinstance(doc.tens, TensorFlowTensor)
+
+    query = TfDoc(tens=np.ones(10))
+
+    result_docs, scores = store.find(query, search_field='tens', limit=5)
+
+    assert len(result_docs) == 5
+    assert len(scores) == 5
+    for doc in result_docs:
+        assert isinstance(doc.tens, TensorFlowTensor)
+    assert result_docs[0].id == index_docs[-1].id
+    assert np.allclose(
+        result_docs[0].tens.unwrap().numpy(), index_docs[-1].tens.unwrap().numpy()
+    )
+    for result in result_docs[1:]:
+        assert np.allclose(result.tens.unwrap().numpy(), np.zeros(10))
 
 
 @pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 from docarray import BaseDocument
 from docarray.index import HnswDocumentIndex
-from docarray.typing import NdArray, TensorFlowTensor, TorchTensor
+from docarray.typing import NdArray, TorchTensor
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -29,10 +29,6 @@ class DeepNestedDoc(BaseDocument):
 
 class TorchDoc(BaseDocument):
     tens: TorchTensor[10]
-
-
-class TfDoc(BaseDocument):
-    tens: TensorFlowTensor[10]
 
 
 @pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
@@ -84,7 +80,13 @@ def test_find_torch(tmp_path, space):
 
 
 @pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
+@pytest.mark.tensorflow
 def test_find_tensorflow(tmp_path, space):
+    from docarray.typing import TensorFlowTensor
+
+    class TfDoc(BaseDocument):
+        tens: TensorFlowTensor[10]
+
     store = HnswDocumentIndex[TfDoc](work_dir=str(tmp_path))
 
     index_docs = [TfDoc(tens=np.zeros(10)) for _ in range(10)]

--- a/tests/index/hnswlib/test_index_get_del.py
+++ b/tests/index/hnswlib/test_index_get_del.py
@@ -9,7 +9,7 @@ from pydantic import Field
 from docarray import BaseDocument, DocumentArray
 from docarray.documents import ImageDoc, TextDoc
 from docarray.index import HnswDocumentIndex
-from docarray.typing import NdArray, NdArrayEmbedding, TensorFlowTensor, TorchTensor
+from docarray.typing import NdArray, NdArrayEmbedding, TorchTensor
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -33,10 +33,6 @@ class DeepNestedDoc(BaseDocument):
 
 class TorchDoc(BaseDocument):
     tens: TorchTensor[10]
-
-
-class TfDoc(BaseDocument):
-    tens: TensorFlowTensor[10]
 
 
 @pytest.fixture
@@ -114,7 +110,13 @@ def test_index_torch(tmp_path):
         assert index.get_current_count() == 10
 
 
+@pytest.mark.tensorflow
 def test_index_tf(tmp_path):
+    from docarray.typing import TensorFlowTensor
+
+    class TfDoc(BaseDocument):
+        tens: TensorFlowTensor[10]
+
     docs = [TfDoc(tens=np.random.randn(10)) for _ in range(10)]
     # assert isinstance(docs[0].tens, torch.Tensor)
     assert isinstance(docs[0].tens, TensorFlowTensor)

--- a/tests/index/hnswlib/test_persist_data.py
+++ b/tests/index/hnswlib/test_persist_data.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+from pydantic import Field
+
+from docarray import BaseDocument
+from docarray.index import HnswDocumentIndex
+from docarray.typing import NdArray
+
+pytestmark = [pytest.mark.slow, pytest.mark.index]
+
+
+class SimpleDoc(BaseDocument):
+    tens: NdArray[10] = Field(dim=1000)
+
+
+class NestedDoc(BaseDocument):
+    d: SimpleDoc
+    tens: NdArray[50]
+
+
+def test_persist_and_restore(tmp_path):
+    query = SimpleDoc(tens=np.random.random((10,)))
+
+    # create index
+    store = HnswDocumentIndex[SimpleDoc](work_dir=str(tmp_path))
+    store.index([SimpleDoc(tens=np.random.random((10,))) for _ in range(10)])
+    assert store.num_docs() == 10
+    find_results_before = store.find(query, search_field='tens', limit=5)
+
+    # delete and restore
+    del store
+    store = HnswDocumentIndex[SimpleDoc](work_dir=str(tmp_path))
+    assert store.num_docs() == 10
+    find_results_after = store.find(query, search_field='tens', limit=5)
+    for doc_before, doc_after in zip(find_results_before[0], find_results_after[0]):
+        assert doc_before.id == doc_after.id
+        assert (doc_before.tens == doc_after.tens).all()
+
+    # add new data
+    store.index([SimpleDoc(tens=np.random.random((10,))) for _ in range(5)])
+    assert store.num_docs() == 15
+
+
+def test_persist_and_restore_nested(tmp_path):
+    query = NestedDoc(
+        tens=np.random.random((50,)), d=SimpleDoc(tens=np.random.random((10,)))
+    )
+
+    # create index
+    store = HnswDocumentIndex[NestedDoc](work_dir=str(tmp_path))
+    store.index(
+        [
+            NestedDoc(
+                tens=np.random.random((50,)), d=SimpleDoc(tens=np.random.random((10,)))
+            )
+            for _ in range(10)
+        ]
+    )
+    assert store.num_docs() == 10
+    find_results_before = store.find(query, search_field='d__tens', limit=5)
+
+    # delete and restore
+    del store
+    store = HnswDocumentIndex[NestedDoc](work_dir=str(tmp_path))
+    assert store.num_docs() == 10
+    find_results_after = store.find(query, search_field='d__tens', limit=5)
+    for doc_before, doc_after in zip(find_results_before[0], find_results_after[0]):
+        assert doc_before.id == doc_after.id
+        assert (doc_before.tens == doc_after.tens).all()
+
+    # delete and restore
+    store.index(
+        [
+            NestedDoc(
+                tens=np.random.random((50,)), d=SimpleDoc(tens=np.random.random((10,)))
+            )
+            for _ in range(5)
+        ]
+    )
+    assert store.num_docs() == 15


### PR DESCRIPTION
Goals:

This fixes the following things in HNSWLibIndex:
- [x] support for torch and tf as index tensors
- [x] allow tensors that are not indexed (e.g. image tensors)
- [x] support for arbitrary python types as "payload"
- [ ] add more configurations and options, and test them
- [ ] more testing
