### PR TITLE
docs: clean up data types section

### DIFF
--- a/docs/data_types/video/video.md
+++ b/docs/data_types/video/video.md
@@ -15,7 +15,7 @@ Moreover, you will learn about DocArray's video-specific types, to represent you
 
 In DocArray video data is represented by a video tensor, an audio tensor, and the key frame indices. 
 
-![type:video](mov_bbb.mp4){: style='autoplay: false; width: 600px; height: 330px'}
+![type:video](mov_bbb.mp4){: style='width: 600px; height: 330px'}
 
 !!! tip
     Check out our predefined [`VideoDoc`](#getting-started-predefined-videodoc) to get started and play around with our video features.

--- a/docs/data_types/video/video.md
+++ b/docs/data_types/video/video.md
@@ -15,7 +15,7 @@ Moreover, you will learn about DocArray's video-specific types, to represent you
 
 In DocArray video data is represented by a video tensor, an audio tensor, and the key frame indices. 
 
-![type:video](mov_bbb.mp4){: style='width: 600px; height: 330px'}
+![type:video](mov_bbb.mp4){: style='autoplay: false; width: 600px; height: 330px'}
 
 !!! tip
     Check out our predefined [`VideoDoc`](#getting-started-predefined-videodoc) to get started and play around with our video features.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,11 @@ extra_css:
 plugins:
   - search
   - awesome-pages
-  - mkdocs-video
+  - mkdocs-video:
+      is_video: True
+      video_autoplay: True
+      video_loop: True
+      video_muted: True
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
Resolving the following issues mentioned by @alexcg1:

- data_types/image/image/ - some local URLs need to be to class names, not HTML pages
- data_types/image/audio/ - some local URLs need to be to class names, not HTML pages
- data_types/image/video/ - some local URLs need to be to class names, not HTML pages

**===>** as for the local urls, I used those for `ImageTensor`, `AudioTensor`, `AnyTensor` etc. I linked to the corresponding docs typing section, because they don't show up correctly in the `API reference` section. Will leave it like this for now.

- data_types/video/video/ - video file plays with audio - very distracting

**===>** fixed: muted loop autoplay

- 3d - huge lumps of nasty code for rendering meshes. can we do iframes instead?

**===>** I am not getting this to work while extracting the iframes to a seperate file.
I tried putting the `srcdoc` content to a separate file (`<!DOCTYPE html><html lang=&quot;en&quot;> .... `) and then load it in an iframe:
```
<iframe src="../iframe_3d_mesh.html" width="100%" height="500px"></iframe>
```
but it would not be able to load it. @alexcg1 do you know how to solve this? Otherwise i'll leave it like this for now
