### PR TITLE
docs: add in memory to documentation as list of supported vector index

### DIFF
--- a/docs/user_guide/storing/first_step.md
+++ b/docs/user_guide/storing/first_step.md
@@ -35,7 +35,7 @@ or recommender systems.
 DocArray's Document Index concept achieves this by providing a unified interface to a number of [vector databases](https://learn.microsoft.com/en-us/semantic-kernel/concepts-ai/vectordb).
 In fact, you can think of Document Index as an **[ORM](https://sqlmodel.tiangolo.com/db-to-code/) for vector databases**.
 
-Currently, DocArray supports the following vector indexes. Some of them wrap a Vector Databases (Weaviate, Qdrant, ElasticSearch) acting as a client for them, while others
+Currently, DocArray supports the following vector indexes. Some of them wrap vector databases (Weaviate, Qdrant, ElasticSearch) and act as a client for them, while others
 use a vector search library locally (HNSWLib, Exact NN search):
 
 - [Weaviate](https://weaviate.io/)  |  [Docs](index_weaviate.md)

--- a/docs/user_guide/storing/first_step.md
+++ b/docs/user_guide/storing/first_step.md
@@ -35,9 +35,11 @@ or recommender systems.
 DocArray's Document Index concept achieves this by providing a unified interface to a number of [vector databases](https://learn.microsoft.com/en-us/semantic-kernel/concepts-ai/vectordb).
 In fact, you can think of Document Index as an **[ORM](https://sqlmodel.tiangolo.com/db-to-code/) for vector databases**.
 
-Currently, DocArray supports the following vector databases:
+Currently, DocArray supports the following vector indexes. Some of them wrap a Vector Databases (Weaviate, Qdrant, ElasticSearch) acting as a client for them, while others
+use a vector search library locally (HNSWLib, Exact NN search):
 
 - [Weaviate](https://weaviate.io/)  |  [Docs](index_weaviate.md)
 - [Qdrant](https://qdrant.tech/)  |  [Docs](index_qdrant.md)
 - [Elasticsearch](https://www.elastic.co/elasticsearch/) v7 and v8  |  [Docs](index_elastic.md)
 - [Hnswlib](https://github.com/nmslib/hnswlib)  |  [Docs](index_hnswlib.md)
+- InMemoryExactNNSearch  |  [Docs](index_in_memory.md)


### PR DESCRIPTION
Fix the fact that InMemoryExactNNSearch is not listed as supported index