### PR TITLE
docs: consistent wording

### DIFF
--- a/docs/user_guide/storing/first_step.md
+++ b/docs/user_guide/storing/first_step.md
@@ -1,4 +1,4 @@
-# Overview
+# Introduction
 
 In the previous sections we saw how to use [`BaseDoc`][docarray.base_doc.doc.BaseDoc], [`DocList`][docarray.array.doc_list.doc_list.DocList] and [`DocVec`][docarray.array.doc_vec.doc_vec.DocVec] to represent multi-modal data and send it over the wire.
 In this section we will see how to store and persist this data.

--- a/docs/user_guide/storing/first_steps.md
+++ b/docs/user_guide/storing/first_steps.md
@@ -1,4 +1,4 @@
-# Overview
+# Introduction
 
 A Document Index lets you store your Documents and search through them using vector similarity.
 

--- a/docs/user_guide/storing/index_elastic.md
+++ b/docs/user_guide/storing/index_elastic.md
@@ -1,4 +1,4 @@
-# ElasticSearch Document Index
+# Elasticsearch Document Index
 
 DocArray comes with two Document Indexes for [Elasticsearch](https://www.elastic.co/elasticsearch/):
 
@@ -33,7 +33,7 @@ DocArray comes with two Document Indexes for [Elasticsearch](https://www.elastic
 The following examples is based on [ElasticDocIndex][docarray.index.backends.elastic.ElasticDocIndex],
 but will also work for [ElasticV7DocIndex][docarray.index.backends.elasticv7.ElasticV7DocIndex].
 
-# Start ElasticSearch
+# Start Elasticsearch
 
 You can use docker-compose to create a local Elasticsearch service with the following `docker-compose.yml`.
 


### PR DESCRIPTION
- `Overview` to `Introduction` throughout
- Fix `ElasticSearch` to `Elasticsearch`

Signed-off-by: Alex C-G <alexcg@outlook.com>