### PR TITLE
fix: make example payload a string and not bytes

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -246,7 +246,9 @@ class AbstractTensor(Generic[TTensor, T], AbstractType, ABC, Sized):
                 <= DISPLAY_TENSOR_OPENAPI_MAX_ITEMS
             ):
                 # custom example only for 'small' shapes, otherwise it is too big to display
-                example_payload = orjson_dumps(np.zeros(cls.__docarray_target_shape__))
+                example_payload = orjson_dumps(
+                    np.zeros(cls.__docarray_target_shape__)
+                ).decode()
                 field_schema.update(example=example_payload)
         else:
             shape_info = 'not specified'

--- a/tests/units/document/test_to_schema.py
+++ b/tests/units/document/test_to_schema.py
@@ -21,8 +21,9 @@ def test_np_schema():
     assert schema['properties']['embedding']['tensor/array shape'] == '[3, 4]'
     assert schema['properties']['embedding']['type'] == 'array'
     assert schema['properties']['embedding']['items']['type'] == 'number'
-    assert schema['properties']['embedding']['example'] == orjson_dumps(
-        np.zeros([3, 4])
+    assert (
+        schema['properties']['embedding']['example']
+        == orjson_dumps(np.zeros([3, 4])).decode()
     )
 
     assert (
@@ -38,8 +39,9 @@ def test_torch_schema():
     assert schema['properties']['embedding']['tensor/array shape'] == '[3, 4]'
     assert schema['properties']['embedding']['type'] == 'array'
     assert schema['properties']['embedding']['items']['type'] == 'number'
-    assert schema['properties']['embedding']['example'] == orjson_dumps(
-        np.zeros([3, 4])
+    assert (
+        schema['properties']['embedding']['example']
+        == orjson_dumps(np.zeros([3, 4])).decode()
     )
 
     assert (
@@ -62,8 +64,9 @@ def test_tensorflow_schema():
     assert schema['properties']['embedding']['tensor/array shape'] == '[3, 4]'
     assert schema['properties']['embedding']['type'] == 'array'
     assert schema['properties']['embedding']['items']['type'] == 'number'
-    assert schema['properties']['embedding']['example'] == orjson_dumps(
-        np.zeros([3, 4])
+    assert (
+        schema['properties']['embedding']['example']
+        == orjson_dumps(np.zeros([3, 4])).decode()
     )
 
     assert (


### PR DESCRIPTION
Before:

```python

from docarray import DocList, BaseDoc
from docarray.documents import TextDoc
from docarray.typing import NdArray
import numpy as np


class MyDoc(BaseDoc):
    text: str
    embedding: NdArray[128]

print(f'{type(MyDoc.schema()["properties"]["embedding"]["example"])}')
```

This would show `bytes`.

Now this would show `str`