### PR TITLE
fix: json and dict when calling empty doclist

### DIFF
--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -249,7 +249,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             # we need to do this because pydantic will not recognize DocList correctly
             original_exclude = original_exclude or {}
             if field not in original_exclude:
-                data[field] = [doc.dict() for doc in getattr(self, field)]
+                val = getattr(self, field)
+                data[field] = [doc.dict() for doc in val] if val is not None else None
 
         # this is copy from pydantic code
         if self.__custom_root_type__:
@@ -319,7 +320,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             # we need to do this because pydantic will not recognize DocList correctly
             original_exclude = original_exclude or {}
             if field not in original_exclude:
-                data[field] = [doc.dict() for doc in getattr(self, field)]
+                val = getattr(self, field)
+                data[field] = [doc.dict() for doc in val] if val is not None else None
 
         return data
 


### PR DESCRIPTION
# Context

fix `json` on LegacyDocument, and basically every optional nested