### PR TITLE
feat: check if a document is already index

### DIFF
--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -1167,15 +1167,6 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             )
             return self._get_root_doc_id(cur_root_id, root, '')
 
-    @abstractmethod
-    def __contains__(self, item: BaseDoc) -> bool:
-        """Checks if a given BaseDoc item is contained in the index.
-
-        :param item: the given BaseDoc
-        :return: if the given BaseDoc item is contained in the index
-        """
-        ...
-
     def subindex_contains(self, item: BaseDoc) -> bool:
         """Checks if a given BaseDoc item is contained in the index or any of its subindices.
 

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -1167,6 +1167,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             )
             return self._get_root_doc_id(cur_root_id, root, '')
 
+    @abstractmethod
     def __contains__(self, item: BaseDoc) -> bool:
         """Checks if a given BaseDoc item is contained in the index.
 
@@ -1175,6 +1176,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
         """
         ...
 
+    @abstractmethod
     def _get_all_documents(self) -> Union[AnyDocArray, List]:
         """Retrieve all documents from the index
 

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -1166,3 +1166,46 @@ class BaseDocIndex(ABC, Generic[TSchema]):
                 id, fields[0], '__'.join(fields[1:])
             )
             return self._get_root_doc_id(cur_root_id, root, '')
+
+    def __contains__(self, item: BaseDoc) -> bool:
+        """Checks if a given BaseDoc item is contained in the index.
+
+        :param item: the given BaseDoc
+        :return: if the given BaseDoc item is contained in the index
+        """
+        ...
+
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        """Retrieve all documents from the index
+
+        :return: a DocArray or list of documents
+        """
+        ...
+
+    def subindex_contains(self, item: BaseDoc) -> bool:
+        """Checks if a given BaseDoc item is contained in the index or any of its subindices.
+
+        :param item: the given BaseDoc
+        :return: if the given BaseDoc item is contained in the index/subindices
+        """
+        if self.num_docs() == 0:
+            return False
+
+        if safe_issubclass(type(item), BaseDoc):
+            docs = self._get_all_documents()
+            for doc in docs:
+                for field_name in doc.__fields__:
+                    sub_doc = getattr(doc, field_name)
+                    if (
+                        safe_issubclass(type(sub_doc), BaseDoc)
+                        and sub_doc.id == item.id
+                    ):
+                        return True
+
+            return self.__contains__(item) or any(
+                index.subindex_contains(item) for index in self._subindices.values()
+            )
+        else:
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -1167,6 +1167,14 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             )
             return self._get_root_doc_id(cur_root_id, root, '')
 
+    def __contains__(self, item: BaseDoc) -> bool:
+        """Checks if a given BaseDoc item is contained in the index.
+
+        :param item: the given BaseDoc
+        :return: if the given BaseDoc item is contained in the index
+        """
+        return False  # Will be overridden by backends
+
     def subindex_contains(self, item: BaseDoc) -> bool:
         """Checks if a given BaseDoc item is contained in the index or any of its subindices.
 

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -1176,14 +1176,6 @@ class BaseDocIndex(ABC, Generic[TSchema]):
         """
         ...
 
