### PR TITLE
feat: support subindex on ExactNNSearch

### DIFF
--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -240,3 +240,17 @@ def get_paths(
         num_docs += 1
         if size is not None and num_docs >= size:
             break
+
+
+def _shallow_copy_doc(doc):
+    cls = doc.__class__
+    shallow_copy = cls.__new__(cls)
+
+    field_set = set(doc.__fields_set__)
+    object.__setattr__(shallow_copy, '__fields_set__', field_set)
+
+    for field_name, field_ in doc.__fields__.items():
+        val = doc.__getattr__(field_name)
+        setattr(shallow_copy, field_name, val)
+
+    return shallow_copy

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -72,6 +72,11 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 self._docs = DocList.__class_getitem__(
                     cast(Type[BaseDoc], self._schema)
                 ).load_binary(file=index_file_path)
+
+                data_by_columns = self._get_col_value_dict(self._docs)
+                self._update_subindex_data(self._docs)
+                self._index_subindex(data_by_columns)
+
             else:
                 self._logger.warning(
                     f'Index file does not exist: {index_file_path}. '

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -19,16 +19,17 @@ from typing import (
 import numpy as np
 
 from docarray import BaseDoc, DocList
+from docarray.array.any_array import AnyDocArray
+from docarray.helper import _shallow_copy_doc
 from docarray.index.abstract import BaseDocIndex, _raise_not_supported
 from docarray.index.backends.helper import (
     _collect_query_args,
     _execute_find_and_filter_query,
 )
 from docarray.typing import AnyTensor, NdArray
-from docarray.array.any_array import AnyDocArray
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
-from docarray.utils.filter import filter_docs
 from docarray.utils._internal._typing import safe_issubclass
+from docarray.utils.filter import filter_docs
 from docarray.utils.find import (
     FindResult,
     FindResultBatched,
@@ -103,6 +104,13 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         """
         return python_type
 
+    @property
+    def out_schema(self) -> Type[BaseDoc]:
+        """Return the original schema (without the parent_id from new_schema type)"""
+        if self._is_subindex:
+            return self._ori_schema
+        return cast(Type[BaseDoc], self._schema)
+
     class QueryBuilder(BaseDocIndex.QueryBuilder):
         def __init__(self, query: Optional[List[Tuple[str, Dict]]] = None):
             super().__init__()
@@ -153,12 +161,13 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         """
         # implementing the public option because conversion to column dict is not needed
         docs = self._validate_docs(docs)
+        self._docs.extend(docs)
 
+        # Add parent_id to all sub-index documents and store sub-index documents
         data_by_columns = self._get_col_value_dict(docs)
         self._update_subindex_data(docs)
         self._index_subindex(data_by_columns)
 
-        self._docs.extend(docs)
         self._rebuild_embedding()
 
     def _index(self, column_to_data: Dict[str, Generator[Any, None, None]]):
@@ -191,14 +200,16 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
 
         :param doc_ids: ids to delete from the Document Store
         """
-        for field, type_, _ in self._flatten_schema(
-            cast(Type[BaseDoc], self._schema)
-        ):
+        for field_, type_, _ in self._flatten_schema(cast(Type[BaseDoc], self._schema)):
             if safe_issubclass(type_, AnyDocArray):
                 for id in doc_ids:
                     doc = self._get_items([id])
-                    sub_ids = [sub_doc.id for sub_doc in getattr(doc, field)]
-                    del self._subindices[field][sub_ids]
+                    if len(doc) == 0:
+                        raise KeyError(
+                            f"The document (id = '{id}') does not exist in the ExactNNIndexer."
+                        )
+                    sub_ids = [sub_doc.id for sub_doc in getattr(doc[0], field_)]
+                    del self._subindices[field_][sub_ids]
 
         indices = []
         for i, doc in enumerate(self._docs):
@@ -208,21 +219,55 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         del self._docs[indices]
         self._rebuild_embedding()
 
+    def _ori_items(self, doc: BaseDoc) -> BaseDoc:
+        """
+        The Indexer's backend stores parent_id to support nested data. However,
+        this method enables us to retrieve the original items in their original
+        type, which is what the user interacts with.
+
+        :param doc: The input document in New_Schema format from the Indexer's backend.
+        :return: The input document with its original schema.
+        """
+
+        ori_doc = _shallow_copy_doc(doc)
+        for field_name, type_, _ in self._flatten_schema(
+            cast(Type[BaseDoc], self.out_schema)
+        ):
+            if safe_issubclass(type_, AnyDocArray):
+                _list = getattr(ori_doc, field_name)
+                for i, nested_doc in enumerate(_list):
+                    nested_doc = self._subindices[field_name]._ori_schema(
+                        **nested_doc.__dict__
+                    )
+
+                    _list[i] = self._subindices[field_name]._ori_items(nested_doc)
+
+        return ori_doc
+
     def _get_items(
-        self, doc_ids: Sequence[str]
+        self, doc_ids: Sequence[str], raw: bool = False
     ) -> Union[Sequence[TSchema], Sequence[Dict[str, Any]]]:
         """Get Documents from the index, by `id`.
         If no document is found, a KeyError is raised.
 
         :param doc_ids: ids to get from the Document index
+        :param raw: if raw, output the new_schema type (with parent id)
         :return: Sequence of Documents, sorted corresponding to the order of `doc_ids`.
             Duplicate `doc_ids` can be omitted in the output.
         """
-        indices = []
+
+        out_docs = []
         for i, doc in enumerate(self._docs):
             if doc.id in doc_ids:
-                indices.append(i)
-        return self._docs[indices]
+                if raw:
+                    out_docs.append(doc)
+                else:
+                    ori_doc = self._ori_items(doc)
+                    schema_cls = cast(Type[BaseDoc], self.out_schema)
+                    new_doc = schema_cls(**ori_doc.__dict__)
+                    out_docs.append(new_doc)
+
+        return out_docs
 
     def execute_query(self, query: List[Tuple[str, Dict]], *args, **kwargs) -> Any:
         """
@@ -283,9 +328,17 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
             metric=config['space'],
             cache=self._embedding_map,
         )
-        docs_with_schema = DocList.__class_getitem__(cast(Type[BaseDoc], self._schema))(
-            docs
-        )
+
+        docs_ = []
+        for doc in docs:
+            ori_doc = self._ori_items(doc)
+            schema_cls = cast(Type[BaseDoc], self.out_schema)
+            docs_.append(schema_cls(**ori_doc.__dict__))
+
+        docs_with_schema = DocList.__class_getitem__(
+            cast(Type[BaseDoc], self.out_schema)
+        )(docs_)
+
         return FindResult(documents=docs_with_schema, scores=scores)
 
     def _find(
@@ -375,3 +428,28 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
     def persist(self, file: str = 'in_memory_index.bin') -> None:
         """Persist InMemoryExactNNIndex into a binary file."""
         self._docs.save_binary(file=file)
+
+    def _get_root_doc_id(self, id: str, root: str, sub: str) -> str:
+        """Get the root_id given the id of a subindex Document and the root and subindex name
+
+        :param id: id of the subindex Document
+        :param root: root index name
+        :param sub: subindex name
+        :return: the root_id of the Document
+        """
+        subindex = self._subindices[root]
+
+        if not sub:
+            sub_doc = subindex._get_items([id], raw=True)
+            parent_id = (
+                sub_doc[0]['parent_id']
+                if isinstance(sub_doc[0], dict)
+                else sub_doc[0].parent_id
+            )
+            return parent_id
+        else:
+            fields = sub.split('__')
+            cur_root_id = subindex._get_root_doc_id(
+                id, fields[0], '__'.join(fields[1:])
+            )
+            return self._get_root_doc_id(cur_root_id, root, '')

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -250,15 +250,17 @@ def test_index_find_speedup():
         assert len(matches) == num_queries
         assert len(matches[0]) == 5
 
+
 def test_nested_document_find():
     from docarray.typing import VideoUrl
 
     class VideoDoc(BaseDoc):
         url: VideoUrl
-        tensor_video: TorchTensor
+        tensor_video: NdArray[256]
+
     class MyDoc(BaseDoc):
         docs: DocList[VideoDoc]
-        tensor: TorchTensor
+        tensor: NdArray[256]
 
     doc_index = InMemoryExactNNIndex[MyDoc]()
 
@@ -268,12 +270,12 @@ def test_nested_document_find():
                 [
                     VideoDoc(
                         url=f'http://example.ai/videos/{i}-{j}',
-                        tensor_video=rand(256),
+                        tensor_video=np.ones(256),
                     )
                     for j in range(10)
                 ]
             ),
-            tensor=rand(256),
+            tensor=np.ones(256),
         )
         for i in range(10)
     ]
@@ -282,7 +284,7 @@ def test_nested_document_find():
     doc_index.index(index_docs)
 
     root_docs, sub_docs, scores = doc_index.find_subindex(
-        rand(256), subindex='docs', search_field='tensor_video', limit=3
+        np.ones(256), subindex='docs', search_field='tensor_video', limit=3
     )
 
     assert len(scores) == 3

--- a/tests/index/in_memory/test_persist_data.py
+++ b/tests/index/in_memory/test_persist_data.py
@@ -25,7 +25,8 @@ class MyDoc(BaseDoc):
     my_tens: NdArray[30]
 
 
-def test_subindex_index(tmp_path):
+@pytest.fixture
+def nested_doc():
     my_docs = [
         MyDoc(
             id=f'{i}',
@@ -67,11 +68,14 @@ def test_subindex_index(tmp_path):
         )
         for i in range(5)
     ]
+    return my_docs
 
+
+def test_persist_restore(nested_doc, tmp_path):
     stored_path = str(tmp_path) + "/in_memory_index.bin"
 
     index = InMemoryExactNNIndex[MyDoc]()
-    index.index(my_docs)
+    index.index(nested_doc)
 
     assert index.num_docs() == 5
     assert index._subindices['docs'].num_docs() == 25
@@ -103,3 +107,36 @@ def test_subindex_index(tmp_path):
     assert type(doc) == MyDoc
     assert doc.list_docs[1].simple_doc.simple_text == 'hello 1'
     assert type(doc.list_docs[0].simple_doc) == SimpleDoc
+
+
+def test_persist_find(nested_doc, tmp_path):
+    index = InMemoryExactNNIndex[MyDoc]()
+    index.index(nested_doc)
+
+    stored_path = str(tmp_path) + "/in_memory_index.bin"
+    index.persist(stored_path)
+
+    del index
+    index = InMemoryExactNNIndex[MyDoc](index_file_path=stored_path)
+
+    # Test find
+    query = np.ones((30,))
+    docs, scores = index.find(query, search_field="my_tens", limit=5)
+
+    assert type(docs[0]) == MyDoc
+    assert type(docs[0].list_docs[0]) == ListDoc
+    assert len(scores) == 5
+
+    # Test find sub-index
+
+    query = np.ones((10,))
+
+    root_docs, docs, scores = index.find_subindex(
+        query, subindex='docs', search_field='simple_tens', limit=5
+    )
+
+    assert type(root_docs[0]) == MyDoc
+    assert type(docs[0]) == SimpleDoc
+    assert len(scores) == 5
+    for root_doc, doc in zip(root_docs, docs):
+        assert root_doc.id == f'{doc.id.split("-")[1]}'

--- a/tests/index/in_memory/test_persist_data.py
+++ b/tests/index/in_memory/test_persist_data.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pytest
+
+from docarray import BaseDoc, DocList
+from docarray.index import InMemoryExactNNIndex
+from docarray.typing import NdArray
+
+pytestmark = [pytest.mark.slow, pytest.mark.index]
+
+
+class SimpleDoc(BaseDoc):
+    simple_tens: NdArray[10]
+    simple_text: str
+
+
+class ListDoc(BaseDoc):
+    docs: DocList[SimpleDoc]
+    simple_doc: SimpleDoc
+    list_tens: NdArray[20]
+
+
+class MyDoc(BaseDoc):
+    docs: DocList[SimpleDoc]
+    list_docs: DocList[ListDoc]
+    my_tens: NdArray[30]
+
+
+def test_subindex_index(tmp_path):
+    my_docs = [
+        MyDoc(
+            id=f'{i}',
+            docs=DocList[SimpleDoc](
+                [
+                    SimpleDoc(
+                        id=f'docs-{i}-{j}',
+                        simple_tens=np.ones(10) * (j + 1),
+                        simple_text=f'hello {j}',
+                    )
+                    for j in range(5)
+                ]
+            ),
+            list_docs=DocList[ListDoc](
+                [
+                    ListDoc(
+                        id=f'list_docs-{i}-{j}',
+                        docs=DocList[SimpleDoc](
+                            [
+                                SimpleDoc(
+                                    id=f'list_docs-docs-{i}-{j}-{k}',
+                                    simple_tens=np.ones(10) * (k + 1),
+                                    simple_text=f'hello {k}',
+                                )
+                                for k in range(5)
+                            ]
+                        ),
+                        simple_doc=SimpleDoc(
+                            id=f'list_docs-simple_doc-{i}-{j}',
+                            simple_tens=np.ones(10) * (j + 1),
+                            simple_text=f'hello {j}',
+                        ),
+                        list_tens=np.ones(20) * (j + 1),
+                    )
+                    for j in range(5)
+                ]
+            ),
+            my_tens=np.ones((30,)) * (i + 1),
+        )
+        for i in range(5)
+    ]
+
+    stored_path = str(tmp_path) + "/in_memory_index.bin"
+
+    index = InMemoryExactNNIndex[MyDoc]()
+    index.index(my_docs)
+
+    assert index.num_docs() == 5
+    assert index._subindices['docs'].num_docs() == 25
+    assert index._subindices['list_docs'].num_docs() == 25
+    assert index._subindices['list_docs']._subindices['docs'].num_docs() == 125
+
+    doc = index['1']
+
+    assert type(doc.list_docs[0].simple_doc) == SimpleDoc
+    assert doc.list_docs[0].simple_doc.id == 'list_docs-simple_doc-1-0'
+    assert np.allclose(doc.list_docs[0].simple_doc.simple_tens, np.ones(10))
+    assert doc.list_docs[0].simple_doc.simple_text == 'hello 0'
+
+    del index['0']
+    assert index.num_docs() == 4
+
+    index.persist(stored_path)
+
+    del index
+
+    index = InMemoryExactNNIndex[MyDoc](index_file_path=stored_path)
+
+    doc = index['1']
+
+    assert index.num_docs() == 4
+    assert index._subindices['docs'].num_docs() == 20
+    assert index._subindices['list_docs'].num_docs() == 20
+    assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+    assert type(doc) == MyDoc
+    assert doc.list_docs[1].simple_doc.simple_text == 'hello 1'
+    assert type(doc.list_docs[0].simple_doc) == SimpleDoc

--- a/tests/units/test_helper.py
+++ b/tests/units/test_helper.py
@@ -131,3 +131,25 @@ def test_get_paths_exclude():
 
     assert len(paths_wo_init) <= len(paths)
     assert '__init__.py' not in paths_wo_init
+
+
+def test_deep_copy():
+    from torch import rand
+
+    from docarray import BaseDoc
+    from docarray.helper import _shallow_copy_doc
+    from docarray.typing import TorchTensor
+
+    class MyDoc(BaseDoc):
+        text: str
+        price: int
+        embedding: TorchTensor
+
+    a = MyDoc(text="Hello world", price=5, embedding=rand(128))
+
+    b = _shallow_copy_doc(a)
+
+    print(b)
+    print(a.__eq__(b))
+
+    # print(a)

--- a/tests/units/test_helper.py
+++ b/tests/units/test_helper.py
@@ -133,23 +133,34 @@ def test_get_paths_exclude():
     assert '__init__.py' not in paths_wo_init
 
 
-def test_deep_copy():
+def test_shallow_copy():
     from torch import rand
 
     from docarray import BaseDoc
     from docarray.helper import _shallow_copy_doc
-    from docarray.typing import TorchTensor
+    from docarray.typing import TorchTensor, VideoUrl
+
+    class VideoDoc(BaseDoc):
+        url: VideoUrl
+        tensor_video: TorchTensor
 
     class MyDoc(BaseDoc):
-        text: str
-        price: int
-        embedding: TorchTensor
+        docs: DocList[VideoDoc]
+        tensor: TorchTensor
 
-    a = MyDoc(text="Hello world", price=5, embedding=rand(128))
+    doc_ori = MyDoc(
+        docs=DocList[VideoDoc](
+            [
+                VideoDoc(
+                    url=f'http://example.ai/videos/{i}',
+                    tensor_video=rand(256),
+                )
+                for i in range(10)
+            ]
+        ),
+        tensor=rand(256),
+    )
 
-    b = _shallow_copy_doc(a)
+    doc_copy = _shallow_copy_doc(doc_ori)
 
-    print(b)
-    print(a.__eq__(b))
-
-    # print(a)
+    assert doc_copy == doc_ori


### PR DESCRIPTION
Currently, the subindex feature is not available on exact in-memory NNIndexer. This PR aims to support nested documents for ExactNNIndexer