### PR TITLE
fix: doc summary for dict and set attributes

### DIFF
--- a/docarray/display/document_summary.py
+++ b/docarray/display/document_summary.py
@@ -137,14 +137,26 @@ class DocumentSummary:
                 table.add_row(col_1, text.Text(col_2))
             elif isinstance(value, AbstractTensor):
                 table.add_row(col_1, TensorDisplay(tensor=value))
-            elif isinstance(value, (tuple, list)):
+            elif isinstance(value, (tuple, list, set)):
+                value_list = list(value)
                 col_2 = ''
-                for i, x in enumerate(value):
+                for i, x in enumerate(value_list):
                     if len(col_2) + len(str(x)) < 50:
-                        col_2 = str(value[:i])
+                        col_2 = str(value_list[: i + 1])
                     else:
-                        col_2 = f'{col_2[:-1]}, ...] (length: {len(value)})'
+                        col_2 = f'{col_2[:-1]}, ...] (length: {len(value_list)})'
                         break
+
+                if type(value) == tuple:
+                    col_2 = col_2.replace('[', '(', 1).replace(']', ')', -1)
+                if type(value) == set:
+                    col_2 = col_2.replace('[', '{', 1).replace(']', '}', -1)
+
+                table.add_row(col_1, text.Text(col_2))
+            elif isinstance(value, dict):
+                col_2 = f'{value}'
+                if len(col_2) > 50:
+                    col_2 = f'{col_2[: 50]}' + ' ... } ' + f'(length: {len(value)})'
                 table.add_row(col_1, text.Text(col_2))
 
         if table.rows:


### PR DESCRIPTION
dict and set attributes are not displayed correctly:

```python
from docarray import BaseDocument


class MyDoc(BaseDocument):
    a: dict
    b: set


doc = MyDoc(
    a={'hello': (1, 0), 'hello1': (1, 0), 'hello2': (1, 0), 'hello3': (1, 0)},
    b={'hi', 'ok', 'bye'}
)

doc.summary()
```
output:
```
📄 MyDoc : f1bfd74 ...
```
expected:
```
📄 MyDoc : 38f8628 ...
╭───────────┬──────────────────────────────────────────────────────────────────╮
│ Attribute │ Value                                                            │
├───────────┼──────────────────────────────────────────────────────────────────┤
│ a: dict   │ {'hello': (1, 0), 'hello1': (1, 0), 'hello2': (1,  ... }         │
│           │ (length: 4)                                                      │
│ b: set    │ {'bye', 'hi', 'ok'}                                              │
╰───────────┴──────────────────────────────────────────────────────────────────╯
```

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
