### PR TITLE
feat: add config to load more field that the schema

### DIFF
--- a/docarray/base_doc/any_doc.py
+++ b/docarray/base_doc/any_doc.py
@@ -8,6 +8,10 @@ class AnyDoc(BaseDoc):
     AnyDoc is a Document that is not tied to any schema
     """
 
+    class Config:
+        load_extra_fields_from_protobuf = True  # I introduce this variable to allow to load more that the fields defined in the schema
+        # will documented this behavior later if this fix our problem
+
     def __init__(self, **kwargs):
         super().__init__()
         self.__dict__.update(kwargs)

--- a/docarray/base_doc/any_doc.py
+++ b/docarray/base_doc/any_doc.py
@@ -26,3 +26,9 @@ class AnyDoc(BaseDoc):
         :return:
         """
         return AnyDoc
+
+    @classmethod
+    def _get_field_type_array(cls, field: str) -> Type:
+        from docarray import DocList
+
+        return DocList

--- a/docarray/base_doc/any_doc.py
+++ b/docarray/base_doc/any_doc.py
@@ -9,7 +9,7 @@ class AnyDoc(BaseDoc):
     """
 
     class Config:
-        load_extra_fields_from_protobuf = True  # I introduce this variable to allow to load more that the fields defined in the schema
+        _load_extra_fields_from_protobuf = True  # I introduce this variable to allow to load more that the fields defined in the schema
         # will documented this behavior later if this fix our problem
 
     def __init__(self, **kwargs):

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -36,7 +36,28 @@ T_update = TypeVar('T_update', bound='UpdateMixin')
 
 class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
     """