-    @abstractmethod
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        """Retrieve all documents from the index
-
-        :return: a DocArray or list of documents
-        """
-        ...
-
     def subindex_contains(self, item: BaseDoc) -> bool:
         """Checks if a given BaseDoc item is contained in the index or any of its subindices.
 
@@ -1194,16 +1186,6 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             return False
 
         if safe_issubclass(type(item), BaseDoc):
-            docs = self._get_all_documents()
-            for doc in docs:
-                for field_name in doc.__fields__:
-                    sub_doc = getattr(doc, field_name)
-                    if (
-                        safe_issubclass(type(sub_doc), BaseDoc)
-                        and sub_doc.id == item.id
-                    ):
-                        return True
-
             return self.__contains__(item) or any(
                 index.subindex_contains(item) for index in self._subindices.values()
             )

--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -30,6 +30,7 @@ from docarray.index.abstract import BaseDocIndex, _ColumnInfo, _raise_not_compos
 from docarray.typing import AnyTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.ndarray import NdArray
+from docarray.utils._internal._typing import safe_issubclass
 from docarray.utils._internal.misc import import_library
 from docarray.utils.find import _FindResult, _FindResultBatched
 
@@ -693,3 +694,12 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
 
     def _client_msearch(self, request: List[Dict[str, Any]]):
         return self._client.msearch(index=self.index_name, searches=request)
+
+    def __contains__(self, item: BaseDoc) -> bool:
+        if safe_issubclass(type(item), BaseDoc):
+            ret = self._client_mget([item.id])
+            return ret["docs"][0]["found"]
+        else:
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )

--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -682,12 +682,6 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        response = self._client.search(index=self.index_name)
-        return self._dict_list_to_docarray(
-            [item["_source"] for item in response["hits"]["hits"]]
-        )
-
     ###############################################
     # API Wrappers                                #
     ###############################################

--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -671,6 +671,23 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
     def _refresh(self, index_name: str):
         self._client.indices.refresh(index=index_name)
 
+    def __contains__(self, item: BaseDoc) -> bool:
+        if safe_issubclass(type(item), BaseDoc):
+            if len(item.id) == 0:
+                return False
+            ret = self._client_mget([item.id])
+            return ret["docs"][0]["found"]
+        else:
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )
+
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        response = self._client.search(index=self.index_name)
+        return self._dict_list_to_docarray(
+            [item["_source"] for item in response["hits"]["hits"]]
+        )
+
     ###############################################
     # API Wrappers                                #
     ###############################################
@@ -694,12 +711,3 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
 
     def _client_msearch(self, request: List[Dict[str, Any]]):
         return self._client.msearch(index=self.index_name, searches=request)
-
-    def __contains__(self, item: BaseDoc) -> bool:
-        if safe_issubclass(type(item), BaseDoc):
-            ret = self._client_mget([item.id])
-            return ret["docs"][0]["found"]
-        else:
-            raise TypeError(
-                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
-            )

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -401,7 +401,9 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
             rows = self._sqlite_cursor.fetchall()
             return len(rows) > 0
         else:
-            raise NotImplementedError
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )
 
     def num_docs(self) -> int:
         """

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -405,6 +405,11 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        self._sqlite_cursor.execute("SELECT data FROM docs")
+        rows = self._sqlite_cursor.fetchall()
+        return [self._doc_from_bytes(row[0]) for row in rows]
+
     def num_docs(self) -> int:
         """
         Get the number of documents.

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -405,11 +405,6 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        self._sqlite_cursor.execute("SELECT data FROM docs")
-        rows = self._sqlite_cursor.fetchall()
-        return [self._doc_from_bytes(row[0]) for row in rows]
-
     def num_docs(self) -> int:
         """
         Get the number of documents.

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -441,9 +441,6 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        return self._docs
-
     def persist(self, file: str = 'in_memory_index.bin') -> None:
         """Persist InMemoryExactNNIndex into a binary file."""
         self._docs.save_binary(file=file)

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -433,6 +433,9 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
     ) -> _FindResultBatched:
         raise NotImplementedError(f'{type(self)} does not support text search.')
 
+    def __contains__(self, item: BaseDoc):
+        return any(doc.id == item.id for doc in self._docs)
+
     def persist(self, file: str = 'in_memory_index.bin') -> None:
         """Persist InMemoryExactNNIndex into a binary file."""
         self._docs.save_binary(file=file)

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -434,7 +434,12 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         raise NotImplementedError(f'{type(self)} does not support text search.')
 
     def __contains__(self, item: BaseDoc):
-        return any(doc.id == item.id for doc in self._docs)
+        if safe_issubclass(type(item), BaseDoc):
+            return any(doc.id == item.id for doc in self._docs)
+        else:
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )
 
     def persist(self, file: str = 'in_memory_index.bin') -> None:
         """Persist InMemoryExactNNIndex into a binary file."""

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -441,6 +441,9 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        return self._docs
+
     def persist(self, file: str = 'in_memory_index.bin') -> None:
         """Persist InMemoryExactNNIndex into a binary file."""
         self._docs.save_binary(file=file)

--- a/docarray/index/backends/qdrant.py
+++ b/docarray/index/backends/qdrant.py
@@ -332,6 +332,16 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        response, _ = self._client.scroll(
+            collection_name=self.index_name,
+            with_payload=True,
+            with_vectors=True,
+        )
+        return self._dict_list_to_docarray(
+            [self._convert_to_doc(point) for point in response]
+        )
+
     def _del_items(self, doc_ids: Sequence[str]):
         items = self._get_items(doc_ids)
         if len(items) < len(doc_ids):

