### PR TITLE
fix: fix nested doc to json

### DIFF
--- a/docarray/array/doc_list/doc_list.py
+++ b/docarray/array/doc_list/doc_list.py
@@ -13,6 +13,7 @@ from typing import (
     overload,
 )
 
+from pydantic import parse_obj_as
 from typing_extensions import SupportsIndex
 from typing_inspect import is_union_type
 
@@ -261,8 +262,13 @@ class DocList(
 
         if isinstance(value, (cls, DocVec)):
             return value
-        elif isinstance(value, Iterable):
+        elif isinstance(value, cls):
             return cls(value)
+        elif isinstance(value, Iterable):
+            docs = []
+            for doc in value:
+                docs.append(parse_obj_as(cls.doc_type, doc))
+            return cls(docs)
         else:
             raise TypeError(f'Expecting an Iterable of {cls.doc_type}')
 

--- a/tests/units/array/test_array.py
+++ b/tests/units/array/test_array.py
@@ -3,6 +3,7 @@ from typing import Optional, TypeVar, Union
 import numpy as np
 import pytest
 import torch
+from pydantic import parse_obj_as
 
 from docarray import BaseDoc, DocList
 from docarray.typing import ImageUrl, NdArray, TorchTensor
@@ -452,3 +453,18 @@ def test_optional_field():
     assert docs.features == [None for _ in range(10)]
     assert isinstance(docs.features, list)
     assert not isinstance(docs.features, DocList)
+
+
+def test_validate_list_dict():
+
+    images = [
+        dict(url=f'http://url.com/foo_{i}.png', tensor=NdArray(i)) for i in [2, 0, 1]
+    ]
+
+    docs = parse_obj_as(DocList[Image], images)
+
+    assert docs.url == [
+        'http://url.com/foo_2.png',
+        'http://url.com/foo_0.png',
+        'http://url.com/foo_1.png',
+    ]

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 import numpy as np
 import pytest
 
-from docarray import BaseDoc, DocList
+from docarray import DocList
+from docarray.base_doc.doc import BaseDoc
 from docarray.typing import NdArray
 
 
@@ -80,11 +81,11 @@ def test_nested_to_dict_exclude_set(nested_docs):
     assert 'hello' not in d.keys()
 
 
-def test_nested_to_dict_exclude_dict(nested_docs):  # doto change
+def test_nested_to_dict_exclude_dict(nested_docs):
     d = nested_docs.dict(exclude={'hello': True})
     assert 'hello' not in d.keys()
 
 
 def test_nested_to_json(nested_docs):
-    nested_docs.json()
-    # nested_docs.__class__.parse_raw(d)
+    d = nested_docs.json()
+    nested_docs.__class__.parse_raw(d)

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -83,3 +83,8 @@ def test_nested_to_dict_exclude_set(nested_docs):
 def test_nested_to_dict_exclude_dict(nested_docs):  # doto change
     d = nested_docs.dict(exclude={'hello': True})
     assert 'hello' not in d.keys()
+
+
+def test_nested_to_json(nested_docs):
+    nested_docs.json()
+    # nested_docs.__class__.parse_raw(d)


### PR DESCRIPTION
# Context

this pr is fixing : https://github.com/docarray/docarray/issues/1501

it allow to do 

```python
from docarray import DocVec, BaseDoc, DocList
from docarray.documents.image import ImageDoc

class Request(BaseDoc):
    images: DocList[ImageDoc]
        
images = DocList[ImageDoc]([ImageDoc(url=f'http://url.com/{i}.png') for i in range(10)])
request = Request(images=images)
request.json()
```
without having an error

## what this pr exactly do:

* when calling `json` it manually deal with the nested DocList, otherwise Pydantic does some weird logic because it think it is a List (which is it)
* Custom validation on DocList. Now if the input is not a DocList but a list of dict lets say, it will try to validate every member of the iterable with the `doc_type` and then create a DocList out of it