### PR TITLE
docs: add mention and example for type coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,39 @@ class MyDocument(BaseDoc):
 
 So not only can you define the types of your data, you can even **specify the shape of your tensors!**
 
+> :bulb: **Type coercion:** When submitting a tensor-like structure to a tensor field, the resulting `TorchTensor` is typed after the provided data.
+
+See:
+
+```python
+from docarray import BaseDoc
+from docarray.typing import TorchTensor
+import numpy as np
+
+
+class MyTensorsDoc(BaseDoc):
+    tensor1: TorchTensor[512]
+    tensor2: TorchTensor[512]
+
+
+rand_series_f64 = np.random.rand(512).astype('float64')
+rand_series_f32 = np.random.rand(512).astype('float32')
+
+doc = MyTensorsDoc(tensor1=rand_series_f64, tensor2=rand_series_f32)
+doc.summary()
+```
+
+```
+📄 MyTensorsDoc : 84877dd ...
+╭──────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────╮
+│ Attribute            │ Value                                                                                    │
+├──────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────┤
+│ tensor1: TorchTensor │ TorchTensor of shape (512,), dtype: torch.float64                                        │
+│ tensor2: TorchTensor │ TorchTensor of shape (512,), dtype: torch.float32                                        │
+╰──────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+
 Once you have your model in the form of a document, you can work with it!
 
 ```python
@@ -119,6 +152,7 @@ doc = MyDocument(
 
 # Load image tensor from URL
 doc.image_tensor = doc.image_url.load()
+
 
 # Compute embedding with any model of your choice
 def clip_image_encoder(image_tensor: TorchTensor) -> TorchTensor:  # dummy function


### PR DESCRIPTION
This PR brings changes to the docs where we mention type coercion for Tensor, with an example.