### PR TITLE
fix: raise error when calling to csv or to dataframe on non homegenou…

### DIFF
--- a/docarray/array/doc_list/io.py
+++ b/docarray/array/doc_list/io.py
@@ -432,6 +432,12 @@ class IOMixinArray(Iterable[T_doc]):
             `'unix'` (for csv file generated on UNIX systems).
 
         """
+        if self.doc_type == AnyDoc:
+            raise TypeError(
+                'DocList must be homogeneous to be converted to a csv.'
+                'There is no document schema defined. '
+                'Please specify the DocList\'s Document type using `DocList[MyDoc]`.'
+            )
         fields = self.doc_type._get_access_paths()
 
         with open(file_path, 'w') as csv_file:
@@ -531,6 +537,13 @@ class IOMixinArray(Iterable[T_doc]):
             import pandas as pd
         else:
             pd = import_library('pandas', raise_error=True)
+
+        if self.doc_type == AnyDoc:
+            raise TypeError(
+                'DocList must be homogeneous to be converted to a DataFrame.'
+                'There is no document schema defined. '
+                'Please specify the DocList\'s Document type using `DocList[MyDoc]`.'
+            )
 
         fields = self.doc_type._get_access_paths()
         df = pd.DataFrame(columns=fields)

--- a/tests/units/array/test_array_from_to_csv.py
+++ b/tests/units/array/test_array_from_to_csv.py
@@ -110,3 +110,13 @@ def test_from_remote_csv_file():
     books = DocList[Book].from_csv(file_path=remote_url)
 
     assert len(books) == 3
+
+
+def test_doc_list_error(tmpdir):
+    class Book(BaseDoc):
+        title: str
+
+    docs = DocList([Book(title='hello'), Book(title='world')])
+    tmp_file = str(tmpdir / 'tmp.csv')
+    with pytest.raises(TypeError):
+        docs.to_csv(tmp_file)

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -85,3 +85,12 @@ def test_from_pandas_with_wrong_schema_raise_exception(nested_doc):
             columns=['title', 'count'], data=[['title 0', 0], ['title 1', 1]]
         )
         DocList[nested_doc.__class__].from_dataframe(df=df)
+
+
+def test_doc_list_error():
+    class Book(BaseDoc):
+        title: str
+
+    docs = DocList([Book(title='hello'), Book(title='world')])
+    with pytest.raises(TypeError):
+        docs.to_dataframe()


### PR DESCRIPTION
# Context

 raise error when calling to csv or to dataframe on non homogenous DocList

fixing : https://github.com/docarray/docarray/issues/1463

