### PR TITLE
Ignore tests which has dependency on tensorflow if tensorflow is missing

### DIFF
--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -6,6 +6,9 @@ from pydantic import Field
 from docarray import BaseDoc
 from docarray.index import HnswDocumentIndex
 from docarray.typing import NdArray, TorchTensor
+from docarray.utils._internal.misc import is_tf_available
+
+tf_available = is_tf_available()
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -79,6 +82,7 @@ def test_find_torch(tmp_path, space):
         assert torch.allclose(result.tens, torch.zeros(10, dtype=torch.float64))
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_find_tensorflow(tmp_path):
     from docarray.typing import TensorFlowTensor

--- a/tests/index/hnswlib/test_index_get_del.py
+++ b/tests/index/hnswlib/test_index_get_del.py
@@ -10,6 +10,9 @@ from docarray import BaseDoc, DocArray
 from docarray.documents import ImageDoc, TextDoc
 from docarray.index import HnswDocumentIndex
 from docarray.typing import NdArray, NdArrayEmbedding, TorchTensor
+from docarray.utils._internal.misc import is_tf_available
+
+tf_available = is_tf_available()
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -110,6 +113,7 @@ def test_index_torch(tmp_path):
         assert index.get_current_count() == 10
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_index_tf(tmp_path):
     from docarray.typing import TensorFlowTensor

--- a/tests/integrations/document/test_proto.py
+++ b/tests/integrations/document/test_proto.py
@@ -124,6 +124,7 @@ def test_all_types():
     assert doc.img_bytes == b'img'
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_tensorflow_types():
     class NestedDoc(BaseDoc):

--- a/tests/integrations/predefined_document/test_audio.py
+++ b/tests/integrations/predefined_document/test_audio.py
@@ -190,6 +190,7 @@ def test_audio_torch():
     assert (audio.tensor == torch.zeros(10, 10, 3)).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_audio_tensorflow():
     audio = parse_obj_as(AudioDoc, tf.zeros((10, 10, 3)))

--- a/tests/integrations/predefined_document/test_image.py
+++ b/tests/integrations/predefined_document/test_image.py
@@ -43,6 +43,7 @@ def test_image_torch():
     assert (image.tensor == torch.zeros(10, 10, 3)).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_image_tensorflow():
     image = ImageDoc(tensor=tf.zeros((10, 10, 3)))

--- a/tests/integrations/predefined_document/test_point_cloud.py
+++ b/tests/integrations/predefined_document/test_point_cloud.py
@@ -39,6 +39,7 @@ def test_point_cloud_torch():
     assert (pc.tensors.points == torch.zeros(10, 3)).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_point_cloud_tensorflow():
     pc = parse_obj_as(PointCloud3D, tf.zeros((10, 3)))

--- a/tests/integrations/predefined_document/test_video.py
+++ b/tests/integrations/predefined_document/test_video.py
@@ -41,6 +41,7 @@ def test_video_torch():
     assert (video.tensor == torch.zeros(10, 10, 3)).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_video_tensorflow():
     video = parse_obj_as(VideoDoc, tf.zeros((10, 10, 3)))

--- a/tests/integrations/typing/test_tensor.py
+++ b/tests/integrations/typing/test_tensor.py
@@ -33,6 +33,7 @@ def test_set_tensor():
     assert (d.tensor == torch.zeros((3, 224, 224))).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_set_tensor_tensorflow():
     class MyDocument(BaseDoc):

--- a/tests/integrations/typing/test_tensorflow_tensor.py
+++ b/tests/integrations/typing/test_tensorflow_tensor.py
@@ -11,6 +11,7 @@ if tf_available:
     from docarray.typing import TensorFlowEmbedding, TensorFlowTensor
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_set_tensorflow_tensor():
     class MyDocument(BaseDoc):
@@ -23,6 +24,7 @@ def test_set_tensorflow_tensor():
     assert tnp.allclose(doc.t.tensor, tf.zeros((3, 224, 224)))
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_set_tf_embedding():
     class MyDocument(BaseDoc):

