### PR TITLE
fix: from proto for nested List and Dict

### DIFF
--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -312,8 +312,11 @@ class IOMixin(Iterable[Tuple[str, Any]]):
 
             elif content_key == 'dict':
                 deser_dict: Dict[str, Any] = dict()
+                field_type = cls.__fields__[field_name].type_ if field_name else None
                 for key_name, node in value.dict.data.items():
-                    deser_dict[key_name] = cls._get_content_from_node_proto(node)
+                    deser_dict[key_name] = cls._get_content_from_node_proto(
+                        node, field_type=field_type
+                    )
                 return_field = deser_dict
             else:
                 raise ValueError(

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -258,7 +258,9 @@ class IOMixin(Iterable[Tuple[str, Any]]):
         if field_name is not None and field_type is not None:
             raise ValueError("field_type and field_name cannot be both passed")
 
-        field_type = field_type or cls._get_field_type(field_name)
+        field_type = (
+            field_type or cls._get_field_type(field_name) if field_name else None
+        )
 
         content_type_dict = _PROTO_TYPE_NAME_TO_CLASS
 
@@ -302,10 +304,9 @@ class IOMixin(Iterable[Tuple[str, Any]]):
                 return_field = getattr(value, content_key)
 
             elif content_key in arg_to_container.keys():
+                field_type = cls.__fields__[field_name].type_ if field_name else None
                 return_field = arg_to_container[content_key](
-                    cls._get_content_from_node_proto(
-                        node, field_type=cls.__fields__[field_name].type_
-                    )
+                    cls._get_content_from_node_proto(node, field_type=field_type)
                     for node in getattr(value, content_key).data
                 )
 

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -258,8 +258,8 @@ class IOMixin(Iterable[Tuple[str, Any]]):
         if field_name is not None and field_type is not None:
             raise ValueError("field_type and field_name cannot be both passed")
 
-        field_type = (
-            field_type or cls._get_field_type(field_name) if field_name else None
+        field_type = field_type or (
+            cls._get_field_type(field_name) if field_name else None
         )
 
         content_type_dict = _PROTO_TYPE_NAME_TO_CLASS
@@ -286,7 +286,7 @@ class IOMixin(Iterable[Tuple[str, Any]]):
         elif content_key == 'doc_array':
             if field_name is None:
                 raise ValueError(
-                    'field_name cannot be None when trying to deseriliaze a BaseDoc'
+                    'field_name cannot be None when trying to deserialize a BaseDoc'
                 )
             return_field = cls._get_field_type_array(field_name).from_protobuf(
                 getattr(value, content_key)

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -101,6 +101,11 @@ def _type_to_protobuf(value: Any) -> 'NodeProto':
         data = {}
 
         for key, content in value.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f'Protobuf only support string as key, but got {type(key)}'
+                )
+
             data[key] = _type_to_protobuf(content)
 
         struct = DictOfAnyProto(data=data)

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -304,3 +304,25 @@ def test_any_doc_proto():
     pt = doc.to_protobuf()
     doc2 = AnyDoc.from_protobuf(pt)
     assert doc2.dict()['hello'] == 'world'
+
+
+def test_nested_list():
+    from typing import List
+
+    from docarray import BaseDoc, DocList
+    from docarray.documents import TextDoc
+
+    class TextDocWithId(TextDoc):
+        id: str
+
+    class ResultTestDoc(BaseDoc):
+        matches: List[TextDocWithId]
+
+    da = DocList[ResultTestDoc](
+        [
+            ResultTestDoc(matches=[TextDocWithId(id=f'{i}') for _ in range(10)])
+            for i in range(10)
+        ]
+    )
+
+    DocList[ResultTestDoc].from_protobuf(da.to_protobuf())

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -221,6 +221,17 @@ def test_nested_dict():
 
 
 @pytest.mark.proto
+def test_nested_dict_error():
+    class MyDoc(BaseDoc):
+        data: Dict
+
+    doc = MyDoc(data={0: (1, 2)})
+
+    with pytest.raises(ValueError, match="Protobuf only support string as key"):
+        doc.to_protobuf()
+
+
+@pytest.mark.proto
 def test_tuple_complex():
     class MyDoc(BaseDoc):
         data: Tuple

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -306,6 +306,7 @@ def test_any_doc_proto():
     assert doc2.dict()['hello'] == 'world'
 
 
+@pytest.mark.proto
 def test_nested_list():
     from typing import List
 

--- a/tests/units/document/proto/test_document_proto.py
+++ b/tests/units/document/proto/test_document_proto.py
@@ -327,3 +327,24 @@ def test_nested_list():
     )
 
     DocList[ResultTestDoc].from_protobuf(da.to_protobuf())
+
+
+@pytest.mark.proto
+def test_nested_dict_typed():
+    from docarray import BaseDoc, DocList
+    from docarray.documents import TextDoc
+
+    class TextDocWithId(TextDoc):
+        id: str
+
+    class ResultTestDoc(BaseDoc):
+        matches: Dict[str, TextDocWithId]
+
+    da = DocList[ResultTestDoc](
+        [
+            ResultTestDoc(matches={f'{i}': TextDocWithId(id=f'{i}') for _ in range(10)})
+            for i in range(10)
+        ]
+    )
+
+    DocList[ResultTestDoc].from_protobuf(da.to_protobuf())


### PR DESCRIPTION
# Context

This pr fixes several bugs related to proto.



- [x] Nested typed List/Set/Tuple with doc inside are now working
- [x] Nested typed Dict with doc inside are now working
- [x] raise informative error message when a dict does not have a string field but to_protobuf is called




## Example

```python
    from typing import List

    from docarray import BaseDoc, DocList
    from docarray.documents import TextDoc

    class TextDocWithId(TextDoc):
        id: str

    class ResultTestDoc(BaseDoc):
        matches: List[TextDocWithId]

    da = DocList[ResultTestDoc](
        [
            ResultTestDoc(matches=[TextDocWithId(id=f'{i}') for _ in range(10)])
            for i in range(10)
        ]
    )

    DocList[ResultTestDoc].from_protobuf(da.to_protobuf())
```