### PR TITLE
Validation bug Fix: DocList and DocVec are not coerced to each other

### DIFF
--- a/docarray/array/doc_list/doc_list.py
+++ b/docarray/array/doc_list/doc_list.py
@@ -267,8 +267,10 @@ class DocList(
     ):
         from docarray.array.doc_vec.doc_vec import DocVec
 
-        if isinstance(value, (cls, DocVec)):
+        if isinstance(value, cls):
             return value
+        elif isinstance(value, DocVec):
+            return value.to_doc_list()
         elif isinstance(value, cls):
             return cls(value)
         elif isinstance(value, Iterable):

--- a/docarray/array/doc_vec/doc_vec.py
+++ b/docarray/array/doc_vec/doc_vec.py
@@ -278,6 +278,8 @@ class DocVec(AnyDocArray[T_doc]):
     ) -> T:
         if isinstance(value, cls):
             return value
+        elif isinstance(value, DocList):
+            return value.to_doc_vec()
         elif isinstance(value, DocList.__class_getitem__(cls.doc_type)):
             return cast(T, value.to_doc_vec())
         elif isinstance(value, Sequence):


### PR DESCRIPTION

fixes issue #1545 

`
from docarray import BaseDoc, DocList, DocVec
from docarray.documents import ImageDoc


class Doc(BaseDoc):
    docs: DocList[ImageDoc]

d = Doc(docs=DocVec[ImageDoc]([ImageDoc()]))
# below gives <DocList[ImageDoc] (length=1)>
print(d.docs)


class OtherDoc(BaseDoc):
    docs: DocVec[ImageDoc]

d = Doc(docs=DocList[ImageDoc]([ImageDoc()]))
# below gives <DocVec[ImageDoc] (length=1)>
print(d.docs)

`