### PR TITLE
chore: add a better looking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-v1.yml
+++ b/.github/ISSUE_TEMPLATE/bug-v1.yml
@@ -1,0 +1,66 @@
+name: 🐛 DocArray V1 Bug (0.1.0 - 0.20.1)
+description: Report a bug or unexpected behavior in DocArray version prior to v2 (0.21.1)
+labels: [bug V1, unconfirmed]
+
+body:
+  - type: markdown
+    attributes:
+      value:  Thank you for contributing to DocArray! 🙌
+
+  - type: markdown
+    attributes:
+      value:  "credits: This issue template is heavily inspired by [pydantic template](https://github.com/pydantic/pydantic/tree/main/.github/ISSUE_TEMPLATE)"
+
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Initial Checks
+      description: |
+        Just a few checks to make sure you need to create a bug report.
+      options:
+        - label: I have read and followed [the docs](https://docs.docarray.org/) and still think this is a bug
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please explain what you're seeing and what you would expect to see.
+
+        Please provide as much detail as possible to make understanding and solving your problem as quick as possible. 🙏
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example Code
+      description: >
+        If applicable, please add a self-contained,
+        [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example)
+        demonstrating the bug.
+
+      placeholder: |
+        import docarray
+
+        ...
+      render: Python
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Python, Pydantic & OS Version
+      description: |
+        Which version of Python & Pydantic are you using, and which Operating System?
+
+        Please run the following command and copy the output below:
+
+        ```bash
+        python -c "import docarray; print(docarray.__version__);"
+        ```
+
+      render: Text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-v2.yml
+++ b/.github/ISSUE_TEMPLATE/bug-v2.yml
@@ -1,0 +1,80 @@
+name: 🐛 DocArray Bug (>=0.30.0 )
+description: Report a bug or unexpected behavior in DocArray (v2) above (0.30.0)
+labels: [bug V2, unconfirmed]
+
+body:
+  - type: markdown
+    attributes:
+      value:  Thank you for contributing to DocArray! 🙌
+
+  - type: markdown
+    attributes:
+      value:  "credits: This issue template is heavily inspired by [pydantic template](https://github.com/pydantic/pydantic/tree/main/.github/ISSUE_TEMPLATE)"
+
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Initial Checks
+      description: |
+        Just a few checks to make sure you need to create a bug report.
+      options:
+        - label: I have read and followed [the docs](https://docs.docarray.org/) and still think this is a bug
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please explain what you're seeing and what you would expect to see.
+
+        Please provide as much detail as possible to make understanding and solving your problem as quick as possible. 🙏
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example Code
+      description: >
+        If applicable, please add a self-contained,
+        [minimal, reproducible, example](https://stackoverflow.com/help/minimal-reproducible-example)
+        demonstrating the bug.
+
+      placeholder: |
+        import docarray
+
+        ...
+      render: Python
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Python, Pydantic & OS Version
+      description: |
+        Which version of Python & Pydantic are you using, and which Operating System?
+
+        Please run the following command and copy the output below:
+
+        ```bash
+        python -c "import docarray; print(docarray.__version__);"
+        ```
+
+      render: Text
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: affected-components
+    attributes:
+      label: Affected Components
+      description: Which of the following parts of pydantic does this feature affect?
+      # keep this lis in sync with bug.yml
+      options:
+        - label: '[Vector Database / Index](https://docs.docarray.org/user_guide/storing/docindex/)'
+        - label: '[Representing](https://docs.docarray.org/user_guide/representing/first_step)'
+        - label: '[Sending](https://docs.docarray.org/user_guide/sending/first_step/)'
+        - label: '[storing](https://docs.docarray.org/user_guide/storing/first_step/)'
+        - label: '[multi modal data type](https://docs.docarray.org/data_types/first_steps/)'
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🤔 Ask a Question
+    url: 'https://github.com/pydantic/pydantic/discussions/new?category=question'
+    about: Ask a question about how to use pydantic using github discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: 🤔 Ask a Question
-    url: 'https://github.com/pydantic/pydantic/discussions/new?category=question'
+    url: 'https://github.com/docarray/docarray/discussions/new?category=question'
     about: Ask a question about how to use pydantic using github discussions
+  - name: 🤔 Ask a Question in discord
+    url: 'https://discord.com/invite/WaMp6PVPgR'
+    about: Or in our discord channel

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: 🚀 DocArray Feature request
+description: |
+  Suggest a new feature for DocArray
+
+labels: [feature request]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for contributing to docarray! ✊
+
+  - type: markdown
+    attributes:
+      value:  "credits: This issue template is heavily inspired by [pydantic template](https://github.com/pydantic/pydantic/tree/main/.github/ISSUE_TEMPLATE)"
+
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Initial Checks
+      description: |
+        Just a few checks to make sure you need to create a feature request.
+
+      options:
+        - label: I have searched Google & GitHub for similar requests and couldn't find anything
+          required: true
+        - label: I have read and followed [the docs](https://docs.docarray.org) and still think this feature is missing
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Please give as much detail as possible about the feature you would like to suggest. 🙏
+
+        You might like to add:
+        * A demo of how code might look when using the feature
+        * Your use case(s) for the feature
+        * Why the feature should be added to DocArray (as opposed to another library or just implemented in your code)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: affected-components
+    attributes:
+      label: Affected Components
+      description: Which of the following parts of DocArray does this feature affect?
+      # keep this lis in sync with bug.yml
+      options:
+        - label: '[Vector Database / Index](https://docs.docarray.org/user_guide/storing/docindex/)'
+        - label: '[Representing](https://docs.docarray.org/user_guide/representing/first_step)'
+        - label: '[Sending](https://docs.docarray.org/user_guide/sending/first_step/)'
+        - label: '[storing](https://docs.docarray.org/user_guide/storing/first_step/)'
+        - label: '[multi modal data type](https://docs.docarray.org/data_types/first_steps/)'


### PR DESCRIPTION
# Context

I am basically copying what pydantic repo is doing for handling issue because it is super helpfull

https://github.com/pydantic/pydantic/issues/new/choose
https://github.com/pydantic/pydantic/issues/new?assignees=&labels=bug+V2%2Cunconfirmed&projects=&template=bug-v2.yml

This just looks too nice to not have it

PS: I am citing the original issue template to give credit to pydantic