### PR TITLE
chore: fix cd for documentation

### DIFF
--- a/.github/workflows/force-docs-build.yml
+++ b/.github/workflows/force-docs-build.yml
@@ -78,6 +78,7 @@ jobs:
           git fetch origin ${{ inputs.pages_branch }}:${{ inputs.pages_branch }} --depth 1
           git checkout -f ${{ inputs.pages_branch }}
           git reset --hard HEAD
+          rm -rf docs
           mv /tmp/tmp_docs docs
 
       - name: Push it up!


### PR DESCRIPTION
# Context
fix : https://github.com/docarray/docarray/issues/1508
somehoe docs build dosn't work and copy past tmp_docs into the old docs folded instead of replacing it