### PR TITLE
fix: fix json behavior of doclist to allow custom json encoder

### DIFF
--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -249,7 +249,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             # we need to do this because pydantic will not recognize DocList correctly
             original_exclude = original_exclude or {}
             if field not in original_exclude:
-                data[field] = [doc.dict() for doc in getattr(self, field)]
+                val = getattr(self, field)
+                data[field] = [doc.dict() for doc in val] if val is not None else None
 
         # this is copy from pydantic code
         if self.__custom_root_type__:
@@ -319,7 +320,8 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             # we need to do this because pydantic will not recognize DocList correctly
             original_exclude = original_exclude or {}
             if field not in original_exclude:
-                data[field] = [doc.dict() for doc in getattr(self, field)]
+                val = getattr(self, field)
+                data[field] = [doc.dict() for doc in val] if val is not None else None
 
         return data
 

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -252,8 +252,9 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             # we need to do this because pydantic will not recognize DocList correctly
             original_exclude = original_exclude or {}
             if field not in original_exclude:
-                val = getattr(self, field)
-                data[field] = [doc.dict() for doc in val] if val is not None else None
+                data[field] = getattr(
+                    self, field
+                )  # here we need to keep doclist as doclist otherwise if a user want to have a special json config it will not work
 
         # this is copy from pydantic code
         if self.__custom_root_type__:

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -151,6 +151,9 @@ class BaseDoc(BaseModel, IOMixin, UpdateMixin, BaseNode):
             object.__setattr__(self, '__dict__', dict_ref)
 
     def __eq__(self, other) -> bool:
+        if not isinstance(other, BaseDoc):
+            return False
+
         if self.__fields__.keys() != other.__fields__.keys():
             return False
 

--- a/tests/units/document/test_base_document.py
+++ b/tests/units/document/test_base_document.py
@@ -89,3 +89,28 @@ def test_nested_to_dict_exclude_dict(nested_docs):
 def test_nested_to_json(nested_docs):
     d = nested_docs.json()
     nested_docs.__class__.parse_raw(d)
+
+
+@pytest.fixture
+def nested_none_docs():
+    class SimpleDoc(BaseDoc):
+        simple_tens: NdArray[10]
+
+    class NestedDoc(BaseDoc):
+        docs: Optional[DocList[SimpleDoc]]
+        hello: str = 'world'
+
+    nested_docs = NestedDoc()
+
+    return nested_docs
+
+
+def test_nested_none_to_dict(nested_none_docs):
+    d = nested_none_docs.dict()
+    assert d == {'docs': None, 'hello': 'world', 'id': nested_none_docs.id}
+
+
+def test_nested_none_to_json(nested_none_docs):
+    d = nested_none_docs.json()
+    d = nested_none_docs.__class__.parse_raw(d)
+    assert d.dict() == {'docs': None, 'hello': 'world', 'id': nested_none_docs.id}


### PR DESCRIPTION
# Context

we need to let Doclist as they are inside BaseDoc otherwise custom json encoder will not worjk