### PR TITLE
refactor: minor changes in weaviate

### DIFF
--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -200,17 +200,17 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
 
         # filter accepts Leaf/Compound query clauses
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
-        def filter(self, filter_query: Dict[str, Any], limit: int = 10):
+        def filter(self, query: Dict[str, Any], limit: int = 10):
             """Find documents in the index based on a filter query
 
-            :param filter_query: the query to execute
+            :param query: the query to execute
             :param limit: maximum number of documents to return
             :return: self
             """
             self._outer_instance._logger.debug('Executing filter query')
 
             self._query['size'] = limit
-            self._query['query']['bool']['filter'].append(filter_query)
+            self._query['query']['bool']['filter'].append(query)
             return self
 
         def text_search(self, query: str, search_field: str = 'text', limit: int = 10):

--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -200,17 +200,17 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
 
         # filter accepts Leaf/Compound query clauses
         # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
-        def filter(self, query: Dict[str, Any], limit: int = 10):
+        def filter(self, filter_query: Dict[str, Any], limit: int = 10):
             """Find documents in the index based on a filter query
 
-            :param query: the query to execute
+            :param filter_query: the query to execute
             :param limit: maximum number of documents to return
             :return: self
             """
             self._outer_instance._logger.debug('Executing filter query')
 
             self._query['size'] = limit
-            self._query['query']['bool']['filter'].append(query)
+            self._query['query']['bool']['filter'].append(filter_query)
             return self
 
         def text_search(self, query: str, search_field: str = 'text', limit: int = 10):
@@ -371,7 +371,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         refresh: bool = True,
         chunk_size: Optional[int] = None,
     ):
-
         self._index_subindex(column_to_data)
 
         data = self._transpose_col_value_dict(column_to_data)
@@ -479,7 +478,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
     def _find(
         self, query: np.ndarray, limit: int, search_field: str = ''
     ) -> _FindResult:
-
         body = self._form_search_body(query, limit, search_field)
 
         resp = self._client_search(**body)
@@ -494,7 +492,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         limit: int,
         search_field: str = '',
     ) -> _FindResultBatched:
-
         request = []
         for query in queries:
             head = {'index': self.index_name}
@@ -513,7 +510,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         filter_query: Dict[str, Any],
         limit: int,
     ) -> List[Dict]:
-
         resp = self._client_search(query=filter_query, size=limit)
 
         docs, _ = self._format_response(resp)
@@ -525,7 +521,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         filter_queries: Any,
         limit: int,
     ) -> List[List[Dict]]:
-
         request = []
         for query in filter_queries:
             head = {'index': self.index_name}
@@ -543,7 +538,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         limit: int,
         search_field: str = '',
     ) -> _FindResult:
-
         body = self._form_text_search_body(query, limit, search_field)
         resp = self._client_search(**body)
 
@@ -557,7 +551,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         limit: int,
         search_field: str = '',
     ) -> _FindResultBatched:
-
         request = []
         for query in queries:
             head = {'index': self.index_name}
@@ -571,7 +564,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         return _FindResultBatched(documents=list(das), scores=scores)
 
     def _filter_by_parent_id(self, id: str) -> List[str]:
-
         resp = self._client_search(
             query={'term': {'parent_id': id}}, fields=['id'], _source=False
         )
@@ -676,7 +668,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         return docs, [parse_obj_as(NdArray, np.array(s)) for s in scores]
 
     def _refresh(self, index_name: str):
-
         self._client.indices.refresh(index=index_name)
 
     ###############################################
@@ -684,27 +675,21 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
     ###############################################
 
     def _client_put_mapping(self, mappings: Dict[str, Any]):
-
         self._client.indices.put_mapping(
             index=self.index_name, properties=mappings['properties']
         )
 
     def _client_create(self, mappings: Dict[str, Any]):
-
         self._client.indices.create(index=self.index_name, mappings=mappings)
 
     def _client_put_settings(self, settings: Dict[str, Any]):
-
         self._client.indices.put_settings(index=self.index_name, settings=settings)
 
     def _client_mget(self, ids: Sequence[str]):
-
         return self._client.mget(index=self.index_name, ids=ids)
 
     def _client_search(self, **kwargs):
-
         return self._client.search(index=self.index_name, **kwargs)
 
     def _client_msearch(self, request: List[Dict[str, Any]]):