--- a/tests/integrations/typing/test_tensors_interop.py
+++ b/tests/integrations/typing/test_tensors_interop.py
@@ -27,6 +27,7 @@ def test_torch_tensors_interop():
     assert t_result.shape == (128,)
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_tensorflow_tensors_interop():
     t1 = AudioTensorFlowTensor(tf.random.normal((128,)))

--- a/tests/integrations/typing/test_typing_proto.py
+++ b/tests/integrations/typing/test_typing_proto.py
@@ -14,6 +14,9 @@ from docarray.typing import (
     TextUrl,
     TorchTensor,
 )
+from docarray.utils._internal.misc import is_tf_available
+
+tf_available = is_tf_available()
 
 
 @pytest.mark.proto
@@ -49,6 +52,7 @@ def test_proto_all_types():
             assert isinstance(value, doc._get_field_type(field))
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_proto_all_types_proto3():
     import tensorflow as tf

--- a/tests/units/array/stack/test_array_stacked_tf.py
+++ b/tests/units/array/stack/test_array_stacked_tf.py
@@ -13,6 +13,8 @@ if tf_available:
     import tensorflow._api.v2.experimental.numpy as tnp
 
     from docarray.typing import TensorFlowTensor
+else:
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.fixture()

--- a/tests/units/array/test_array.py
+++ b/tests/units/array/test_array.py
@@ -209,6 +209,7 @@ def test_get_bulk_attributes_union_type():
         assert text == f'hello{i}'
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_get_bulk_attributes_union_type_nested():
     class MyDoc(BaseDoc):

--- a/tests/units/computation_backends/tensorflow_backend/test_basics.py
+++ b/tests/units/computation_backends/tensorflow_backend/test_basics.py
@@ -9,6 +9,8 @@ if tf_available:
 
     from docarray.computation.tensorflow_backend import TensorFlowCompBackend
     from docarray.typing import TensorFlowTensor
+else:
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.mark.tensorflow

--- a/tests/units/computation_backends/tensorflow_backend/test_metrics.py
+++ b/tests/units/computation_backends/tensorflow_backend/test_metrics.py
@@ -11,6 +11,7 @@ if tf_available:
 
     metrics = TensorFlowCompBackend.Metrics
 else:
+    pytest.skip(allow_module_level=True)
     metrics = None
 
 

--- a/tests/units/computation_backends/tensorflow_backend/test_retrieval.py
+++ b/tests/units/computation_backends/tensorflow_backend/test_retrieval.py
@@ -9,6 +9,8 @@ if tf_available:
 
     from docarray.computation.tensorflow_backend import TensorFlowCompBackend
     from docarray.typing import TensorFlowTensor
+else:
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.mark.tensorflow

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -9,7 +9,8 @@ from docarray.base_doc import BaseDoc
 from docarray.typing import NdArray, TorchTensor
 from docarray.utils._internal.misc import is_tf_available
 
-if is_tf_available():
+tf_available = is_tf_available()
+if tf_available:
     import tensorflow as tf
 
 
@@ -287,6 +288,7 @@ def test_super_complex_nested():
     (doc2.data['hello'][3][0] == torch.ones(55)).all()
 
 
+@pytest.mark.skipif(not tf_available, reason="Tensorflow not found")
 @pytest.mark.tensorflow
 def test_super_complex_nested_tensorflow():
     class MyDoc(BaseDoc):

--- a/tests/units/util/test_typing.py
+++ b/tests/units/util/test_typing.py
@@ -31,6 +31,7 @@ def test_is_type_tensor(type_, is_tensor):
     assert is_type_tensor(type_) == is_tensor
 
 
+@pytest.mark.skipif(not tf_available, reason="TensorFlow not found")
 @pytest.mark.tensorflow
 @pytest.mark.parametrize(
     'type_, is_tensor',
@@ -61,6 +62,7 @@ def test_is_union_type_tensor(type_, is_union_tensor):
     assert is_tensor_union(type_) == is_union_tensor
 
 
+@pytest.mark.skipif(not tf_available, reason="TensorFlow not found")
 @pytest.mark.tensorflow
 @pytest.mark.parametrize(
     'type_, is_union_tensor',


### PR DESCRIPTION
Goals:

- ignore tests which are using tensorflow but tensorflow is missing from device ignore tests instead of tests getting failed