### PR TITLE
docs: qdrant in memory usage

### DIFF
--- a/docs/user_guide/storing/index_qdrant.md
+++ b/docs/user_guide/storing/index_qdrant.md
@@ -52,7 +52,7 @@ class MyDocument(BaseDoc):
 
 
 # Creating an in-memory Qdrant document index
-qdrant_config = QdrantDocumentIndex.DBConfig(":memory:")
+qdrant_config = QdrantDocumentIndex.DBConfig(location=":memory:")
 doc_index = QdrantDocumentIndex[MyDocument](qdrant_config)
 
 # Connecting to a local Qdrant instance running as a Docker container


### PR DESCRIPTION
```python
from typing import Optional

from docarray import BaseDoc
from docarray.index import QdrantDocumentIndex
from docarray.typing import NdArray

class MyDocument(BaseDoc):
    title: str
    title_embedding: NdArray[786]
    image_path: Optional[str]
    image_embedding: NdArray[512]


# Creating an in-memory Qdrant document index
qdrant_config = QdrantDocumentIndex.DBConfig(":memory:")
doc_index = QdrantDocumentIndex[MyDocument](qdrant_config)
```

This snippet from our docs doesn't work, ":memory:" gets assigned to index_name instead of location. 