### PR TITLE
fix: len check in doc index logger if docs isinstance of BaseDoc

### DIFF
--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -387,7 +387,8 @@ class BaseDocIndex(ABC, Generic[TSchema]):
 
         :param docs: Documents to index.
         """
-        self._logger.debug(f'Indexing {len(docs)} documents')
+        n_docs = 1 if isinstance(docs, BaseDoc) else len(docs)
+        self._logger.debug(f'Indexing {n_docs} documents')
         docs_validated = self._validate_docs(docs)
         data_by_columns = self._get_col_value_dict(docs_validated)
         self._index(data_by_columns, **kwargs)

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -203,7 +203,8 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
         if kwargs:
             raise ValueError(f'{list(kwargs.keys())} are not valid keyword arguments')
 
-        self._logger.debug(f'Indexing {len(docs)} documents')
+        n_docs = 1 if isinstance(docs, BaseDoc) else len(docs)
+        self._logger.debug(f'Indexing {n_docs} documents')
         docs_validated = self._validate_docs(docs)
         data_by_columns = self._get_col_value_dict(docs_validated)
         hashed_ids = tuple(self._to_hashed_id(doc.id) for doc in docs_validated)


### PR DESCRIPTION
`DocIndex.index()` method allows `Union[BaseDoc, Sequence[BaseDoc]]` as input. As a first step in the method we check for docs length (`len(docs)`), which fails if docs is an instance of BaseDoc, instead of a list. 
Therefore we need to adjust the check.