### PR TITLE
fix: hnswlib must be able to search with limit more than num docs

### DIFF
--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -293,6 +293,8 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
         if self.num_docs() == 0:
             return _FindResultBatched(documents=[], scores=[])  # type: ignore
 
+        limit = min(limit, self.num_docs())
+
         index = self._hnsw_indices[search_field]
         labels, distances = index.knn_query(queries, k=limit)
         result_das = [

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -63,6 +63,16 @@ def test_find_empty_index(tmp_path):
     assert len(scores) == 0
 
 
+def test_find_limit_larger_than_index(tmp_path):
+    index = HnswDocumentIndex[SimpleDoc](work_dir=str(tmp_path))
+    query = SimpleDoc(tens=np.ones(10))
+    index_docs = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    index.index(index_docs)
+    docs, scores = index.find(query, search_field='tens', limit=20)
+    assert len(docs) == 10
+    assert len(scores) == 10
+
+
 @pytest.mark.parametrize('space', ['cosine', 'l2', 'ip'])
 def test_find_torch(tmp_path, space):
     index = HnswDocumentIndex[TorchDoc](work_dir=str(tmp_path))


### PR DESCRIPTION
Before, running `find` or `find_batched` on a HNSWLibIndex, the search would raise an Exception from the hnswlib. This PR fixes it by limiting the `limit` parameter to the actual number of Documents in the index