-
         return self._client.msearch(index=self.index_name, searches=request)

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -332,20 +332,19 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         query: Union[AnyTensor, BaseDoc],
         search_field: str = '',
         limit: int = 10,
-        **kwargs,
+        **kwargs: Any,
     ):
         """
         Find k-nearest neighbors of the query.
 
         :param query: query vector for KNN/ANN search. Has single axis.
-        :param search_field: name of the field to search on
         :param limit: maximum number of documents to return per query
         :return: a named tuple containing `documents` and `scores`
         """
         self._logger.debug('Executing `find`')
-        if search_field != '':
-            raise ValueError(
-                'Argument search_field is not supported for WeaviateDocumentIndex.\nSet search_field to an empty string to proceed.'
+        if kwargs.get('search_field'):
+            logging.warning(
+                'The search_field argument is not supported for the WeaviateDocumentIndex and will be ignored.'
             )
         embedding_field = self._get_embedding_field()
         if isinstance(query, BaseDoc):
@@ -381,14 +380,14 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         self,
         query: np.ndarray,
         limit: int,
-        search_field: str = '',
         score_name: Literal["certainty", "distance"] = "certainty",
         score_threshold: Optional[float] = None,
+        **kwargs: Any,
     ) -> _FindResult:
         index_name = self.index_name
-        if search_field:
+        if kwargs.get('search_field'):
             logging.warning(
-                'Argument search_field is not supported for WeaviateDocumentIndex. Ignoring.'
+                'The search_field argument is not supported for the WeaviateDocumentIndex and will be ignored.'
             )
         near_vector: Dict[str, Any] = {
             "vector": query,
@@ -435,7 +434,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         queries: Union[AnyTensor, DocList],
         search_field: str = '',
         limit: int = 10,
-        **kwargs,
+        **kwargs: Any,
     ) -> FindResultBatched:
         """Find documents in the index using nearest neighbor search.
 
@@ -443,16 +442,13 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             Can be either a tensor-like (np.array, torch.Tensor, etc.) with a,
             or a DocList.
             If a tensor-like is passed, it should have shape (batch_size, vector_dim)
-        :param search_field: name of the field to search on.
-            Documents in the index are retrieved based on this similarity
-            of this field to the query.
         :param limit: maximum number of documents to return per query
         :return: a named tuple containing `documents` and `scores`
         """
         self._logger.debug('Executing `find_batched`')
-        if search_field != '':
-            raise ValueError(
-                'Argument search_field is not supported for WeaviateDocumentIndex.\nSet search_field to an empty string to proceed.'
+        if kwargs.get('search_field'):
+            logging.warning(
+                'The search_field argument is not supported for the WeaviateDocumentIndex and will be ignored.'
             )
         embedding_field = self._get_embedding_field()
 
@@ -831,7 +827,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             query,
             score_name: Literal["certainty", "distance"] = "certainty",
             score_threshold: Optional[float] = None,
-            search_field: str = '',
+            **kwargs: Any,
         ) -> Any:
             """
             Find k-nearest neighbors of the query.
@@ -839,12 +835,11 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             :param query: query vector for search. Has single axis.
             :param score_name: either `"certainty"` (default) or `"distance"`
             :param score_threshold: the threshold of the score
-            :param search_field: name of the field to search on
             :return: self
             """