-    The base class for Documents
+    BaseDoc is the base class for all Documents. This class should be subclassed
+    to create new Document types with a specific schema.
+
+    The schema of a Document is defined by the fields of the class.
+
+    Example:
+    ```python
+    from docarray import BaseDoc
+    from docarray.typing import NdArray, ImageUrl
+    import numpy as np
+
+
+    class MyDoc(BaseDoc):
+        embedding: NdArray[512]
+        image: ImageUrl
+
+
+    doc = MyDoc(embedding=np.zeros(512), image='https://example.com/image.jpg')
+    ```
+
+
+    BaseDoc is a subclass of [pydantic.BaseModel](https://docs.pydantic.dev/usage/models/) and can be used in a similar way.
     """
 
     id: Optional[ID] = Field(default_factory=lambda: ID(os.urandom(16).hex()))

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -71,7 +71,7 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
         json_encoders = {AbstractTensor: lambda x: x}
 
         validate_assignment = True
-        load_extra_fields_from_protobuf = False
+        _load_extra_fields_from_protobuf = False
 
     @classmethod
     def from_view(cls: Type[T], storage_view: 'ColumnStorageView') -> T:

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -50,6 +50,7 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
         json_encoders = {AbstractTensor: lambda x: x}
 
         validate_assignment = True
+        load_extra_fields_from_protobuf = False
 
     @classmethod
     def from_view(cls: Type[T], storage_view: 'ColumnStorageView') -> T:

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -39,7 +39,6 @@ else:
     if torch is not None:
         from docarray.typing import TorchTensor
 
-
 T = TypeVar('T', bound='IOMixin')
 
 
@@ -122,6 +121,9 @@ class IOMixin(Iterable[Tuple[str, Any]]):
 
     __fields__: Dict[str, 'ModelField']
 
+    class Config:
+        load_extra_fields_from_protobuf: bool
+
     @classmethod
     @abstractmethod
     def _get_field_type(cls, field: str) -> Type:
@@ -153,7 +155,8 @@ class IOMixin(Iterable[Tuple[str, Any]]):
             bstr = self.to_protobuf().SerializePartialToString()
         else:
             raise ValueError(
-                f'protocol={protocol} is not supported. Can be only `protobuf` or pickle protocols 0-5.'
+                f'protocol={protocol} is not supported. Can be only `protobuf` or '
+                f'pickle protocols 0-5.'
             )
         return _compress_bytes(bstr, algorithm=compress)
 
@@ -182,7 +185,8 @@ class IOMixin(Iterable[Tuple[str, Any]]):
             return cls.from_protobuf(pb_msg)
         else:
             raise ValueError(
-                f'protocol={protocol} is not supported. Can be only `protobuf` or pickle protocols 0-5.'
+                f'protocol={protocol} is not supported. Can be only `protobuf` or '
+                f'pickle protocols 0-5.'
             )
 
     def to_base64(

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -127,6 +127,10 @@ class IOMixin(Iterable[Tuple[str, Any]]):
     def _get_field_type(cls, field: str) -> Type:
         ...
 
+    @classmethod
+    def _get_field_type_array(cls, field: str) -> Type:
+        return cls._get_field_type(field)
+
     def __bytes__(self) -> bytes:
         return self.to_bytes()
 
@@ -256,12 +260,20 @@ class IOMixin(Iterable[Tuple[str, Any]]):
             return_field = content_type_dict[docarray_type].from_protobuf(
                 getattr(value, content_key)
             )
-        elif content_key in ['doc', 'doc_array']:
+        elif content_key == 'doc':
             if field_name is None:
                 raise ValueError(
-                    'field_name cannot be None when trying to deseriliaze a Document or a DocList'
+                    'field_name cannot be None when trying to deseriliaze a BaseDoc'
                 )
             return_field = cls._get_field_type(field_name).from_protobuf(
+                getattr(value, content_key)
+            )  # we get to the parent class
+        elif content_key == 'doc_array':
+            if field_name is None:
+                raise ValueError(
+                    'field_name cannot be None when trying to deseriliaze a BaseDoc'
+                )
+            return_field = cls._get_field_type_array(field_name).from_protobuf(
                 getattr(value, content_key)
             )  # we get to the parent class
         elif content_key is None:

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -219,7 +219,10 @@ class IOMixin(Iterable[Tuple[str, Any]]):
         fields: Dict[str, Any] = {}
 
         for field_name in pb_msg.data:
-            if field_name not in cls.__fields__.keys():
+            if (
+                not (cls.Config.load_extra_fields_from_protobuf)
+                and field_name not in cls.__fields__.keys()
+            ):
                 continue  # optimization we don't even load the data if the key does not
                 # match any field in the cls or in the mapping
 

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -122,7 +122,7 @@ class IOMixin(Iterable[Tuple[str, Any]]):
     __fields__: Dict[str, 'ModelField']
 
     class Config:
-        load_extra_fields_from_protobuf: bool
+        _load_extra_fields_from_protobuf: bool
 
     @classmethod
     @abstractmethod
@@ -228,7 +228,7 @@ class IOMixin(Iterable[Tuple[str, Any]]):
 
         for field_name in pb_msg.data:
             if (
-                not (cls.Config.load_extra_fields_from_protobuf)
+                not (cls.Config._load_extra_fields_from_protobuf)
                 and field_name not in cls.__fields__.keys()
             ):
                 continue  # optimization we don't even load the data if the key does not

--- a/tests/units/array/test_array_proto.py
+++ b/tests/units/array/test_array_proto.py
@@ -68,3 +68,26 @@ def test_any_doc_list_proto():
     pt = DocList([doc]).to_protobuf()
     docs = DocList.from_protobuf(pt)
     assert docs[0].dict()['hello'] == 'world'
+
+
+@pytest.mark.proto
+def test_any_nested_doc_list_proto():
+    from docarray import BaseDoc, DocList
+
+    class TextDocWithId(BaseDoc):
+        id: str
+        text: str
+
+    class ResultTestDoc(BaseDoc):
+        matches: DocList[TextDocWithId]
+
+    index_da = DocList[TextDocWithId](
+        [TextDocWithId(id=f'{i}', text=f'ID {i}') for i in range(10)]
+    )
+
+    out_da = DocList[ResultTestDoc]([ResultTestDoc(matches=index_da[0:2])])
+    pb = out_da.to_protobuf()
+    docs = DocList.from_protobuf(pb)
+    assert docs[0].matches[0].id == '0'
+    assert len(docs[0].matches) == 2
+    assert len(docs) == 1

--- a/tests/units/array/test_array_proto.py
+++ b/tests/units/array/test_array_proto.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from docarray import BaseDoc, DocList
+from docarray.base_doc import AnyDoc
 from docarray.documents import ImageDoc, TextDoc
 from docarray.typing import NdArray
 
@@ -59,3 +60,11 @@ def test_nested_proto_any_doc():
     )
 
     DocList.from_protobuf(da.to_protobuf())
+
+
+@pytest.mark.proto
+def test_any_doc_list_proto():
+    doc = AnyDoc(hello='world')
+    pt = DocList([doc]).to_protobuf()
+    docs = DocList.from_protobuf(pt)
+    assert docs[0].dict()['hello'] == 'world'

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -287,7 +287,6 @@ def test_super_complex_nested():
     (doc2.data['hello'][3][0] == torch.ones(55)).all()
 
 
-@pytest.mark.proto
 @pytest.mark.tensorflow
 def test_super_complex_nested_tensorflow():
     class MyDoc(BaseDoc):

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from docarray import DocList
-from docarray.base_doc import BaseDoc
+from docarray.base_doc import AnyDoc, BaseDoc
 from docarray.typing import NdArray, TorchTensor
 from docarray.utils._internal.misc import is_tf_available
 
@@ -287,6 +287,7 @@ def test_super_complex_nested():
     (doc2.data['hello'][3][0] == torch.ones(55)).all()
 
 
+@pytest.mark.proto
 @pytest.mark.tensorflow
 def test_super_complex_nested_tensorflow():
     class MyDoc(BaseDoc):
@@ -296,3 +297,11 @@ def test_super_complex_nested_tensorflow():
     doc = MyDoc(data=data)
 
     MyDoc.from_protobuf(doc.to_protobuf())
+
+
+@pytest.mark.proto
+def test_any_doc_proto():
+    doc = AnyDoc(hello='world')
+    pt = doc.to_protobuf()
+    doc2 = AnyDoc.from_protobuf(pt)
+    assert doc2.dict()['hello'] == 'world'


### PR DESCRIPTION
# Context

the goal of this pr is to allow AnyDoc to load any protobuf file without knowing the class beforehand

code example :

```python
from docarray.base_doc.any_doc import AnyDoc

doc = AnyDoc(hello='world')

print(f"doc= \n {doc}")
pt = doc.to_protobuf()
print(f"pt= \n {pt}")
doc2 = AnyDoc.from_protobuf(pt)
print(f"doc2= \n {doc2}")
assert doc2.dict()['hello'] == 'world'
```