### PR TITLE
fix: dict method for document view

### DIFF
--- a/docarray/array/doc_vec/column_storage.py
+++ b/docarray/array/doc_vec/column_storage.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    ItemsView,
     Iterable,
     MutableMapping,
     Optional,
@@ -142,15 +143,16 @@ class ColumnStorageView(dict, MutableMapping[str, Any]):
     def __len__(self):
         return len(self.storage.columns)
 
+    def _local_dict(self):
+        """The storage.columns dictionary with every value at position self.index"""
+
+        return {key: self[key] for key in self.storage.columns.keys()}
+
     def keys(self):
         return self.storage.columns.keys()
 
     def values(self):
-        storage_items = self.storage.columns.items()
-        print(f'{storage_items=}')
-        return ValuesView(
-            {
-                key: val[self.index] if val is not None else val
-                for key, val in storage_items
-            }
-        )
+        return ValuesView(self._local_dict())
+
+    def items(self):
+        return ItemsView(self._local_dict())

--- a/docarray/array/doc_vec/column_storage.py
+++ b/docarray/array/doc_vec/column_storage.py
@@ -9,6 +9,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    ValuesView,
 )
 
 from docarray.array.list_advance_indexing import ListAdvancedIndexing
@@ -143,3 +144,13 @@ class ColumnStorageView(dict, MutableMapping[str, Any]):
 
     def keys(self):
         return self.storage.columns.keys()
+
+    def values(self):
+        storage_items = self.storage.columns.items()
+        print(f'{storage_items=}')
+        return ValuesView(
+            {
+                key: val[self.index] if val is not None else val
+                for key, val in storage_items
+            }
+        )

--- a/docarray/array/doc_vec/column_storage.py
+++ b/docarray/array/doc_vec/column_storage.py
@@ -151,8 +151,12 @@ class ColumnStorageView(dict, MutableMapping[str, Any]):
     def keys(self):
         return self.storage.columns.keys()
 
-    def values(self):
+    # type ignore because return type dict_values is private and we cannot use it.
+    # context: https://github.com/python/typing/discussions/1033
+    def values(self) -> ValuesView:  # type: ignore
         return ValuesView(self._local_dict())
 
-    def items(self):
+    # type ignore because return type dict_items is private and we cannot use it.
+    # context: https://github.com/python/typing/discussions/1033
+    def items(self) -> ItemsView:  # type: ignore
         return ItemsView(self._local_dict())

--- a/tests/units/array/stack/storage/test_storage.py
+++ b/tests/units/array/stack/storage/test_storage.py
@@ -53,3 +53,32 @@ def test_column_storage_view():
     assert storage.any_columns['id'][0] == 1
     assert (storage.tensor_columns['tensor'][0] == np.ones(10)).all()
     assert storage.any_columns['name'][0] == 'byebye'
+
+
+def test_storage_view_dict_like():
+    class MyDoc(BaseDoc):
+        tensor: AnyTensor
+        name: str
+
+    docs = [MyDoc(tensor=np.zeros((10, 10)), name='hello', id=i) for i in range(4)]
+
+    storage = DocVec[MyDoc](docs)._storage
+
+    view = ColumnStorageView(0, storage)
+
+    assert list(view.keys()) == ['id', 'name', 'tensor']
+
+    # since boolean value of np array is ambiguous, we iterate manually
+    for val_view, val_reference in zip(view.values(), ['0', 'hello', np.zeros(10)]):
+        if isinstance(val_view, np.ndarray):
+            assert (val_view == val_reference).all()
+        else:
+            assert val_view == val_reference
+    for item_view, item_reference in zip(
+        view.items(), [('id', '0'), ('name', 'hello'), ('tensor', np.zeros(10))]
+    ):
+        if isinstance(item_view[1], np.ndarray):
+            assert item_view[0] == item_reference[0]
+            assert (item_view[1] == item_reference[1]).all()
+        else:
+            assert item_view == item_reference

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -571,3 +571,11 @@ def test_type_error_no_doc_type():
 
     with pytest.raises(TypeError):
         DocVec([BaseDoc() for _ in range(10)])
+
+
+def test_doc_view_dict(batch):
+    doc_view = batch[0]
+    assert doc_view.is_view()
+    d = doc_view.dict()
+    assert d['tensor'].shape == (3, 224, 224)
+    assert d['id'] == doc_view.id

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -579,3 +579,9 @@ def test_doc_view_dict(batch):
     d = doc_view.dict()
     assert d['tensor'].shape == (3, 224, 224)
     assert d['id'] == doc_view.id
+
+    doc_view_two = batch[1]
+    assert doc_view_two.is_view()
+    d = doc_view_two.dict()
+    assert d['tensor'].shape == (3, 224, 224)
+    assert d['id'] == doc_view_two.id


### PR DESCRIPTION
Before this, calling `doc.dict()` when `doc.is_view() == True` would return an empty dict.
The core issue is that the `ColumnStorageView` did not behave like a proper dict: `.values()` and `.keys()` were not implemented, and would return empty values.
That is fixed in this PR.