### PR TITLE
fix: torch tensor with grad to numpy

### DIFF
--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -854,9 +854,9 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             return val.unwrap().numpy()
         if isinstance(val, (list, tuple)):
             return np.array(val)
-        if (torch is not None and isinstance(val, torch.Tensor)) or (
-            tf is not None and isinstance(val, tf.Tensor)
-        ):
+        if torch is not None and isinstance(val, torch.Tensor):
+            return val.detach().numpy()
+        if tf is not None and isinstance(val, tf.Tensor):
             return val.numpy()
         if allow_passthrough:
             return val


### PR DESCRIPTION
Fixes a bug in Document Index where torch tensors that require grad were not able to be converted to np array