### PR TITLE
fix: detach the torch tensors

### DIFF
--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -137,7 +137,7 @@ class TorchTensor(
         Convert `TorchTensor` into a json compatible object
         :return: a representation of the tensor compatible with orjson
         """
-        return self.numpy()  ## might need to check device later
+        return self.detach().numpy()  # might need to check device later
 
     def unwrap(self) -> torch.Tensor:
         """

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -63,7 +63,7 @@ def test_wrong_but_reshapable():
         parse_obj_as(TorchTensor[3, 224, 224], torch.zeros(224, 224))
 
 
-def test_inependent_variable_dim():
+def test_independent_variable_dim():
     # test independent variable dimensions
     tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
@@ -177,3 +177,16 @@ def test_deepcopy():
 
     doc_copy.embedding = torch.randn(32)
     assert not (doc.embedding == doc_copy.embedding).all()
+
+
+def test_serialization():
+    from docarray import BaseDoc
+
+    class MyDoc(BaseDoc):
+        tens: TorchTensor
+
+    doc = MyDoc(tens=torch.rand(10, requires_grad=False))
+    assert doc.json()
+
+    doc = MyDoc(tens=torch.rand(10, requires_grad=True))
+    assert doc.json()

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -1,9 +1,17 @@
+import json
+
 import pytest
 import torch
 from pydantic.tools import parse_obj_as, schema_json_of
 
+from docarray import BaseDoc
 from docarray.base_doc.io.json import orjson_dumps
+from docarray.proto import DocProto
 from docarray.typing import TorchEmbedding, TorchTensor
+
+
+class MyDoc(BaseDoc):
+    tens: TorchTensor
 
 
 @pytest.mark.proto
@@ -65,50 +73,50 @@ def test_wrong_but_reshapable():
 
 def test_independent_variable_dim():
     # test independent variable dimensions
-    tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 224, 224))
+    tensor = parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
 
 def test_param():
-    tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 60, 128))
+    tensor = parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(3, 60, 128))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 60, 128)
 
     with pytest.raises(ValueError):
-        parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(4, 224, 224))
+        parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(4, 224, 224))
 
     with pytest.raises(ValueError):
-        parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(100, 1))
+        parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(100, 1))
 
 
 def test_dependent_variable_dim():
     # test dependent variable dimensions
-    tensor = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 224, 224))
+    tensor = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
     with pytest.raises(ValueError):
-        _ = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 60, 128))
+        _ = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 60, 128))
 
     with pytest.raises(ValueError):
-        _ = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 60))
+        _ = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 60))
 
 
-@pytest.mark.parametrize('shape', [(3, 224, 224), (224, 224, 3)])
+@pytest.mark.parametrize("shape", [(3, 224, 224), (224, 224, 3)])
 def test_parameterized_tensor_class_name(shape):
     MyTT = TorchTensor[3, 224, 224]
     tensor = parse_obj_as(MyTT, torch.zeros(shape))
 
-    assert MyTT.__name__ == 'TorchTensor[3, 224, 224]'
-    assert MyTT.__qualname__ == 'TorchTensor[3, 224, 224]'
+    assert MyTT.__name__ == "TorchTensor[3, 224, 224]"
+    assert MyTT.__qualname__ == "TorchTensor[3, 224, 224]"
 
-    assert tensor.__class__.__name__ == 'TorchTensor'
-    assert tensor.__class__.__qualname__ == 'TorchTensor'
-    assert f'{tensor[0][0][0]}' == 'TorchTensor(0.)'
+    assert tensor.__class__.__name__ == "TorchTensor"
+    assert tensor.__class__.__qualname__ == "TorchTensor"
+    assert f"{tensor[0][0][0]}" == "TorchTensor(0.)"
 
 
 def test_torch_embedding():
@@ -179,14 +187,51 @@ def test_deepcopy():
     assert not (doc.embedding == doc_copy.embedding).all()
 
 
-def test_serialization():
-    from docarray import BaseDoc
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_json_serialization(requires_grad):
+    orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
+    serialized_doc = orig_doc.to_json()
+    assert serialized_doc
+    assert isinstance(serialized_doc, str)
 
