### PR TITLE
docs(store_jac): remove wrong info

### DIFF
--- a/docs/user_guide/storing/doc_store/store_jac.md
+++ b/docs/user_guide/storing/doc_store/store_jac.md
@@ -37,9 +37,6 @@ dl.push(f'jac://{DL_NAME}')
 dl_pull = DocList[SimpleDoc].pull(f'jac://{DL_NAME}')
 ```
 
-!!! note
-    When using `.push()` and `.pull()`, `DocList` calls the default `boto3` client. Be sure your default session is correctly set up.
-
 ## Push and pull with streaming
 
 When you have a large amount of documents to push and pull, you can use the streaming function. 


### PR DESCRIPTION
This information is for `store_s3`, but wrongly copied to `store_jac` I believe.