### PR TITLE
feat: create documents from dict

### DIFF
--- a/docarray/documents/helper.py
+++ b/docarray/documents/helper.py
@@ -149,8 +149,8 @@ def create_from_dict(model_name: str, data_dict: Dict[str, Any]) -> Type['T_doc'
     if not data_dict:
         raise ValueError('`data_dict` should contain at least one item')
 
-    field_types: Dict[str, Tuple[Type, ...]] = {
+    field_types = {
         field: (type(value) if value else Any, ...)
         for field, value in data_dict.items()
     }
-    return create_doc(__model_name=model_name, **field_types)
+    return create_doc(__model_name=model_name, **field_types)  # type: ignore

--- a/docarray/documents/helper.py
+++ b/docarray/documents/helper.py
@@ -73,7 +73,7 @@ def create_doc(
     return doc
 
 
-def create_from_typeddict(
+def create_doc_from_typeddict(
     typeddict_cls: Type['TypedDict'],  # type: ignore
     **kwargs: Any,
 ):
@@ -91,7 +91,7 @@ def create_from_typeddict(
 
         from docarray import BaseDocument
         from docarray.documents import Audio
-        from docarray.documents.helper import create_from_typeddict
+        from docarray.documents.helper import create_doc_from_typeddict
         from docarray.typing.tensor.audio import AudioNdArray
 
 
@@ -100,7 +100,7 @@ def create_from_typeddict(
             tensor: AudioNdArray
 
 
-        Doc = create_from_typeddict(MyAudio, __base__=Audio)
+        Doc = create_doc_from_typeddict(MyAudio, __base__=Audio)
 
         assert issubclass(Doc, BaseDocument)
         assert issubclass(Doc, Audio)
@@ -120,7 +120,7 @@ def create_from_typeddict(
     return doc
 
 
-def create_from_dict(model_name: str, data_dict: Dict[str, Any]) -> Type['T_doc']:
+def create_doc_from_dict(model_name: str, data_dict: Dict[str, Any]) -> Type['T_doc']:
     """
     Create a subclass of BaseDocument based on example data given as a dictionary.
 
@@ -137,11 +137,11 @@ def create_from_dict(model_name: str, data_dict: Dict[str, Any]) -> Type['T_doc'
 
         import numpy as np
         from docarray.documents import ImageDoc
-        from docarray.documents.helper import create_from_dict
+        from docarray.documents.helper import create_doc_from_dict
 
         data_dict = {'image': ImageDoc(tensor=np.random.rand(3, 224, 224)), 'author': 'me'}
 
-        MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+        MyDoc = create_doc_from_dict(model_name='MyDoc', data_dict=data_dict)
 
         assert issubclass(MyDoc, BaseDocument)
 

--- a/docarray/documents/helper.py
+++ b/docarray/documents/helper.py
@@ -118,3 +118,39 @@ def create_from_typeddict(
     doc = create_model_from_typeddict(typeddict_cls, **kwargs)
 
     return doc
+
+
+def create_from_dict(model_name: str, data_dict: Dict[str, Any]) -> Type['T_doc']:
+    """
+    Create a subclass of BaseDocument based on example data given as a dictionary.
+
+    In case the example contains None as a value,
+    corresponding field will be viewed as the type Any.
+
+    :param model_name: Name of the new Document class
+    :param data_dict: Dictionary of field types to their corresponding values.
+    :return: the new Document class
+
+    EXAMPLE USAGE
+
+    .. code-block:: python
+
+        import numpy as np
+        from docarray.documents import ImageDoc
+        from docarray.documents.helper import create_from_dict
+
+        data_dict = {'image': ImageDoc(tensor=np.random.rand(3, 224, 224)), 'author': 'me'}
+
+        MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+
+        assert issubclass(MyDoc, BaseDocument)
+
+    """
+    if not data_dict:
+        raise ValueError('`data_dict` should contain at least one item')
+
+    field_types: Dict[str, Tuple[Type, ...]] = {
+        field: (type(value) if value else Any, ...)
+        for field, value in data_dict.items()
+    }
+    return create_doc(__model_name=model_name, **field_types)

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -9,8 +9,8 @@ from docarray import BaseDocument, DocumentArray
 from docarray.documents import AudioDoc, ImageDoc, TextDoc
 from docarray.documents.helper import (
     create_doc,
-    create_from_typeddict,
-    create_from_dict,
+    create_doc_from_typeddict,
+    create_doc_from_dict,
 )
 from docarray.typing import AudioNdArray
 
@@ -82,15 +82,15 @@ def test_create_doc():
     assert issubclass(MyAudio, AudioDoc)
 
 
-def test_create_from_typeddict():
+def test_create_doc_from_typeddict():
     class MyMultiModalDoc(TypedDict):
         image: ImageDoc
         text: TextDoc
 
     with pytest.raises(ValueError):
-        _ = create_from_typeddict(MyMultiModalDoc, __base__=BaseModel)
+        _ = create_doc_from_typeddict(MyMultiModalDoc, __base__=BaseModel)
 
-    Doc = create_from_typeddict(MyMultiModalDoc)
+    Doc = create_doc_from_typeddict(MyMultiModalDoc)
 
     assert issubclass(Doc, BaseDocument)
 
@@ -98,20 +98,20 @@ def test_create_from_typeddict():
         title: str
         tensor: Optional[AudioNdArray]
 
-    Doc = create_from_typeddict(MyAudio, __base__=AudioDoc)
+    Doc = create_doc_from_typeddict(MyAudio, __base__=AudioDoc)
 
     assert issubclass(Doc, BaseDocument)
     assert issubclass(Doc, AudioDoc)
 
 
-def test_create_from_dict():
+def test_create_doc_from_dict():
     data_dict = {
         'image': ImageDoc(tensor=np.random.rand(3, 224, 224)),
         'text': TextDoc(text='hello'),
         'id': 123,
     }
 
-    MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+    MyDoc = create_doc_from_dict(model_name='MyDoc', data_dict=data_dict)
 
     assert issubclass(MyDoc, BaseDocument)
 
@@ -136,11 +136,11 @@ def test_create_from_dict():
 
     # Handle empty data_dict
     with pytest.raises(ValueError):
-        MyDoc = create_from_dict(model_name='MyDoc', data_dict={})
+        MyDoc = create_doc_from_dict(model_name='MyDoc', data_dict={})
 
     # Data with a None value
     data_dict = {'text': 'some text', 'other': None}
-    MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+    MyDoc = create_doc_from_dict(model_name='MyDoc', data_dict=data_dict)
 
     assert issubclass(MyDoc, BaseDocument)
 

--- a/tests/integrations/document/test_document.py
+++ b/tests/integrations/document/test_document.py
@@ -2,12 +2,16 @@ from typing import Optional
 
 import numpy as np
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing_extensions import TypedDict
 
 from docarray import BaseDocument, DocumentArray
 from docarray.documents import AudioDoc, ImageDoc, TextDoc
-from docarray.documents.helper import create_doc, create_from_typeddict
+from docarray.documents.helper import (
+    create_doc,
+    create_from_typeddict,
+    create_from_dict,
+)
 from docarray.typing import AudioNdArray
 
 
@@ -98,3 +102,49 @@ def test_create_from_typeddict():
 
     assert issubclass(Doc, BaseDocument)
     assert issubclass(Doc, AudioDoc)
+
+
+def test_create_from_dict():
+    data_dict = {
+        'image': ImageDoc(tensor=np.random.rand(3, 224, 224)),
+        'text': TextDoc(text='hello'),
+        'id': 123,
+    }
+
+    MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+
+    assert issubclass(MyDoc, BaseDocument)
+
+    doc = MyDoc(
+        image=ImageDoc(tensor=np.random.rand(3, 224, 224)),
+        text=TextDoc(text='hey'),
+        id=111,
+    )
+
+    assert isinstance(doc, BaseDocument)
+    assert isinstance(doc.text, TextDoc)
+    assert isinstance(doc.image, ImageDoc)
+    assert isinstance(doc.id, int)
+
+    # Create a doc with an incorrect type
+    with pytest.raises(ValidationError):
+        doc = MyDoc(
+            image=ImageDoc(tensor=np.random.rand(3, 224, 224)),
+            text=['some', 'text'],  # should be TextDoc
+            id=111,
+        )
+
+    # Handle empty data_dict
+    with pytest.raises(ValueError):
+        MyDoc = create_from_dict(model_name='MyDoc', data_dict={})
+
+    # Data with a None value
+    data_dict = {'text': 'some text', 'other': None}
+    MyDoc = create_from_dict(model_name='MyDoc', data_dict=data_dict)
+
+    assert issubclass(MyDoc, BaseDocument)
+
+    doc1 = MyDoc(text='txt', other=10)
+    doc2 = MyDoc(text='txt', other='also text')
+
+    assert isinstance(doc1, BaseDocument) and isinstance(doc2, BaseDocument)


### PR DESCRIPTION
Dynamically create model by guessing types based on an example data given as a dictionary of fields to their corresponding values.

```python
import numpy as np
from docarray.documents import ImageDoc
from docarray.documents.helper import create_from_dict

# Data example containing fields and their values
data_dict = {'image': ImageDoc(tensor=np.random.rand(3, 224, 224)), 'author': 'me'}

# Create a class based on the example
MyDoc = create_doc_from_dict(model_name='MyDoc', data_dict=data_dict)

# Use the class to create docs
doc = MyDoc(image=ImageDoc(tensor=np.random.rand(3, 224, 224)), author='jina')

```

Notes:
1. We don't allow passing an empty dict because what's the point then
2. In case the dict contains None value, we treat corresponding field as type Any
3. Had to disable mypy for the return statement otherwise was throwing weird errors (something with kwargs)

- [ ] check and update documentation, if required. See [guide](https://github.com/jina-ai/jina/blob/master/CONTRIBUTING.md#documentation-guidelines)