-            if search_field != '':
-                raise ValueError(
-                    'Argument search_field is not supported for WeaviateDocumentIndex.\nSet search_field to an empty string to proceed.'
+            if kwargs.get('search_field'):
+                logging.warning(
+                    'The search_field argument is not supported for the WeaviateDocumentIndex and will be ignored.'
                 )
 
             near_vector = {

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -330,7 +330,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
     def find(
         self,
         query: Union[AnyTensor, BaseDoc],
-        search_field: str = '',
         limit: int = 10,
         **kwargs: Any,
     ):
@@ -353,7 +352,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             query_vec = query
         query_vec_np = self._to_numpy(query_vec)
         docs, scores = self._find(
-            query_vec_np, search_field=search_field, limit=limit, **kwargs
+            query_vec_np, limit=limit, **kwargs
         )
 
         if isinstance(docs, List):
@@ -432,7 +431,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
     def find_batched(
         self,
         queries: Union[AnyTensor, DocList],
-        search_field: str = '',
         limit: int = 10,
         **kwargs: Any,
     ) -> FindResultBatched:
@@ -461,7 +459,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             query_vec_np = self._to_numpy(queries)
 
         da_list, scores = self._find_batched(
-            query_vec_np, search_field=search_field, limit=limit, **kwargs
+            query_vec_np, limit=limit, **kwargs
         )
 
         if len(da_list) > 0 and isinstance(da_list[0], List):
@@ -473,7 +471,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         self,
         queries: np.ndarray,
         limit: int,
-        search_field: str = '',
         score_name: Literal["certainty", "distance"] = "certainty",
         score_threshold: Optional[float] = None,
     ) -> _FindResultBatched:

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -837,7 +837,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             Find k-nearest neighbors of the query.
 
             :param query: query vector for search. Has single axis.
-            :param search_field: name of the field to search on
             :param score_name: either `"certainty"` (default) or `"distance"`
             :param score_threshold: the threshold of the score
             :return: self

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -890,12 +890,12 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
 
             return self
 
-        def filter(self, filter_query: Any) -> Any:
+        def filter(self, where_filter: Any) -> Any:
             """Find documents in the index based on a filter query
-            :param filter_query: a filter
+            :param where_filter: a filter
             :return: self
             """
-            where_filter = filter_query.copy()
+            where_filter = where_filter.copy()
             self._overwrite_id(where_filter)
             self._queries[0] = self._queries[0].with_where(where_filter)
             return self

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -770,7 +770,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 )
             ]
 
-        def build(self) -> Any:
+        def build(self, *args, **kwargs) -> Any:
             """Build the query object."""
             num_queries = len(self._queries)
 
@@ -831,6 +831,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             query,
             score_name: Literal["certainty", "distance"] = "certainty",
             score_threshold: Optional[float] = None,
+            search_field: str = '',
         ) -> Any:
             """
             Find k-nearest neighbors of the query.
@@ -838,8 +839,14 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             :param query: query vector for search. Has single axis.
             :param score_name: either `"certainty"` (default) or `"distance"`
             :param score_threshold: the threshold of the score
+            :param search_field: name of the field to search on
             :return: self
             """
+            if search_field != '':
+                raise ValueError(
+                    'Argument search_field is not supported for WeaviateDocumentIndex.\nSet search_field to an empty string to proceed.'
+                )
+
             near_vector = {
                 "vector": query,
             }
@@ -883,12 +890,12 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
 
             return self
 
-        def filter(self, where_filter) -> Any:
+        def filter(self, filter_query: Any) -> Any:
             """Find documents in the index based on a filter query
-            :param where_filter: a filter
+            :param filter_query: a filter
             :return: self
             """
-            where_filter = where_filter.copy()
+            where_filter = filter_query.copy()
             self._overwrite_id(where_filter)
             self._queries[0] = self._queries[0].with_where(where_filter)
             return self
@@ -913,7 +920,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             return self
 
         def text_search(self, query: str, search_field: Optional[str] = None) -> Any:
-
             """Find documents in the index based on a text search query
 
             :param query: The text to search for

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -451,8 +451,8 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         """
         self._logger.debug('Executing `find_batched`')
         if search_field != '':
-            logging.warning(
-                'The search_field argument is not supported for the WeaviateDocumentIndex and will be ignored.'
+            raise ValueError(
+                'Argument search_field is not supported for WeaviateDocumentIndex.\nSet search_field to an empty string to proceed.'
             )
         embedding_field = self._get_embedding_field()
 

--- a/docs/how_to/multimodal_training_and_serving.md
+++ b/docs/how_to/multimodal_training_and_serving.md
@@ -135,6 +135,18 @@ class PairTextImage(BaseDoc):
     image: ImageDoc
 ```
 
+You then need to forward declare the following types. This will allow the objects to be properly pickled and unpickled.
+
+This will be unnecessary once [this issue](https://github.com/docarray/docarray/issues/1330) is resolved.
+
+```python
+from docarray import DocVec
+DocVec[Tokens]
+DocVec[TextDoc]
+DocVec[ImageDoc]
+DocVec[PairTextImage]
+```
+
 ### Create the dataset 
 
 In this section we will create a multimodal pytorch dataset around the Flick8k dataset using DocArray.


### PR DESCRIPTION
https://github.com/docarray/docarray/issues/1620

two non-breaking changes:
1. build() is more flexible and follows abstract signature
2. query_builder's `find()` can receive search_field even though it won't / can't use it 