### PR TITLE
fix: fix type in es test

### DIFF
--- a/tests/integrations/doc_index/elastic/fixture.py
+++ b/tests/integrations/doc_index/elastic/fixture.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from docarray import BaseDoc
 from docarray.typing import NdArray
 
-pytestmark = [pytest.mark.slow, pytest.mark.doc_index]
+pytestmark = [pytest.mark.slow, pytest.mark.index]
 
 
 class SimpleDoc(BaseDoc):


### PR DESCRIPTION
# context

fix es test that were not run bc of pytest mark typo