### PR TITLE
fix: fix to dict exclude

### DIFF
--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -278,7 +278,7 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
         if exclude is None:
             exclude = set(doclist_exclude_fields)
         elif isinstance(exclude, AbstractSet):
-            exclude = set(*exclude, *doclist_exclude_fields)
+            exclude = set([*exclude, *doclist_exclude_fields])
         elif isinstance(exclude, Mapping):
             exclude = dict(**exclude)
             exclude.update({field: ... for field in doclist_exclude_fields})
@@ -295,8 +295,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
 
         for field in doclist_exclude_fields:
             # we need to do this because pydantic will not recognize DocList correctly
-            if original_exclude:
-                if field not in original_exclude:
-                    data[field] = [doc.dict() for doc in getattr(self, field)]
+            original_exclude = original_exclude or {}
+            if field not in original_exclude:
+                data[field] = [doc.dict() for doc in getattr(self, field)]
 
         return data

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -109,7 +109,7 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
 
     @classmethod
     def schema_summary(cls) -> None:
-        """Print a summary of the Documents schema."""
+        """Print a summary Fof the Documents schema."""
         from docarray.display.document_summary import DocumentSummary
 
         DocumentSummary.schema_summary(cls)
@@ -270,7 +270,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
         for field in self.__fields__.keys():
             from docarray import DocList
 
-            if issubclass(self._get_field_type(field), DocList):
+            type_ = self._get_field_type(field)
+            if isinstance(type_, type) and issubclass(type_, DocList):
                 doclist_exclude_fields.append(field)
 
         original_exclude = exclude

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -109,7 +109,7 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
 
     @classmethod
     def schema_summary(cls) -> None:
-        """Print a summary Fof the Documents schema."""
+        """Print a summary of the Documents schema."""
         from docarray.display.document_summary import DocumentSummary
 
         DocumentSummary.schema_summary(cls)

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -277,8 +277,9 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
         if exclude is None:
             exclude = set(doclist_exclude_fields)
         elif isinstance(exclude, AbstractSet):
-            exclude.update(doclist_exclude_fields)
+            exclude = set(*exclude, *doclist_exclude_fields)
         elif isinstance(exclude, Mapping):
+            exclude = dict(**exclude)
             exclude.update({field: ... for field in doclist_exclude_fields})
 
         data = super().dict(
@@ -293,7 +294,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
 
         for field in doclist_exclude_fields:
             # we need to do this because pydantic will not recognize DocList correctly
-            if field not in original_exclude:
-                data[field] = [doc.dict() for doc in getattr(self, field)]
+            if original_exclude:
+                if field not in original_exclude:
+                    data[field] = [doc.dict() for doc in getattr(self, field)]
 
         return data

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -82,5 +82,4 @@ def test_nested_to_dict_exclude_set(nested_docs):
 
 def test_nested_to_dict_exclude_dict(nested_docs):  # doto change
     d = nested_docs.dict(exclude={'hello': True})
-    assert 'docs' not in d.keys()
     assert 'hello' not in d.keys()

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -1,6 +1,10 @@
 from typing import List, Optional
 
-from docarray.base_doc.doc import BaseDoc
+import numpy as np
+import pytest
+
+from docarray import BaseDoc, DocList
+from docarray.typing import NdArray
 
 
 def test_base_document_init():
@@ -43,3 +47,40 @@ def test_equal_nested_docs():
     )
 
     assert nested_docs == nested_docs
+
+
+@pytest.fixture
+def nested_docs():
+    class SimpleDoc(BaseDoc):
+        simple_tens: NdArray[10]
+
+    class NestedDoc(BaseDoc):
+        docs: DocList[SimpleDoc]
+        hello: str = 'world'
+
+    nested_docs = NestedDoc(
+        docs=DocList[SimpleDoc]([SimpleDoc(simple_tens=np.ones(10)) for j in range(2)]),
+    )
+
+    return nested_docs
+
+
+def test_nested_to_dict(nested_docs):
+    d = nested_docs.dict()
+    assert (d['docs'][0]['simple_tens'] == np.ones(10)).all()
+
+
+def test_nested_to_dict_exclude_1(nested_docs):
+    d = nested_docs.dict(exclude={'docs'})
+    assert 'docs' not in d.keys()
+
+
+def test_nested_to_dict_exclude_2(nested_docs):
+    d = nested_docs.dict(exclude={'hello'})
+    assert 'hello' not in d.keys()
+
+
+def test_nested_to_dict_exclude_3(nested_docs):  # doto change
+    d = nested_docs.dict(exclude={'hello': True})
+    assert 'docs' not in d.keys()
+    assert 'hello' not in d.keys()

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -70,17 +70,17 @@ def test_nested_to_dict(nested_docs):
     assert (d['docs'][0]['simple_tens'] == np.ones(10)).all()
 
 
-def test_nested_to_dict_exclude_1(nested_docs):
+def test_nested_to_dict_exclude(nested_docs):
     d = nested_docs.dict(exclude={'docs'})
     assert 'docs' not in d.keys()
 
 
-def test_nested_to_dict_exclude_2(nested_docs):
+def test_nested_to_dict_exclude_set(nested_docs):
     d = nested_docs.dict(exclude={'hello'})
     assert 'hello' not in d.keys()
 
 
-def test_nested_to_dict_exclude_3(nested_docs):  # doto change
+def test_nested_to_dict_exclude_dict(nested_docs):  # doto change
     d = nested_docs.dict(exclude={'hello': True})
     assert 'docs' not in d.keys()
     assert 'hello' not in d.keys()


### PR DESCRIPTION
# Context

this PR fix calling `dict` on a document that contain a nested DocList.

Now when calling `dict` with a nested DocList the dict results will be a list of dict whereas before it was just the DocList.


Fix the real problem that was hidden under this issue https://github.com/docarray/docarray/issues/1474 


```python
class SimpleDoc(BaseDoc):
    simple_tens: NdArray[10]

class NestedDoc(BaseDoc):
    docs: DocList[SimpleDoc]
    hello: str = 'world'

nested_docs = NestedDoc(
    docs=DocList[SimpleDoc]([SimpleDoc(simple_tens=np.ones(10)) for j in range(2)]),
) 

nested_docs.dict() # use to fail now is working
```