### PR TITLE
fix: proto ser and deser for nested tuple/dict/list

### DIFF
--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -255,6 +255,10 @@ class IOMixin(Iterable[Tuple[str, Any]]):
                 getattr(value, content_key)
             )
         elif content_key in ['document', 'document_array']:
+            if field_name is None:
+                raise ValueError(
+                    'field_name cannot be None when trying to deseriliaze a Document or a DocumentArray'
+                )
             return_field = cls._get_field_type(field_name).from_protobuf(
                 getattr(value, content_key)
             )  # we get to the parent class
@@ -278,10 +282,10 @@ class IOMixin(Iterable[Tuple[str, Any]]):
                 )
 
             elif content_key == 'dict':
-                return_field: Dict[str, Any] = dict()
+                deser_dict: Dict[str, Any] = dict()
                 for key_name, node in value.dict.data.items():
-                    return_field[key_name] = cls._get_content_from_node_proto(node)
-
+                    deser_dict[key_name] = cls._get_content_from_node_proto(node)
+                return_field = deser_dict
             else:
                 raise ValueError(
                     f'key {content_key} is not supported for deserialization'

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -66,6 +66,7 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
         nested_item = value._to_node_protobuf()
         return nested_item
 
+    base_node_wrap: BaseNode
     if torch_available:
         if isinstance(value, torch.Tensor):
             base_node_wrap = TorchTensor._docarray_from_native(value)

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -18,6 +18,7 @@ import numpy as np
 from typing_inspect import is_union_type
 
 from docarray.base_document.base_node import BaseNode
+from docarray.typing import NdArray
 from docarray.typing.proto_register import _PROTO_TYPE_NAME_TO_CLASS
 from docarray.utils.compress import _compress_bytes, _decompress_bytes
 from docarray.utils.misc import is_tf_available, is_torch_available
@@ -32,7 +33,7 @@ torch_available = is_torch_available()
 if torch_available:
     import torch
 
-    from docarray.typing import NdArray, TorchTensor
+    from docarray.typing import TorchTensor
 
 if TYPE_CHECKING:
     from pydantic.fields import ModelField

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -66,10 +66,14 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
                 return nested_item
 
         if isinstance(value, dict):
-            from google.protobuf.struct_pb2 import Struct
+            from docarray.proto import DictOfAnyProto
 
-            struct = Struct()
-            struct.update(value)
+            data = {}
+
+            for key, content in value.items():
+                data[key] = _type_to_protobuf(content)
+
+            struct = DictOfAnyProto(data=data)
             nested_item = NodeProto(dict=struct)
 
         elif value is None:

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -36,59 +36,57 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
     """
     from docarray.proto import NodeProto
 
+    basic_type_to_key = {
+        str: 'text',
+        bool: 'boolean',
+        int: 'integer',
+        float: 'float',
+        bytes: 'blob',
+    }
+
     nested_item: 'NodeProto'
     if isinstance(value, BaseNode):
         nested_item = value._to_node_protobuf()
-
-    elif isinstance(value, str):
-        nested_item = NodeProto(text=value)
-
-    elif isinstance(value, bool):
-        nested_item = NodeProto(boolean=value)
-
-    elif isinstance(value, int):
-        nested_item = NodeProto(integer=value)
-
-    elif isinstance(value, float):
-        nested_item = NodeProto(float=value)
-
-    elif isinstance(value, bytes):
-        nested_item = NodeProto(blob=value)
-
-    elif isinstance(value, list):
-        from google.protobuf.struct_pb2 import ListValue
-
-        lvalue = ListValue()
-        for item in value:
-            lvalue.append(item)
-        nested_item = NodeProto(list=lvalue)
-
-    elif isinstance(value, set):
-        from google.protobuf.struct_pb2 import ListValue
-
-        lvalue = ListValue()
-        for item in value:
-            lvalue.append(item)
-        nested_item = NodeProto(set=lvalue)
-
-    elif isinstance(value, tuple):
-        from google.protobuf.struct_pb2 import ListValue
-
-        lvalue = ListValue()
-        for item in value:
-            lvalue.append(item)
-        nested_item = NodeProto(tuple=lvalue)
-
-    elif isinstance(value, dict):
-        from google.protobuf.struct_pb2 import Struct
-
-        struct = Struct()
-        struct.update(value)
-        nested_item = NodeProto(dict=struct)
-    elif value is None:
-        nested_item = NodeProto()
     else:
-        raise ValueError(f'{type(value)} is not supported with protobuf')
+        for basic_type, key_name in basic_type_to_key.items():
+            if isinstance(value, basic_type):
+                nested_item = NodeProto(**{key_name: value})
+                return nested_item
+
+        if isinstance(value, list):
+            from google.protobuf.struct_pb2 import ListValue
+
+            lvalue = ListValue()
+            for item in value:
+                lvalue.append(item)
+            nested_item = NodeProto(list=lvalue)
+
+        elif isinstance(value, set):
+            from google.protobuf.struct_pb2 import ListValue
+
+            lvalue = ListValue()
+            for item in value:
+                lvalue.append(item)
+            nested_item = NodeProto(set=lvalue)
+
+        elif isinstance(value, tuple):
+            from google.protobuf.struct_pb2 import ListValue
+
+            lvalue = ListValue()
+            for item in value:
+                lvalue.append(item)
+            nested_item = NodeProto(tuple=lvalue)
+
+        elif isinstance(value, dict):
+            from google.protobuf.struct_pb2 import Struct
+
+            struct = Struct()
+            struct.update(value)
+            nested_item = NodeProto(dict=struct)
+        elif value is None:
+            nested_item = NodeProto()
+        else:
+            raise ValueError(f'{type(value)} is not supported with protobuf')
     return nested_item
 
 

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -44,6 +44,8 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
         bytes: 'blob',
     }
 
+    container_type_to_key = {list: 'list', set: 'set', tuple: 'tuple'}
+
     nested_item: 'NodeProto'
     if isinstance(value, BaseNode):
         nested_item = value._to_node_protobuf()
@@ -53,31 +55,17 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
                 nested_item = NodeProto(**{key_name: value})
                 return nested_item
 
-        if isinstance(value, list):
-            from google.protobuf.struct_pb2 import ListValue
+        for container_type, key_name in container_type_to_key.items():
+            if isinstance(value, container_type):
+                from google.protobuf.struct_pb2 import ListValue
 
-            lvalue = ListValue()
-            for item in value:
-                lvalue.append(item)
-            nested_item = NodeProto(list=lvalue)
+                lvalue = ListValue()
+                for item in value:
+                    lvalue.append(item)
+                nested_item = NodeProto(**{key_name: lvalue})
+                return nested_item
 
-        elif isinstance(value, set):
-            from google.protobuf.struct_pb2 import ListValue
-
-            lvalue = ListValue()
-            for item in value:
-                lvalue.append(item)
-            nested_item = NodeProto(set=lvalue)
-
-        elif isinstance(value, tuple):
-            from google.protobuf.struct_pb2 import ListValue
-
-            lvalue = ListValue()
-            for item in value:
-                lvalue.append(item)
-            nested_item = NodeProto(tuple=lvalue)
-
-        elif isinstance(value, dict):
+        if isinstance(value, dict):
             from google.protobuf.struct_pb2 import Struct
 
             struct = Struct()

--- a/docarray/base_document/mixins/io.py
+++ b/docarray/base_document/mixins/io.py
@@ -57,11 +57,11 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
 
         for container_type, key_name in container_type_to_key.items():
             if isinstance(value, container_type):
-                from google.protobuf.struct_pb2 import ListValue
+                from docarray.proto import ListOfAnyProto
 
-                lvalue = ListValue()
+                lvalue = ListOfAnyProto()
                 for item in value:
-                    lvalue.append(item)
+                    lvalue.data.append(_type_to_protobuf(item))
                 nested_item = NodeProto(**{key_name: lvalue})
                 return nested_item
 
@@ -71,6 +71,7 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
             struct = Struct()
             struct.update(value)
             nested_item = NodeProto(dict=struct)
+
         elif value is None:
             nested_item = NodeProto()
         else:

--- a/docarray/proto/__init__.py
+++ b/docarray/proto/__init__.py
@@ -2,6 +2,7 @@ from google.protobuf import __version__ as __pb__version__
 
 if __pb__version__.startswith('4'):
     from docarray.proto.pb.docarray_pb2 import (
+        DictOfAnyProto,
         DocumentArrayProto,
         DocumentArrayStackedProto,
         DocumentProto,
@@ -12,6 +13,7 @@ if __pb__version__.startswith('4'):
     )
 else:
     from docarray.proto.pb2.docarray_pb2 import (
+        DictOfAnyProto,
         DocumentArrayProto,
         DocumentArrayStackedProto,
         DocumentProto,
@@ -30,4 +32,5 @@ __all__ = [
     'DocumentArrayProto',
     'ListOfDocumentArrayProto',
     'ListOfAnyProto',
+    'DictOfAnyProto',
 ]

--- a/docarray/proto/docarray.proto
+++ b/docarray/proto/docarray.proto
@@ -35,7 +35,12 @@ message GenericDictValue {
   repeated KeyValuePair entries = 1;
 }
 
-//
+
+message ListOfAnyProto {
+  repeated NodeProto data = 1;
+}
+
+
 message NodeProto {
 
   oneof content {
@@ -56,11 +61,11 @@ message NodeProto {
     // a sub DocumentArray
     DocumentArrayProto document_array = 8;
     //any list
-    google.protobuf.ListValue list = 9;
+    ListOfAnyProto list = 9;
     //any set
-    google.protobuf.ListValue set = 10;
+    ListOfAnyProto set = 10;
     //any tuple
-    google.protobuf.ListValue tuple = 11;
+    ListOfAnyProto tuple = 11;
     // dictionary with string as keys
     google.protobuf.Struct dict = 12;
   }
@@ -86,10 +91,6 @@ message DocumentArrayProto {
 
 message ListOfDocumentArrayProto {
   repeated DocumentArrayProto data = 1;
-}
-
-message ListOfAnyProto {
-  repeated NodeProto data = 1;
 }
 
 message DocumentArrayStackedProto{

--- a/docarray/proto/docarray.proto
+++ b/docarray/proto/docarray.proto
@@ -36,10 +36,6 @@ message GenericDictValue {
 }
 
 
-message ListOfAnyProto {
-  repeated NodeProto data = 1;
-}
-
 
 message NodeProto {
 
@@ -67,7 +63,7 @@ message NodeProto {
     //any tuple
     ListOfAnyProto tuple = 11;
     // dictionary with string as keys
-    google.protobuf.Struct dict = 12;
+    DictOfAnyProto dict = 12;
   }
 
   oneof docarray_type {
@@ -85,9 +81,20 @@ message DocumentProto {
 
 }
 
+message DictOfAnyProto {
+
+  map<string, NodeProto> data = 1;
+
+}
+
+message ListOfAnyProto {
+  repeated NodeProto data = 1;
+}
+
 message DocumentArrayProto {
     repeated DocumentProto docs = 1; // a list of Documents
 }
+
 
 message ListOfDocumentArrayProto {
   repeated DocumentArrayProto data = 1;

--- a/docarray/proto/pb/docarray_pb2.py
+++ b/docarray/proto/pb/docarray_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\xc5\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"\xc6\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12(\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x18.docarray.DictOfAnyProtoH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\"\x84\x01\n\x0e\x44ictOfAnyProto\x12\x30\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\".docarray.DictOfAnyProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'docarray_pb2', globals())
@@ -23,6 +23,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _DOCUMENTPROTO_DATAENTRY._options = None
   _DOCUMENTPROTO_DATAENTRY._serialized_options = b'8\001'
+  _DICTOFANYPROTO_DATAENTRY._options = None
+  _DICTOFANYPROTO_DATAENTRY._serialized_options = b'8\001'
   _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._options = None
   _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_options = b'8\001'
   _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._options = None
@@ -39,26 +41,30 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _KEYVALUEPAIR._serialized_end=320
   _GENERICDICTVALUE._serialized_start=322
   _GENERICDICTVALUE._serialized_end=381
-  _LISTOFANYPROTO._serialized_start=383
-  _LISTOFANYPROTO._serialized_end=434
-  _NODEPROTO._serialized_start=437
-  _NODEPROTO._serialized_end=890
-  _DOCUMENTPROTO._serialized_start=893
-  _DOCUMENTPROTO._serialized_end=1023
-  _DOCUMENTPROTO_DATAENTRY._serialized_start=959
-  _DOCUMENTPROTO_DATAENTRY._serialized_end=1023
-  _DOCUMENTARRAYPROTO._serialized_start=1025
-  _DOCUMENTARRAYPROTO._serialized_end=1084
-  _LISTOFDOCUMENTARRAYPROTO._serialized_start=1086
-  _LISTOFDOCUMENTARRAYPROTO._serialized_end=1156
-  _DOCUMENTARRAYSTACKEDPROTO._serialized_start=1159
-  _DOCUMENTARRAYSTACKEDPROTO._serialized_end=1815
-  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start=1488
-  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end=1564
-  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start=1566
-  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end=1652
-  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start=1654
-  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end=1738
-  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start=1740
-  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end=1815
+  _NODEPROTO._serialized_start=384
+  _NODEPROTO._serialized_end=838
+  _DOCUMENTPROTO._serialized_start=841
+  _DOCUMENTPROTO._serialized_end=971
+  _DOCUMENTPROTO_DATAENTRY._serialized_start=907
+  _DOCUMENTPROTO_DATAENTRY._serialized_end=971
+  _DICTOFANYPROTO._serialized_start=974
+  _DICTOFANYPROTO._serialized_end=1106
+  _DICTOFANYPROTO_DATAENTRY._serialized_start=907
+  _DICTOFANYPROTO_DATAENTRY._serialized_end=971
+  _LISTOFANYPROTO._serialized_start=1108
+  _LISTOFANYPROTO._serialized_end=1159
+  _DOCUMENTARRAYPROTO._serialized_start=1161
+  _DOCUMENTARRAYPROTO._serialized_end=1220
+  _LISTOFDOCUMENTARRAYPROTO._serialized_start=1222
+  _LISTOFDOCUMENTARRAYPROTO._serialized_end=1292
+  _DOCUMENTARRAYSTACKEDPROTO._serialized_start=1295
+  _DOCUMENTARRAYSTACKEDPROTO._serialized_end=1951
+  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start=1624
+  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end=1700
+  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start=1702
+  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end=1788
+  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start=1790
+  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end=1874
+  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start=1876
+  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end=1951
 # @@protoc_insertion_point(module_scope)

--- a/docarray/proto/pb/docarray_pb2.py
+++ b/docarray/proto/pb/docarray_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"\xcb\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12*\n\x04list\x18\t \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12)\n\x03set\x18\n \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12+\n\x05tuple\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\xc5\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'docarray_pb2', globals())
@@ -39,26 +39,26 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _KEYVALUEPAIR._serialized_end=320
   _GENERICDICTVALUE._serialized_start=322
   _GENERICDICTVALUE._serialized_end=381
-  _NODEPROTO._serialized_start=384
-  _NODEPROTO._serialized_end=843
-  _DOCUMENTPROTO._serialized_start=846
-  _DOCUMENTPROTO._serialized_end=976
-  _DOCUMENTPROTO_DATAENTRY._serialized_start=912
-  _DOCUMENTPROTO_DATAENTRY._serialized_end=976
-  _DOCUMENTARRAYPROTO._serialized_start=978
-  _DOCUMENTARRAYPROTO._serialized_end=1037
-  _LISTOFDOCUMENTARRAYPROTO._serialized_start=1039
-  _LISTOFDOCUMENTARRAYPROTO._serialized_end=1109
-  _LISTOFANYPROTO._serialized_start=1111
-  _LISTOFANYPROTO._serialized_end=1162
-  _DOCUMENTARRAYSTACKEDPROTO._serialized_start=1165
-  _DOCUMENTARRAYSTACKEDPROTO._serialized_end=1821
-  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start=1494
-  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end=1570
-  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start=1572
-  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end=1658
-  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start=1660
-  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end=1744
-  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start=1746
-  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end=1821
+  _LISTOFANYPROTO._serialized_start=383
+  _LISTOFANYPROTO._serialized_end=434
+  _NODEPROTO._serialized_start=437
+  _NODEPROTO._serialized_end=890
+  _DOCUMENTPROTO._serialized_start=893
+  _DOCUMENTPROTO._serialized_end=1023
+  _DOCUMENTPROTO_DATAENTRY._serialized_start=959
+  _DOCUMENTPROTO_DATAENTRY._serialized_end=1023
+  _DOCUMENTARRAYPROTO._serialized_start=1025
+  _DOCUMENTARRAYPROTO._serialized_end=1084
+  _LISTOFDOCUMENTARRAYPROTO._serialized_start=1086
+  _LISTOFDOCUMENTARRAYPROTO._serialized_end=1156
+  _DOCUMENTARRAYSTACKEDPROTO._serialized_start=1159
+  _DOCUMENTARRAYSTACKEDPROTO._serialized_end=1815
+  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start=1488
+  _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end=1564
+  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start=1566
+  _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end=1652
+  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start=1654
+  _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end=1738
+  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start=1740
+  _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end=1815
 # @@protoc_insertion_point(module_scope)

--- a/docarray/proto/pb2/docarray_pb2.py
+++ b/docarray/proto/pb2/docarray_pb2.py
@@ -16,7 +16,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"\xcb\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12*\n\x04list\x18\t \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12)\n\x03set\x18\n \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12+\n\x05tuple\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.ListValueH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3'
+    b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\xc5\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3'
 )
 
 
@@ -24,12 +24,12 @@ _DENSENDARRAYPROTO = DESCRIPTOR.message_types_by_name['DenseNdArrayProto']
 _NDARRAYPROTO = DESCRIPTOR.message_types_by_name['NdArrayProto']
 _KEYVALUEPAIR = DESCRIPTOR.message_types_by_name['KeyValuePair']
 _GENERICDICTVALUE = DESCRIPTOR.message_types_by_name['GenericDictValue']
+_LISTOFANYPROTO = DESCRIPTOR.message_types_by_name['ListOfAnyProto']
 _NODEPROTO = DESCRIPTOR.message_types_by_name['NodeProto']
 _DOCUMENTPROTO = DESCRIPTOR.message_types_by_name['DocumentProto']
 _DOCUMENTPROTO_DATAENTRY = _DOCUMENTPROTO.nested_types_by_name['DataEntry']
 _DOCUMENTARRAYPROTO = DESCRIPTOR.message_types_by_name['DocumentArrayProto']
 _LISTOFDOCUMENTARRAYPROTO = DESCRIPTOR.message_types_by_name['ListOfDocumentArrayProto']
-_LISTOFANYPROTO = DESCRIPTOR.message_types_by_name['ListOfAnyProto']
 _DOCUMENTARRAYSTACKEDPROTO = DESCRIPTOR.message_types_by_name[
     'DocumentArrayStackedProto'
 ]
@@ -89,6 +89,17 @@ GenericDictValue = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(GenericDictValue)
 
+ListOfAnyProto = _reflection.GeneratedProtocolMessageType(
+    'ListOfAnyProto',
+    (_message.Message,),
+    {
+        'DESCRIPTOR': _LISTOFANYPROTO,
+        '__module__': 'docarray_pb2'
+        # @@protoc_insertion_point(class_scope:docarray.ListOfAnyProto)
+    },
+)
+_sym_db.RegisterMessage(ListOfAnyProto)
+
 NodeProto = _reflection.GeneratedProtocolMessageType(
     'NodeProto',
     (_message.Message,),
@@ -142,17 +153,6 @@ ListOfDocumentArrayProto = _reflection.GeneratedProtocolMessageType(
     },
 )
 _sym_db.RegisterMessage(ListOfDocumentArrayProto)
-
-ListOfAnyProto = _reflection.GeneratedProtocolMessageType(
-    'ListOfAnyProto',
-    (_message.Message,),
-    {
-        'DESCRIPTOR': _LISTOFANYPROTO,
-        '__module__': 'docarray_pb2'
-        # @@protoc_insertion_point(class_scope:docarray.ListOfAnyProto)
-    },
-)
-_sym_db.RegisterMessage(ListOfAnyProto)
 
 DocumentArrayStackedProto = _reflection.GeneratedProtocolMessageType(
     'DocumentArrayStackedProto',
@@ -226,26 +226,26 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _KEYVALUEPAIR._serialized_end = 320
     _GENERICDICTVALUE._serialized_start = 322
     _GENERICDICTVALUE._serialized_end = 381
-    _NODEPROTO._serialized_start = 384
-    _NODEPROTO._serialized_end = 843
-    _DOCUMENTPROTO._serialized_start = 846
-    _DOCUMENTPROTO._serialized_end = 976
-    _DOCUMENTPROTO_DATAENTRY._serialized_start = 912
-    _DOCUMENTPROTO_DATAENTRY._serialized_end = 976
-    _DOCUMENTARRAYPROTO._serialized_start = 978
-    _DOCUMENTARRAYPROTO._serialized_end = 1037
-    _LISTOFDOCUMENTARRAYPROTO._serialized_start = 1039
-    _LISTOFDOCUMENTARRAYPROTO._serialized_end = 1109
-    _LISTOFANYPROTO._serialized_start = 1111
-    _LISTOFANYPROTO._serialized_end = 1162
-    _DOCUMENTARRAYSTACKEDPROTO._serialized_start = 1165
-    _DOCUMENTARRAYSTACKEDPROTO._serialized_end = 1821
-    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start = 1494
-    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end = 1570
-    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start = 1572
-    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end = 1658
-    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start = 1660
-    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end = 1744
-    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start = 1746
-    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end = 1821
+    _LISTOFANYPROTO._serialized_start = 383
+    _LISTOFANYPROTO._serialized_end = 434
+    _NODEPROTO._serialized_start = 437
+    _NODEPROTO._serialized_end = 890
+    _DOCUMENTPROTO._serialized_start = 893
+    _DOCUMENTPROTO._serialized_end = 1023
+    _DOCUMENTPROTO_DATAENTRY._serialized_start = 959
+    _DOCUMENTPROTO_DATAENTRY._serialized_end = 1023
+    _DOCUMENTARRAYPROTO._serialized_start = 1025
+    _DOCUMENTARRAYPROTO._serialized_end = 1084
+    _LISTOFDOCUMENTARRAYPROTO._serialized_start = 1086
+    _LISTOFDOCUMENTARRAYPROTO._serialized_end = 1156
+    _DOCUMENTARRAYSTACKEDPROTO._serialized_start = 1159
+    _DOCUMENTARRAYSTACKEDPROTO._serialized_end = 1815
+    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start = 1488
+    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end = 1564
+    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start = 1566
+    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end = 1652
+    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start = 1654
+    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end = 1738
+    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start = 1740
+    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end = 1815
 # @@protoc_insertion_point(module_scope)

--- a/docarray/proto/pb2/docarray_pb2.py
+++ b/docarray/proto/pb2/docarray_pb2.py
@@ -16,7 +16,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\"\xc5\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x17.google.protobuf.StructH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3'
+    b'\n\x0e\x64ocarray.proto\x12\x08\x64ocarray\x1a\x1cgoogle/protobuf/struct.proto\"A\n\x11\x44\x65nseNdArrayProto\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05shape\x18\x02 \x03(\r\x12\r\n\x05\x64type\x18\x03 \x01(\t\"g\n\x0cNdArrayProto\x12*\n\x05\x64\x65nse\x18\x01 \x01(\x0b\x32\x1b.docarray.DenseNdArrayProto\x12+\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"Z\n\x0cKeyValuePair\x12#\n\x03key\x18\x01 \x01(\x0b\x32\x16.google.protobuf.Value\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\";\n\x10GenericDictValue\x12\'\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x16.docarray.KeyValuePair\"\xc6\x03\n\tNodeProto\x12\x0e\n\x04text\x18\x01 \x01(\tH\x00\x12\x11\n\x07integer\x18\x02 \x01(\x05H\x00\x12\x0f\n\x05\x66loat\x18\x03 \x01(\x01H\x00\x12\x11\n\x07\x62oolean\x18\x04 \x01(\x08H\x00\x12\x0e\n\x04\x62lob\x18\x05 \x01(\x0cH\x00\x12)\n\x07ndarray\x18\x06 \x01(\x0b\x32\x16.docarray.NdArrayProtoH\x00\x12+\n\x08\x64ocument\x18\x07 \x01(\x0b\x32\x17.docarray.DocumentProtoH\x00\x12\x36\n\x0e\x64ocument_array\x18\x08 \x01(\x0b\x32\x1c.docarray.DocumentArrayProtoH\x00\x12(\n\x04list\x18\t \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12\'\n\x03set\x18\n \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12)\n\x05tuple\x18\x0b \x01(\x0b\x32\x18.docarray.ListOfAnyProtoH\x00\x12(\n\x04\x64ict\x18\x0c \x01(\x0b\x32\x18.docarray.DictOfAnyProtoH\x00\x12\x0e\n\x04type\x18\r \x01(\tH\x01\x42\t\n\x07\x63ontentB\x0f\n\rdocarray_type\"\x82\x01\n\rDocumentProto\x12/\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32!.docarray.DocumentProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\"\x84\x01\n\x0e\x44ictOfAnyProto\x12\x30\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\".docarray.DictOfAnyProto.DataEntry\x1a@\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.docarray.NodeProto:\x02\x38\x01\"3\n\x0eListOfAnyProto\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x13.docarray.NodeProto\";\n\x12\x44ocumentArrayProto\x12%\n\x04\x64ocs\x18\x01 \x03(\x0b\x32\x17.docarray.DocumentProto\"F\n\x18ListOfDocumentArrayProto\x12*\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\x1c.docarray.DocumentArrayProto\"\x90\x05\n\x19\x44ocumentArrayStackedProto\x12N\n\x0etensor_columns\x18\x01 \x03(\x0b\x32\x36.docarray.DocumentArrayStackedProto.TensorColumnsEntry\x12H\n\x0b\x64oc_columns\x18\x02 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.DocColumnsEntry\x12\x46\n\nda_columns\x18\x03 \x03(\x0b\x32\x32.docarray.DocumentArrayStackedProto.DaColumnsEntry\x12H\n\x0b\x61ny_columns\x18\x04 \x03(\x0b\x32\x33.docarray.DocumentArrayStackedProto.AnyColumnsEntry\x1aL\n\x12TensorColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.docarray.NdArrayProto:\x02\x38\x01\x1aV\n\x0f\x44ocColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.docarray.DocumentArrayStackedProto:\x02\x38\x01\x1aT\n\x0e\x44\x61\x43olumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x31\n\x05value\x18\x02 \x01(\x0b\x32\".docarray.ListOfDocumentArrayProto:\x02\x38\x01\x1aK\n\x0f\x41nyColumnsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x18.docarray.ListOfAnyProto:\x02\x38\x01\x62\x06proto3'
 )
 
 
@@ -24,10 +24,12 @@ _DENSENDARRAYPROTO = DESCRIPTOR.message_types_by_name['DenseNdArrayProto']
 _NDARRAYPROTO = DESCRIPTOR.message_types_by_name['NdArrayProto']
 _KEYVALUEPAIR = DESCRIPTOR.message_types_by_name['KeyValuePair']
 _GENERICDICTVALUE = DESCRIPTOR.message_types_by_name['GenericDictValue']
-_LISTOFANYPROTO = DESCRIPTOR.message_types_by_name['ListOfAnyProto']
 _NODEPROTO = DESCRIPTOR.message_types_by_name['NodeProto']
 _DOCUMENTPROTO = DESCRIPTOR.message_types_by_name['DocumentProto']
 _DOCUMENTPROTO_DATAENTRY = _DOCUMENTPROTO.nested_types_by_name['DataEntry']
+_DICTOFANYPROTO = DESCRIPTOR.message_types_by_name['DictOfAnyProto']
+_DICTOFANYPROTO_DATAENTRY = _DICTOFANYPROTO.nested_types_by_name['DataEntry']
+_LISTOFANYPROTO = DESCRIPTOR.message_types_by_name['ListOfAnyProto']
 _DOCUMENTARRAYPROTO = DESCRIPTOR.message_types_by_name['DocumentArrayProto']
 _LISTOFDOCUMENTARRAYPROTO = DESCRIPTOR.message_types_by_name['ListOfDocumentArrayProto']
 _DOCUMENTARRAYSTACKEDPROTO = DESCRIPTOR.message_types_by_name[
@@ -89,17 +91,6 @@ GenericDictValue = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(GenericDictValue)
 
-ListOfAnyProto = _reflection.GeneratedProtocolMessageType(
-    'ListOfAnyProto',
-    (_message.Message,),
-    {
-        'DESCRIPTOR': _LISTOFANYPROTO,
-        '__module__': 'docarray_pb2'
-        # @@protoc_insertion_point(class_scope:docarray.ListOfAnyProto)
-    },
-)
-_sym_db.RegisterMessage(ListOfAnyProto)
-
 NodeProto = _reflection.GeneratedProtocolMessageType(
     'NodeProto',
     (_message.Message,),
@@ -131,6 +122,38 @@ DocumentProto = _reflection.GeneratedProtocolMessageType(
 )
 _sym_db.RegisterMessage(DocumentProto)
 _sym_db.RegisterMessage(DocumentProto.DataEntry)
+
+DictOfAnyProto = _reflection.GeneratedProtocolMessageType(
+    'DictOfAnyProto',
+    (_message.Message,),
+    {
+        'DataEntry': _reflection.GeneratedProtocolMessageType(
+            'DataEntry',
+            (_message.Message,),
+            {
+                'DESCRIPTOR': _DICTOFANYPROTO_DATAENTRY,
+                '__module__': 'docarray_pb2'
+                # @@protoc_insertion_point(class_scope:docarray.DictOfAnyProto.DataEntry)
+            },
+        ),
+        'DESCRIPTOR': _DICTOFANYPROTO,
+        '__module__': 'docarray_pb2'
+        # @@protoc_insertion_point(class_scope:docarray.DictOfAnyProto)
+    },
+)
+_sym_db.RegisterMessage(DictOfAnyProto)
+_sym_db.RegisterMessage(DictOfAnyProto.DataEntry)
+
+ListOfAnyProto = _reflection.GeneratedProtocolMessageType(
+    'ListOfAnyProto',
+    (_message.Message,),
+    {
+        'DESCRIPTOR': _LISTOFANYPROTO,
+        '__module__': 'docarray_pb2'
+        # @@protoc_insertion_point(class_scope:docarray.ListOfAnyProto)
+    },
+)
+_sym_db.RegisterMessage(ListOfAnyProto)
 
 DocumentArrayProto = _reflection.GeneratedProtocolMessageType(
     'DocumentArrayProto',
@@ -210,6 +233,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
     _DOCUMENTPROTO_DATAENTRY._options = None
     _DOCUMENTPROTO_DATAENTRY._serialized_options = b'8\001'
+    _DICTOFANYPROTO_DATAENTRY._options = None
+    _DICTOFANYPROTO_DATAENTRY._serialized_options = b'8\001'
     _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._options = None
     _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_options = b'8\001'
     _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._options = None
@@ -226,26 +251,30 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _KEYVALUEPAIR._serialized_end = 320
     _GENERICDICTVALUE._serialized_start = 322
     _GENERICDICTVALUE._serialized_end = 381
-    _LISTOFANYPROTO._serialized_start = 383
-    _LISTOFANYPROTO._serialized_end = 434
-    _NODEPROTO._serialized_start = 437
-    _NODEPROTO._serialized_end = 890
-    _DOCUMENTPROTO._serialized_start = 893
-    _DOCUMENTPROTO._serialized_end = 1023
-    _DOCUMENTPROTO_DATAENTRY._serialized_start = 959
-    _DOCUMENTPROTO_DATAENTRY._serialized_end = 1023
-    _DOCUMENTARRAYPROTO._serialized_start = 1025
-    _DOCUMENTARRAYPROTO._serialized_end = 1084
-    _LISTOFDOCUMENTARRAYPROTO._serialized_start = 1086
-    _LISTOFDOCUMENTARRAYPROTO._serialized_end = 1156
-    _DOCUMENTARRAYSTACKEDPROTO._serialized_start = 1159
-    _DOCUMENTARRAYSTACKEDPROTO._serialized_end = 1815
-    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start = 1488
-    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end = 1564
-    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start = 1566
-    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end = 1652
-    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start = 1654
-    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end = 1738
-    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start = 1740
-    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end = 1815
+    _NODEPROTO._serialized_start = 384
+    _NODEPROTO._serialized_end = 838
+    _DOCUMENTPROTO._serialized_start = 841
+    _DOCUMENTPROTO._serialized_end = 971
+    _DOCUMENTPROTO_DATAENTRY._serialized_start = 907
+    _DOCUMENTPROTO_DATAENTRY._serialized_end = 971
+    _DICTOFANYPROTO._serialized_start = 974
+    _DICTOFANYPROTO._serialized_end = 1106
+    _DICTOFANYPROTO_DATAENTRY._serialized_start = 907
+    _DICTOFANYPROTO_DATAENTRY._serialized_end = 971
+    _LISTOFANYPROTO._serialized_start = 1108
+    _LISTOFANYPROTO._serialized_end = 1159
+    _DOCUMENTARRAYPROTO._serialized_start = 1161
+    _DOCUMENTARRAYPROTO._serialized_end = 1220
+    _LISTOFDOCUMENTARRAYPROTO._serialized_start = 1222
+    _LISTOFDOCUMENTARRAYPROTO._serialized_end = 1292
+    _DOCUMENTARRAYSTACKEDPROTO._serialized_start = 1295
+    _DOCUMENTARRAYSTACKEDPROTO._serialized_end = 1951
+    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_start = 1624
+    _DOCUMENTARRAYSTACKEDPROTO_TENSORCOLUMNSENTRY._serialized_end = 1700
+    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_start = 1702
+    _DOCUMENTARRAYSTACKEDPROTO_DOCCOLUMNSENTRY._serialized_end = 1788
+    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_start = 1790
+    _DOCUMENTARRAYSTACKEDPROTO_DACOLUMNSENTRY._serialized_end = 1874
+    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_start = 1876
+    _DOCUMENTARRAYSTACKEDPROTO_ANYCOLUMNSENTRY._serialized_end = 1951
 # @@protoc_insertion_point(module_scope)

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -214,3 +214,13 @@ def test_nested_dict():
     doc = MyDoc(data={'data': (1, 2)})
 
     MyDoc.from_protobuf(doc.to_protobuf())
+
+
+@pytest.mark.proto
+def test_tuple_complex():
+    class MyDoc(BaseDocument):
+        data: Tuple
+
+    doc = MyDoc(data=(1, 2))
+
+    MyDoc.from_protobuf(doc.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -7,6 +7,10 @@ import torch
 from docarray import DocumentArray
 from docarray.base_document import BaseDocument
 from docarray.typing import NdArray, TorchTensor
+from docarray.utils.misc import is_tf_available
+
+if is_tf_available():
+    import tensorflow as tf
 
 
 @pytest.mark.proto
@@ -232,6 +236,17 @@ def test_super_complex_nested():
         data: Dict
 
     data = {'hello': (torch.zeros(55), 1, 'hi', [torch.ones(55), np.zeros(10), (1, 2)])}
+    doc = MyDoc(data=data)
+
+    MyDoc.from_protobuf(doc.to_protobuf())
+
+
+@pytest.mark.tensorflow
+def test_super_complex_nested_tensorflow():
+    class MyDoc(BaseDocument):
+        data: Dict
+
+    data = {'hello': (torch.zeros(55), 1, 'hi', [tf.ones(55), np.zeros(10), (1, 2)])}
     doc = MyDoc(data=data)
 
     MyDoc.from_protobuf(doc.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -260,6 +260,21 @@ def test_nested_tensor_list():
 
 
 @pytest.mark.proto
+def test_nested_tensor_dict():
+    class MyDoc(BaseDocument):
+        data: Dict
+
+    doc = MyDoc(data={'hello': np.zeros(10)})
+
+    doc2 = MyDoc.from_protobuf(doc.to_protobuf())
+
+    assert isinstance(doc2.data['hello'], np.ndarray)
+    assert isinstance(doc2.data['hello'], NdArray)
+
+    assert (doc2.data['hello'] == np.zeros(10)).all()
+
+
+@pytest.mark.proto
 def test_super_complex_nested():
     class MyDoc(BaseDocument):
         data: Dict
@@ -267,7 +282,9 @@ def test_super_complex_nested():
     data = {'hello': (torch.zeros(55), 1, 'hi', [torch.ones(55), np.zeros(10), (1, 2)])}
     doc = MyDoc(data=data)
 
-    MyDoc.from_protobuf(doc.to_protobuf())
+    doc2 = MyDoc.from_protobuf(doc.to_protobuf())
+
+    (doc2.data['hello'][3][0] == torch.ones(55)).all()
 
 
 @pytest.mark.tensorflow

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -227,7 +227,7 @@ def test_tuple_complex():
 
 
 @pytest.mark.proto
-def test_super_complex_nested_whatever():
+def test_super_complex_nested():
     class MyDoc(BaseDocument):
         data: Dict
 

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -204,3 +204,13 @@ def test_torch_dtype(dtype):
     assert doc.tensor.dtype == dtype
     assert MyDoc.from_protobuf(doc.to_protobuf()).tensor.dtype == dtype
     assert MyDoc.parse_obj(doc.dict()).tensor.dtype == dtype
+
+
+@pytest.mark.proto
+def test_nested_dict():
+    class MyDoc(BaseDocument):
+        data: Dict
+
+    doc = MyDoc(data={'data': (1, 2)})
+
+    MyDoc.from_protobuf(doc.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -224,3 +224,14 @@ def test_tuple_complex():
     doc = MyDoc(data=(1, 2))
 
     MyDoc.from_protobuf(doc.to_protobuf())
+
+
+@pytest.mark.proto
+def test_super_complex_nested_whatever():
+    class MyDoc(BaseDocument):
+        data: Dict
+
+    data = {'hello': (torch.zeros(55), 1, 'hi', [torch.ones(55), (1, 2)])}
+    doc = MyDoc(data=data)
+
+    MyDoc.from_protobuf(doc.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -231,7 +231,7 @@ def test_super_complex_nested():
     class MyDoc(BaseDocument):
         data: Dict
 
-    data = {'hello': (torch.zeros(55), 1, 'hi', [torch.ones(55), (1, 2)])}
+    data = {'hello': (torch.zeros(55), 1, 'hi', [torch.ones(55), np.zeros(10), (1, 2)])}
     doc = MyDoc(data=data)
 
     MyDoc.from_protobuf(doc.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -227,7 +227,36 @@ def test_tuple_complex():
 
     doc = MyDoc(data=(1, 2))
 
-    MyDoc.from_protobuf(doc.to_protobuf())
+    doc2 = MyDoc.from_protobuf(doc.to_protobuf())
+
+    assert doc2.data == (1, 2)
+
+
+@pytest.mark.proto
+def test_list_complex():
+    class MyDoc(BaseDocument):
+        data: List
+
+    doc = MyDoc(data=[(1, 2)])
+
+    doc2 = MyDoc.from_protobuf(doc.to_protobuf())
+
+    assert doc2.data == [(1, 2)]
+
+
+@pytest.mark.proto
+def test_nested_tensor_list():
+    class MyDoc(BaseDocument):
+        data: List
+
+    doc = MyDoc(data=[np.zeros(10)])
+
+    doc2 = MyDoc.from_protobuf(doc.to_protobuf())
+
+    assert isinstance(doc2.data[0], np.ndarray)
+    assert isinstance(doc2.data[0], NdArray)
+
+    assert (doc2.data[0] == np.zeros(10)).all()
 
 
 @pytest.mark.proto


### PR DESCRIPTION
# Context

mainly fix https://github.com/docarray/docarray/issues/1275


```python
from docarray import BaseDocument

class InputSchema(BaseDocument):
    data: Dict

doc = InputSchema(data = {'data': (torch.zeros(1), 2)})

doc2 = MyDoc.from_protobuf(doc.to_protobuf())

```

This make this work by using a list of node proto instead of the predefined list of Protobuf