--- a/docarray/index/backends/qdrant.py
+++ b/docarray/index/backends/qdrant.py
@@ -332,16 +332,6 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        response, _ = self._client.scroll(
-            collection_name=self.index_name,
-            with_payload=True,
-            with_vectors=True,
-        )
-        return self._dict_list_to_docarray(
-            [self._convert_to_doc(point) for point in response]
-        )
-
     def _del_items(self, doc_ids: Sequence[str]):
         items = self._get_items(doc_ids)
         if len(items) < len(doc_ids):

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -776,11 +776,24 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 )
                 .do()
             )
-            return len(result["data"]["Get"][self.index_name]) > 0
+            docs = result["data"]["Get"][self.index_name]
+            return docs is not None and len(docs) > 0
         else:
             raise TypeError(
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
+
+    def _get_all_documents(self) -> Union[AnyDocArray, List]:
+        result = self._client.query.get(self.index_name, ['docarrayid']).do()
+
+        return self._dict_list_to_docarray(
+            self._get_items(
+                [
+                    list(doc.values())[0]
+                    for doc in result["data"]["Get"][self.index_name]
+                ]
+            )
+        )
 
     class QueryBuilder(BaseDocIndex.QueryBuilder):
         def __init__(self, document_index):

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -783,18 +783,6 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def _get_all_documents(self) -> Union[AnyDocArray, List]:
-        result = self._client.query.get(self.index_name, ['docarrayid']).do()
-
-        return self._dict_list_to_docarray(
-            self._get_items(
-                [
-                    list(doc.values())[0]
-                    for doc in result["data"]["Get"][self.index_name]
-                ]
-            )
-        )
-
     class QueryBuilder(BaseDocIndex.QueryBuilder):
         def __init__(self, document_index):
             self._queries = [

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -31,6 +31,7 @@ from docarray.index.abstract import BaseDocIndex, FindResultBatched, _FindResult
 from docarray.typing import AnyTensor
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 from docarray.typing.tensor.ndarray import NdArray
+from docarray.utils._internal._typing import safe_issubclass
 from docarray.utils._internal.misc import import_library
 from docarray.utils.find import FindResult, _FindResult
 
@@ -761,6 +762,25 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             for res in results['data']['Get'][self._db_config.index_name]
         ]
         return ids
+
+    def __contains__(self, item: BaseDoc) -> bool:
+        if safe_issubclass(type(item), BaseDoc):
+            result = (
+                self._client.query.get(self.index_name, ['docarrayid'])
+                .with_where(
+                    {
+                        "path": ['docarrayid'],
+                        "operator": "Equal",
+                        "valueString": f'{item.id}',
+                    }
+                )
+                .do()
+            )
+            return len(result["data"]["Get"][self.index_name]) > 0
+        else:
+            raise TypeError(
+                f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
+            )
 
     class QueryBuilder(BaseDocIndex.QueryBuilder):
         def __init__(self, document_index):

--- a/docarray/utils/_internal/_typing.py
+++ b/docarray/utils/_internal/_typing.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 from typing_extensions import get_origin
 from typing_inspect import get_args, is_typevar, is_union_type
 
+from docarray.typing.id import ID
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
 
@@ -45,6 +46,6 @@ def safe_issubclass(x: type, a_tuple: type) -> bool:
     :return: A boolean value - 'True' if 'x' is a subclass of 'A_tuple', 'False' otherwise.
              Note that if the origin of 'x' is a list or tuple, the function immediately returns 'False'.
     """
-    if (get_origin(x) in (list, tuple, dict, set)) or is_typevar(x):
+    if (get_origin(x) in (list, tuple, dict, set)) or is_typevar(x) or x == ID:
         return False
     return issubclass(x, a_tuple)

--- a/tests/index/elastic/v7/test_find.py
+++ b/tests/index/elastic/v7/test_find.py
@@ -323,3 +323,22 @@ def test_query_builder(tmp_index_name):  # noqa: F811
 
     docs, _ = index.execute_query(query)
     assert [doc['id'] for doc in docs] == ['7', '6', '5', '4']
+
+
+def test_contain():
+    class SimpleSchema(BaseDoc):
+        tens: NdArray[10]
+
+    index = ElasticV7DocIndex[SimpleSchema]()
+    index_docs = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+
+    assert (index_docs[0] in index) is False
+
+    index.index(index_docs)
+
+    for doc in index_docs:
+        assert (doc in index) is True
+
+    index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    for doc in index_docs_new:
+        assert (doc in index) is False

--- a/tests/index/elastic/v7/test_subindex.py
+++ b/tests/index/elastic/v7/test_subindex.py
@@ -170,3 +170,32 @@ def test_subindex_del(index):
     assert index._subindices['docs'].num_docs() == 20
     assert index._subindices['list_docs'].num_docs() == 20
     assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+
+
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = ElasticV7DocIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False

--- a/tests/index/elastic/v8/test_find.py
+++ b/tests/index/elastic/v8/test_find.py
@@ -342,3 +342,22 @@ def test_index_name():
 
     index = ElasticDocIndex[MyDoc]()
     assert index.index_name == MyDoc.__name__.lower()
+
+
+def test_contain():
+    class SimpleSchema(BaseDoc):
+        tens: NdArray[10]
+
+    index = ElasticDocIndex[SimpleSchema]()
+    index_docs = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+
+    assert (index_docs[0] in index) is False
+
+    index.index(index_docs)
+
+    for doc in index_docs:
+        assert (doc in index) is True
+
+    index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    for doc in index_docs_new:
+        assert (doc in index) is False

--- a/tests/index/elastic/v8/test_subindex.py
+++ b/tests/index/elastic/v8/test_subindex.py
@@ -166,9 +166,30 @@ def test_subindex_filter(index):
         assert doc.id.split('-')[-1] == '0'
 
 
-def test_subindex_del(index):
-    del index['0']
-    assert index.num_docs() == 4
-    assert index._subindices['docs'].num_docs() == 20
-    assert index._subindices['list_docs'].num_docs() == 20
-    assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = ElasticDocIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -345,5 +345,3 @@ def test_contain(tmp_path):
     index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
     for doc in index_docs_new:
         assert (doc in index) is False
-
-    print(index._get_all_documents())

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -329,3 +329,19 @@ def test_query_builder_limits(find_limit, filter_limit, expected_docs, tmp_path)
     docs, scores = index.execute_query(q)
 
     assert len(docs) == expected_docs
+
+
+def test_contain(tmp_path):
+    class SimpleSchema(BaseDoc):
+        tens: NdArray[10] = Field(space="cosine")
+
+    index = HnswDocumentIndex[SimpleSchema](work_dir=str(tmp_path))
+    index_docs = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    index.index(index_docs)
+
+    for doc in index_docs:
+        assert (doc in index) is True
+
+    index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    for doc in index_docs_new:
+        assert (doc in index) is False

--- a/tests/index/hnswlib/test_find.py
+++ b/tests/index/hnswlib/test_find.py
@@ -345,3 +345,5 @@ def test_contain(tmp_path):
     index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
     for doc in index_docs_new:
         assert (doc in index) is False
+
+    print(index._get_all_documents())

--- a/tests/index/hnswlib/test_subindex.py
+++ b/tests/index/hnswlib/test_subindex.py
@@ -154,3 +154,32 @@ def test_subindex_del(index):
     assert index._subindices['docs'].num_docs() == 20
     assert index._subindices['list_docs'].num_docs() == 20
     assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+
+
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = HnswDocumentIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -341,3 +341,9 @@ def test_nested_document_find():
     del doc_index['0']
     assert doc_index.num_docs() == 9
     assert doc_index._subindices['docs'].num_docs() == 90
+
+
+def test_document_contain(doc_index):
+    num_docs = doc_index.num_docs()
+    for i in range(num_docs):
+        assert (doc_index._docs[i] in doc_index) is True

--- a/tests/index/in_memory/test_subindex.py
+++ b/tests/index/in_memory/test_subindex.py
@@ -152,3 +152,32 @@ def test_subindex_del(index):
     assert index._subindices['docs'].num_docs() == 20
     assert index._subindices['list_docs'].num_docs() == 20
     assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+
+
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = InMemoryExactNNIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False

--- a/tests/index/qdrant/test_find.py
+++ b/tests/index/qdrant/test_find.py
@@ -221,3 +221,25 @@ def test_find_batched(space, tmp_collection_name):  # noqa: F811
     assert len(scores[1]) == 1
     assert docs[0][0].id == index_docs[0].id
     assert docs[1][0].id == index_docs[-1].id
+
+
+def test_contain():
+    class SimpleDoc(BaseDoc):
+        tens: NdArray[10] = Field(dims=1000)
+
+    class SimpleSchema(BaseDoc):
+        tens: NdArray[10]
+
+    index = QdrantDocumentIndex[SimpleSchema]()
+    index_docs = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+
+    assert (index_docs[0] in index) is False
+
+    index.index(index_docs)
+
+    for doc in index_docs:
+        assert (doc in index) is True
+
+    index_docs_new = [SimpleDoc(tens=np.zeros(10)) for _ in range(10)]
+    for doc in index_docs_new:
+        assert (doc in index) is False

--- a/tests/index/qdrant/test_subindex.py
+++ b/tests/index/qdrant/test_subindex.py
@@ -193,3 +193,32 @@ def test_subindex_del(index):
     assert index._subindices['docs'].num_docs() == 20
     assert index._subindices['list_docs'].num_docs() == 20
     assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+
+
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = QdrantDocumentIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False

--- a/tests/index/weaviate/test_find_weaviate.py
+++ b/tests/index/weaviate/test_find_weaviate.py
@@ -66,3 +66,57 @@ def test_find_tensorflow():
     assert np.allclose(
         docs[0].tens.unwrap().numpy(), index_docs[-1].tens.unwrap().numpy()
     )
+
+
+def test_comprehensive():
+    import numpy as np
+    from pydantic import Field
+
+    from docarray import BaseDoc
+    from docarray.index.backends.weaviate import WeaviateDocumentIndex
+    from docarray.typing import NdArray
+
+    class Document(BaseDoc):
+        text: str
+        embedding: NdArray[2] = Field(
+            dims=2, is_embedding=True
+        )  # Embedding column -> vector representation of the document
+        file: NdArray[100] = Field(dims=100)
+
+    docs = [
+        Document(
+            text="Hello world",
+            embedding=np.array([1, 2]),
+            file=np.random.rand(100),
+            id="1",
+        ),
+        Document(
+            text="Hello world, how are you?",
+            embedding=np.array([3, 4]),
+            file=np.random.rand(100),
+            id="2",
+        ),
+        Document(
+            text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut",
+            embedding=np.array([5, 6]),
+            file=np.random.rand(100),
+            id="3",
+        ),
+    ]
+
+    batch_config = {
+        "batch_size": 20,
+        "dynamic": False,
+        "timeout_retries": 3,
+        "num_workers": 1,
+    }
+
+    dbconfig = WeaviateDocumentIndex.DBConfig(
+        host="https://docarray-test-4mfexsso.weaviate.network",  # Replace with your endpoint
+        auth_api_key="JPsfPHB3OLHrgnN80JAa7bmPApOxOfaHy0SO",
+    )
+
+    runtimeconfig = WeaviateDocumentIndex.RuntimeConfig(batch_config=batch_config)
+    store = WeaviateDocumentIndex[Document](db_config=dbconfig)
+    store.configure(runtimeconfig)  # Batch settings being passed on
+    store.index(docs)

--- a/tests/index/weaviate/test_subindex.py
+++ b/tests/index/weaviate/test_subindex.py
@@ -186,3 +186,32 @@ def test_subindex_del(index):
     assert index._subindices['docs'].num_docs() == 20
     assert index._subindices['list_docs'].num_docs() == 20
     assert index._subindices['list_docs']._subindices['docs'].num_docs() == 100
+
+
+def test_subindex_contain(index):
+    # Checks for individual simple_docs within list_docs
+    for i in range(4):
+        doc = index[f'{i + 1}']
+        for simple_doc in doc.list_docs:
+            assert index.subindex_contains(simple_doc) is True
+            for nested_doc in simple_doc.docs:
+                assert index.subindex_contains(nested_doc) is True
+
+    invalid_doc = SimpleDoc(
+        id='non_existent',
+        simple_tens=np.zeros(10),
+        simple_text='invalid',
+    )
+    assert index.subindex_contains(invalid_doc) is False
+
+    # Checks for an empty doc
+    empty_doc = SimpleDoc(
+        id='',
+        simple_tens=np.zeros(10),
+        simple_text='',
+    )
+    assert index.subindex_contains(empty_doc) is False
+
+    # Empty index
+    empty_index = WeaviateDocumentIndex[MyDoc]()
+    assert (empty_doc in empty_index) is False


### PR DESCRIPTION
This PR is designed to enable the indexer (for all supported backends) to check whether a document has already been indexed. We aim to accommodate various backends including in_memory, hnswlib, elastic, qdrant, and weaviate. Given that different backends store and index documents in distinct ways, we need to custom-tailor our function for each backend.

Progress:

- [x] In-Memory
- [x] Hnswlib
- [x] Elastic
- [x] Qdrant
- [x] Weaviate