-    class MyDoc(BaseDoc):
-        tens: TorchTensor
+    json_doc = json.loads(serialized_doc)
+    assert json_doc["tens"]
+    assert len(json_doc["tens"]) == 10
 
-    doc = MyDoc(tens=torch.rand(10, requires_grad=False))
-    assert doc.json()
 
-    doc = MyDoc(tens=torch.rand(10, requires_grad=True))
-    assert doc.json()
+@pytest.mark.parametrize("protocol", ["pickle", "protobuf"])
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_bytes_serialization(requires_grad, protocol):
+    orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
+    serialized_doc = orig_doc.to_bytes(protocol=protocol)
+    assert serialized_doc
+    assert isinstance(serialized_doc, bytes)
+
+    conv_doc = MyDoc.from_bytes(serialized_doc, protocol=protocol)
+    assert isinstance(conv_doc.tens, TorchTensor)
+    assert conv_doc.tens.shape == (10,)
+
+
+@pytest.mark.parametrize("protocol", ["pickle", "protobuf"])
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_base64_serialization(requires_grad, protocol):
+    orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
+    serialized_doc = orig_doc.to_base64(protocol=protocol)
+    assert serialized_doc
+    assert isinstance(serialized_doc, str)
+
+    conv_doc = MyDoc.from_base64(serialized_doc, protocol=protocol)
+    assert isinstance(conv_doc.tens, TorchTensor)
+    assert conv_doc.tens.shape == (10,)
+
+
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_protobuf_serialization(requires_grad):
+    orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
+    serialized_doc = orig_doc.to_protobuf()
+    assert serialized_doc
+    assert isinstance(serialized_doc, DocProto)
+
+    conv_doc = MyDoc.from_protobuf(serialized_doc)
+    assert isinstance(conv_doc.tens, TorchTensor)
+    assert conv_doc.tens.shape == (10,)

--- a/tests/units/typing/tensor/test_torch_tensor.py
+++ b/tests/units/typing/tensor/test_torch_tensor.py
@@ -73,50 +73,50 @@ def test_wrong_but_reshapable():
 
 def test_independent_variable_dim():
     # test independent variable dimensions
-    tensor = parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(3, 224, 224))
+    tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
 
 def test_param():
-    tensor = parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(3, 60, 128))
+    tensor = parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(3, 60, 128))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 60, 128)
 
     with pytest.raises(ValueError):
-        parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(4, 224, 224))
+        parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(4, 224, 224))
 
     with pytest.raises(ValueError):
-        parse_obj_as(TorchTensor[3, "x", "y"], torch.zeros(100, 1))
+        parse_obj_as(TorchTensor[3, 'x', 'y'], torch.zeros(100, 1))
 
 
 def test_dependent_variable_dim():
     # test dependent variable dimensions
-    tensor = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 224, 224))
+    tensor = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 224, 224))
     assert isinstance(tensor, TorchTensor)
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
 
     with pytest.raises(ValueError):
-        _ = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 60, 128))
+        _ = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 60, 128))
 
     with pytest.raises(ValueError):
-        _ = parse_obj_as(TorchTensor[3, "x", "x"], torch.zeros(3, 60))
+        _ = parse_obj_as(TorchTensor[3, 'x', 'x'], torch.zeros(3, 60))
 
 
-@pytest.mark.parametrize("shape", [(3, 224, 224), (224, 224, 3)])
+@pytest.mark.parametrize('shape', [(3, 224, 224), (224, 224, 3)])
 def test_parameterized_tensor_class_name(shape):
     MyTT = TorchTensor[3, 224, 224]
     tensor = parse_obj_as(MyTT, torch.zeros(shape))
 
-    assert MyTT.__name__ == "TorchTensor[3, 224, 224]"
-    assert MyTT.__qualname__ == "TorchTensor[3, 224, 224]"
+    assert MyTT.__name__ == 'TorchTensor[3, 224, 224]'
+    assert MyTT.__qualname__ == 'TorchTensor[3, 224, 224]'
 
