### PR TITLE
fix: filter limits

### DIFF
--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -335,7 +335,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         """
         self._logger.debug(f'Executing `filter` for the query {filter_query}')
 
-        docs = filter_docs(docs=self._docs, query=filter_query)
+        docs = filter_docs(docs=self._docs, query=filter_query)[:limit]
         return cast(DocList, docs)
 
     def _filter(self, filter_query: Any, limit: int) -> Union[DocList, List[Dict]]:

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -302,3 +302,30 @@ def test_usage_adapt_max_elements_after_restore(tmpdir):
     for q, matches in zip(queries, docs_responses):
         assert len(matches) == 10
         assert q.id == matches[0].id
+
+
+@pytest.mark.parametrize(
+    'find_limit, filter_limit, expected_docs', [(10, 3, 3), (5, None, 3)]
+)
+def test_query_builder_limits(find_limit, filter_limit, expected_docs, tmp_path):
+    class SimpleSchema(BaseDoc):
+        tensor: NdArray[10] = Field(space='cosine')
+        price: int
+
+    index = HnswDocumentIndex[SimpleSchema](work_dir=str(tmp_path))
+
+    index_docs = [SimpleSchema(tensor=np.array([i] * 10), price=i) for i in range(10)]
+    index.index(index_docs)
+
+    query = SimpleSchema(tensor=np.ones(10), price=3)
+
+    q = (
+        index.build_query()
+        .find(query=query, search_field='tensor', limit=find_limit)
+        .filter(filter_query={'price': {'$lte': 5}}, limit=filter_limit)
+        .build()
+    )
+
+    docs, scores = index.execute_query(q)
+
+    assert len(docs) == expected_docs


### PR DESCRIPTION
We allow passing filter limits but never use in a couple of places.

Fix filter limits in:
- InMemory index `filter`
- InMemory index hybrid search
- Hnsw hybrid search