### PR TITLE
fix: save index during creation for hnswlib

### DIFF
--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -116,7 +116,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 self._hnsw_indices[col_name] = self._load_index(col_name, col)
                 self._logger.info(f'Loading an existing index for column `{col_name}`')
             else:
-                self._hnsw_indices[col_name] = self._create_index(col)
+                self._hnsw_indices[col_name] = self._create_index(col_name, col)
                 self._logger.info(f'Created a new index for column `{col_name}`')
 
         # SQLite setup
@@ -396,13 +396,14 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
             construct_params['dim'] = col.n_dim
         return hnswlib.Index(**construct_params)
 
-    def _create_index(self, col: '_ColumnInfo') -> hnswlib.Index:
+    def _create_index(self, col_name: str, col: '_ColumnInfo') -> hnswlib.Index:
         """Create a new HNSW index for a column, and initialize it."""
         index = self._create_index_class(col)
         init_params = dict((k, col.config[k]) for k in self._index_init_params)
         index.init_index(**init_params)
         index.set_ef(col.config['ef'])
         index.set_num_threads(col.config['num_threads'])
+        index.save_index(self._hnsw_locations[col_name])
         return index
 
     # SQLite helpers

--- a/tests/index/hnswlib/test_persist_data.py
+++ b/tests/index/hnswlib/test_persist_data.py
@@ -78,3 +78,8 @@ def test_persist_and_restore_nested(tmp_path):
         ]
     )
     assert store.num_docs() == 15
+
+
+def test_persist_index_file(tmp_path):
+    _ = HnswDocumentIndex[SimpleDoc](work_dir=str(tmp_path))
+    _ = HnswDocumentIndex[SimpleDoc](work_dir=str(tmp_path))


### PR DESCRIPTION
This PR is related to issue #1351 

The issue is that using two time the same `work_dir` lead to error.

```python
from docarray.documents import ImageDoc
from docarray.index import HnswDocumentIndex

# create a Document Index
index = HnswDocumentIndex[ImageDoc](work_dir='/tmp/test_index2')
index = HnswDocumentIndex[ImageDoc](work_dir='/tmp/test_index2') # second time is failing
```

The error is that hnswlib index file `.bin` is created in function `index()` but not `_create_index()`. Second time it tries to load `.bin` file from the `work_dir`, which doesn't exist.