-    assert tensor.__class__.__name__ == "TorchTensor"
-    assert tensor.__class__.__qualname__ == "TorchTensor"
-    assert f"{tensor[0][0][0]}" == "TorchTensor(0.)"
+    assert tensor.__class__.__name__ == 'TorchTensor'
+    assert tensor.__class__.__qualname__ == 'TorchTensor'
+    assert f'{tensor[0][0][0]}' == 'TorchTensor(0.)'
 
 
 def test_torch_embedding():
@@ -187,7 +187,7 @@ def test_deepcopy():
     assert not (doc.embedding == doc_copy.embedding).all()
 
 
-@pytest.mark.parametrize("requires_grad", [True, False])
+@pytest.mark.parametrize('requires_grad', [True, False])
 def test_json_serialization(requires_grad):
     orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
     serialized_doc = orig_doc.to_json()
@@ -195,12 +195,12 @@ def test_json_serialization(requires_grad):
     assert isinstance(serialized_doc, str)
 
     json_doc = json.loads(serialized_doc)
-    assert json_doc["tens"]
-    assert len(json_doc["tens"]) == 10
+    assert json_doc['tens']
+    assert len(json_doc['tens']) == 10
 
 
-@pytest.mark.parametrize("protocol", ["pickle", "protobuf"])
-@pytest.mark.parametrize("requires_grad", [True, False])
+@pytest.mark.parametrize('protocol', ['pickle', 'protobuf'])
+@pytest.mark.parametrize('requires_grad', [True, False])
 def test_bytes_serialization(requires_grad, protocol):
     orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
     serialized_doc = orig_doc.to_bytes(protocol=protocol)
@@ -212,8 +212,8 @@ def test_bytes_serialization(requires_grad, protocol):
     assert conv_doc.tens.shape == (10,)
 
 
-@pytest.mark.parametrize("protocol", ["pickle", "protobuf"])
-@pytest.mark.parametrize("requires_grad", [True, False])
+@pytest.mark.parametrize('protocol', ['pickle', 'protobuf'])
+@pytest.mark.parametrize('requires_grad', [True, False])
 def test_base64_serialization(requires_grad, protocol):
     orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
     serialized_doc = orig_doc.to_base64(protocol=protocol)
@@ -225,7 +225,7 @@ def test_base64_serialization(requires_grad, protocol):
     assert conv_doc.tens.shape == (10,)
 
 
-@pytest.mark.parametrize("requires_grad", [True, False])
+@pytest.mark.parametrize('requires_grad', [True, False])
 def test_protobuf_serialization(requires_grad):
     orig_doc = MyDoc(tens=torch.rand(10, requires_grad=requires_grad))
     serialized_doc = orig_doc.to_protobuf()


### PR DESCRIPTION
Detach `TorchTensors` before converting to `numpy` for serialization. 

Change is only needed for PyTorch as Tensorflow operates differently afaik. I have tried different initialization for tensorflow and the below serializing script worked without any error.


```python

import time

from docarray import BaseDoc
from docarray.typing import TensorFlowTensor
import tensorflow as tf


class MyDoc(BaseDoc):
    x: TensorFlowTensor
    y: TensorFlowTensor


# 1. Eager execution with GradientTape
x = tf.Variable(3.0)  # trainable: Default: `True`, GradientTapes automatically watch uses of this variable.

with tf.GradientTape() as tape:
    y = x**2

doc = MyDoc(x=x, y=y)
doc.json()


# 2. GradientTape with tf.function
@tf.function
def square(a):
    return a**2


x = tf.Variable(tf.random.normal((3, 2)))

with tf.GradientTape() as tape:
    y = square(x)

doc = MyDoc(x=x, y=y)
doc.json()

# 3. TF constants
x = tf.Variable(tf.random.normal((3, 2)))
y = tf.constant(2.0)

doc = MyDoc(x=x, y=y)
doc.json()

# 4. Full example
w = tf.Variable(tf.random.normal((3, 2)), name="w")
b = tf.Variable(tf.zeros(2, dtype=tf.float32), name="b")
x = [[1.0, 2.0, 3.0]]

with tf.GradientTape(persistent=True) as tape:
    y = x @ w + b
    loss = tf.reduce_mean(y**2)

[dl_dw, dl_db] = tape.gradient(loss, [w, b])

doc = MyDoc(x=dl_dw, y=dl_db)
doc.json()

```