### PR TITLE
feat: point to older versions when importing Document or DocumentArray

### DIFF
--- a/docarray/__init__.py
+++ b/docarray/__init__.py
@@ -20,7 +20,7 @@ def __getattr__(name: str):
     if name in ['Document', 'DocumentArray']:
         raise ImportError(
             f'Cannot import name \'{name}\' from \'{_get_path_from_docarray_root_level(__file__)}\'.\n'
-            f'The concept of \'{name}\' does not exist in this version of docarray.\n'
+            f'The object named \'{name}\' does not exist anymore in this version of docarray.\n'
             f'If you still want to use \'{name}\' please downgrade to version <=0.21.0 '
             f'with: `pip install -U docarray==0.21.0`.'
         )


### PR DESCRIPTION
Point to older docarray versions from v1 if someone tries to run:
```python
from docarray import Document, DocumentArray
```
Throw error with instructions to install older version:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/73693835/233006771-8fe910ce-2652-4a99-9848-6a6c8761a334.png">
