### PR TITLE
fix: solve issues caused by issubclass

### DIFF
--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -22,6 +22,7 @@ from docarray.typing import NdArray
 from docarray.typing.proto_register import _PROTO_TYPE_NAME_TO_CLASS
 from docarray.utils._internal.compress import _compress_bytes, _decompress_bytes
 from docarray.utils._internal.misc import import_library
+from docarray.utils._internal._typing import safe_issubclass
 
 if TYPE_CHECKING:
     import tensorflow as tf  # type: ignore
@@ -394,7 +395,7 @@ class IOMixin(Iterable[Tuple[str, Any]]):
         paths = []
         for field in cls.__fields__.keys():
             field_type = cls._get_field_type(field)
-            if not is_union_type(field_type) and issubclass(field_type, BaseDoc):
+            if not is_union_type(field_type) and safe_issubclass(field_type, BaseDoc):
                 sub_paths = field_type._get_access_paths()
                 for path in sub_paths:
                     paths.append(f'{field}__{path}')

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -20,9 +20,9 @@ from typing_inspect import is_union_type
 from docarray.base_doc.base_node import BaseNode
 from docarray.typing import NdArray
 from docarray.typing.proto_register import _PROTO_TYPE_NAME_TO_CLASS
+from docarray.utils._internal._typing import safe_issubclass
 from docarray.utils._internal.compress import _compress_bytes, _decompress_bytes
 from docarray.utils._internal.misc import import_library
-from docarray.utils._internal._typing import safe_issubclass
 
 if TYPE_CHECKING:
     import tensorflow as tf  # type: ignore

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 import pandas as pd
 import pytest
@@ -27,9 +27,11 @@ def test_to_from_pandas_df(nested_doc_cls):
                 count=0,
                 text='hello',
                 image=ImageDoc(url='aux.png'),
-                lst = ["hello", "world"]
+                lst=["hello", "world"],
             ),
-            nested_doc_cls(text='hello world', image=ImageDoc(), lst = ["hello","world"]),
+            nested_doc_cls(
+                text='hello world', image=ImageDoc(), lst=["hello", "world"]
+            ),
         ]
     )
     df = da.to_dataframe()
@@ -46,7 +48,7 @@ def test_to_from_pandas_df(nested_doc_cls):
             'image__tensor',
             'image__embedding',
             'image__bytes_',
-            'lst'
+            'lst',
         ]
     ).all()
 

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import pandas as pd
 import pytest
@@ -15,6 +15,7 @@ def nested_doc_cls():
 
     class MyDocNested(MyDoc):
         image: ImageDoc
+        lst: List[str]
 
     return MyDocNested
 
@@ -26,8 +27,9 @@ def test_to_from_pandas_df(nested_doc_cls):
                 count=0,
                 text='hello',
                 image=ImageDoc(url='aux.png'),
+                lst = ["hello", "world"]
             ),
-            nested_doc_cls(text='hello world', image=ImageDoc()),
+            nested_doc_cls(text='hello world', image=ImageDoc(), lst = ["hello","world"]),
         ]
     )
     df = da.to_dataframe()
@@ -44,6 +46,7 @@ def test_to_from_pandas_df(nested_doc_cls):
             'image__tensor',
             'image__embedding',
             'image__bytes_',
+            'lst'
         ]
     ).all()
 


### PR DESCRIPTION
In Issue #1584, we encountered a problem where the program would crash when the document contained non-class objects during the exportation of JSON/Pandas tables. The safe version of subclass method fixes this bug.