### PR TITLE
fix: support list in document class (#1557)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,29 +337,32 @@ Good docs make developers happy, and we love happy developers! We've got a few d
 
 ### Building documentation on your local machine
 
-#### Requirements
-
-* Python 3
-* [jq](https://stedolan.github.io/jq/download/)
 
 #### Steps to build locally
 
+First install the documentation dependency
+```
+poetry install --with docs
+```
+
+Note: if you need to install extra (proto, database, ...) you need to specify those as well.
+
+Then build the documentation:
 ```bash
 cd docs
-pip install -r requirements.txt
-export NUM_RELEASES=10
-bash makedoc.sh
+./makedoc.sh
 ```
 
 The docs website will be generated in `site`.
 To serve it, run:
 
 ```bash
-mkdocs serve
-python -m http.server
+cd ..
+poetry run mkdocs serve
 ```
 
 You can now see docs website on [http://localhost:8000](http://localhost:8000) on your browser.
+Note: You may have to change the port from 8000 to something else if you already have a server running on that port.
 
 ## 🙏 Thank you
 

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -390,7 +390,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
         for field_name, type_, _ in self._flatten_schema(
             cast(Type[BaseDoc], self._schema)
         ):
-            if issubclass(type_, AnyDocArray):
+            if safe_issubclass(type_, AnyDocArray):
                 for doc_id in key:
                     nested_docs_id = self._subindices[field_name]._filter_by_parent_id(
                         doc_id

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -98,7 +98,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
         }
         self._hnsw_indices = {}
         for col_name, col in self._column_infos.items():
-            if issubclass(col.docarray_type, AnyDocArray):
+            if BaseDocIndex.custom_issubclass(col.docarray_type, AnyDocArray):
                 continue
             if not col.config:
                 # non-tensor type; don't create an index
@@ -200,7 +200,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
             or None if ``python_type`` is not supported.
         """
         for allowed_type in HNSWLIB_PY_VEC_TYPES:
-            if issubclass(python_type, allowed_type):
+            if BaseDocIndex.custom_issubclass(python_type, allowed_type):
                 return np.ndarray
 
         return None  # all types allowed, but no db type needed
@@ -350,7 +350,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
         for field_name, type_, _ in self._flatten_schema(
             cast(Type[BaseDoc], self._schema)
         ):
-            if issubclass(type_, AnyDocArray):
+            if BaseDocIndex.custom_issubclass(type_, AnyDocArray):
                 for id in doc_ids:
                     doc = self.__getitem__(id)
                     sub_ids = [sub_doc.id for sub_doc in getattr(doc, field_name)]

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -34,7 +34,7 @@ def change_cls_name(cls: type, new_name: str, scope: Optional[dict] = None) -> N
     cls.__name__ = new_name
 
 
-def safe_issubclass(x: type, a_tuple: tuple) -> bool:
+def safe_issubclass(x: type, a_tuple: type) -> bool:
     """
     This is a modified version of the built-in 'issubclass' function to support non-class input.
     Traditional 'issubclass' calls can result in a crash if the input is non-class type (e.g. list/tuple).

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -33,7 +33,7 @@ def change_cls_name(cls: type, new_name: str, scope: Optional[dict] = None) -> N
     cls.__qualname__ = cls.__qualname__[: -len(cls.__name__)] + new_name
     cls.__name__ = new_name
 
-def safe_issubclass(x, a_tuple) -> bool:
+def safe_issubclass(x: type, a_tuple: tuple) -> bool:
     """
     This is a modified version of the built-in 'issubclass' function to support non-class input.
     Traditional 'issubclass' calls can result in a crash if the input is non-class type (e.g. list/tuple).

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -1,5 +1,6 @@
-from typing import Any, Optional, get_origin
+from typing import Any, Optional
 
+from typing_extensions import get_origin
 from typing_inspect import get_args, is_typevar, is_union_type
 
 from docarray.typing.tensor.abstract_tensor import AbstractTensor

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, get_origin
 
-from typing_inspect import get_args, is_union_type, is_typevar
+from typing_inspect import get_args, is_typevar, is_union_type
 
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
@@ -32,6 +32,7 @@ def change_cls_name(cls: type, new_name: str, scope: Optional[dict] = None) -> N
         scope[new_name] = cls
     cls.__qualname__ = cls.__qualname__[: -len(cls.__name__)] + new_name
     cls.__name__ = new_name
+
 
 def safe_issubclass(x: type, a_tuple: tuple) -> bool:
     """

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, get_origin
 
-from typing_inspect import get_args, is_union_type
+from typing_inspect import get_args, is_union_type, is_typevar
 
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
@@ -43,6 +43,6 @@ def safe_issubclass(x, a_tuple) -> bool:
     :return: A boolean value - 'True' if 'x' is a subclass of 'A_tuple', 'False' otherwise.
              Note that if the origin of 'x' is a list or tuple, the function immediately returns 'False'.
     """
-    if get_origin(x) in (list, tuple):
+    if (get_origin(x) in (list, tuple, dict, set)) or is_typevar(x):
         return False
     return issubclass(x, a_tuple)

--- a/tests/index/hnswlib/test_index_get_del.py
+++ b/tests/index/hnswlib/test_index_get_del.py
@@ -128,8 +128,10 @@ def test_index_tf(tmp_path):
     for index in index._hnsw_indices.values():
         assert index.get_current_count() == 10
 
+
 def test_index_lst_str(tmp_path):
     from typing import List
+
     class ListDoc(BaseDoc):
         list_str: List[str]
 
@@ -142,10 +144,12 @@ def test_index_lst_str(tmp_path):
     for index in index._hnsw_indices.values():
         assert index.get_current_count() == 10
 
+
 def test_index_typevar(tmp_path):
     from typing import TypeVar
 
     T = TypeVar("T")
+
     class TypeDoc(BaseDoc):
         list_str: T
 
@@ -153,6 +157,7 @@ def test_index_typevar(tmp_path):
     docs = [TypeDoc(list_str=10) for _ in range(10)]
     index.index(docs)
     assert index.num_docs() == 10
+
 
 def test_index_builtin_docs(tmp_path):
     # TextDoc

--- a/tests/index/hnswlib/test_index_get_del.py
+++ b/tests/index/hnswlib/test_index_get_del.py
@@ -128,7 +128,7 @@ def test_index_tf(tmp_path):
     for index in index._hnsw_indices.values():
         assert index.get_current_count() == 10
 
-def test_index_list_str(tmp_path):
+def test_index_lst_str(tmp_path):
     from typing import List
     class ListDoc(BaseDoc):
         list_str: List[str]
@@ -141,6 +141,18 @@ def test_index_list_str(tmp_path):
     assert index.num_docs() == 10
     for index in index._hnsw_indices.values():
         assert index.get_current_count() == 10
+
+def test_index_typevar(tmp_path):
+    from typing import TypeVar
+
+    T = TypeVar("T")
+    class TypeDoc(BaseDoc):
+        list_str: T
+
+    index = HnswDocumentIndex[TypeDoc](work_dir=str(tmp_path))
+    docs = [TypeDoc(list_str=10) for _ in range(10)]
+    index.index(docs)
+    assert index.num_docs() == 10
 
 def test_index_builtin_docs(tmp_path):
     # TextDoc

--- a/tests/units/util/test_typing.py
+++ b/tests/units/util/test_typing.py
@@ -1,10 +1,14 @@
-from typing import Dict, Optional, Union, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import pytest
 
 from docarray.typing import NdArray, TorchTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
-from docarray.utils._internal._typing import is_tensor_union, is_type_tensor, safe_issubclass
+from docarray.utils._internal._typing import (
+    is_tensor_union,
+    is_type_tensor,
+    safe_issubclass,
+)
 from docarray.utils._internal.misc import is_tf_available
 
 tf_available = is_tf_available()

--- a/tests/units/util/test_typing.py
+++ b/tests/units/util/test_typing.py
@@ -1,10 +1,10 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, List, Set, Tuple
 
 import pytest
 
 from docarray.typing import NdArray, TorchTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
-from docarray.utils._internal._typing import is_tensor_union, is_type_tensor
+from docarray.utils._internal._typing import is_tensor_union, is_type_tensor, safe_issubclass
 from docarray.utils._internal.misc import is_tf_available
 
 tf_available = is_tf_available()
@@ -73,3 +73,17 @@ def test_is_union_type_tensor(type_, is_union_tensor):
 )
 def test_is_union_type_tensor_with_tf(type_, is_union_tensor):
     assert is_tensor_union(type_) == is_union_tensor
+
+
+@pytest.mark.parametrize(
+    'type_, cls, is_subclass',
+    [
+        (List[str], object, False),
+        (List[List[int]], object, False),
+        (Set[str], object, False),
+        (Dict, object, False),
+        (Tuple[int, int], object, False),
+    ],
+)
+def test_safe_issubclass(type_, cls, is_subclass):
+    assert safe_issubclass(type_, cls) == is_subclass


### PR DESCRIPTION
This pull request resolves the TypeError in BaseDocIndex._flatten_schema that occurs when a non-class type, such as List[str], is used as an argument for issubclass(). As observed in issue #1557, this causes the HnswDocumentIndex initialisation to crash.

As Johannes suggested, I use a custom issubclass function that can handle non-class types by returning False instead of failing. This change prevents crashes when a non-class type is passed as input.
