### PR TITLE
docs: remove duplicate api references section

### DIFF
--- a/docs/api_references/index/backends.md
+++ b/docs/api_references/index/backends.md
@@ -1,3 +1,0 @@
-# Backends
-
-::: docarray.index.backends


### PR DESCRIPTION
Remove duplicate api reference section, that includes only doc index related sections:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/73693835/232572117-7fd88336-6d78-4c25-af81-7c77c5151fc7.png">
