### PR TITLE
fix: use `pd.concat()` instead `df.append()` in `to_dataframe()` to avoid warning

### DIFF
--- a/docarray/array/doc_list/io.py
+++ b/docarray/array/doc_list/io.py
@@ -543,8 +543,8 @@ class IOMixinArray(Iterable[T_doc]):
         df = pd.DataFrame(columns=fields)
 
         for doc in self:
-            doc_dict = _dict_to_access_paths(doc.dict())
-            df = df.append(doc_dict, ignore_index=True)
+            df_doc = pd.DataFrame(_dict_to_access_paths(doc.dict()))
+            df = pd.concat([df, df_doc], ignore_index=True)
 
         return df
 

--- a/docarray/array/doc_list/io.py
+++ b/docarray/array/doc_list/io.py
@@ -543,8 +543,9 @@ class IOMixinArray(Iterable[T_doc]):
         df = pd.DataFrame(columns=fields)
 
         for doc in self:
-            df_doc = pd.DataFrame(_dict_to_access_paths(doc.dict()))
-            df = pd.concat([df, df_doc], ignore_index=True)
+            doc_dict = _dict_to_access_paths(doc.dict())
+            doc_dict = {k: [v] for k, v in doc_dict.items()}
+            df = pd.concat([df, pd.DataFrame.from_dict(doc_dict)], ignore_index=True)
 
         return df
 


### PR DESCRIPTION
To avoid this warning, use `pd.concat()`:
<img width="1853" alt="image" src="https://user-images.githubusercontent.com/73693835/235101195-3513cea0-98b8-42de-869c-a90eb18c3d09.png">
