### PR TITLE
feat: tensor type for protobuf deserialization

### DIFF
--- a/docs/user_guide/sending/serialization.md
+++ b/docs/user_guide/sending/serialization.md
@@ -265,4 +265,42 @@ proto_message_dv = dv.to_protobuf()
 dv_from_proto = DocVec[SimpleVecDoc].from_protobuf(proto_message_dv)
 ```
 
+You can deserialize any [DocVec][docarray.array.doc_list.doc_list.DocVec] protobuf message to any tensor type,
+by passing the `tensor_type=...` parameter to [`from_protobuf`][docarray.array.doc_list.doc_list.DocVec.from_protobuf]
+
+This means that you can choose at deserialization time if you are working with numpy, PyTorch, or TensorFlow tensors.
+
+If no `tensor_type` is passed, the default is `NdArray`.
+
+
+```python
+import torch
+
+from docarray import BaseDoc, DocVec
+from docarray.typing import TorchTensor, NdArray, AnyTensor
+
+
+class AnyTensorDoc(BaseDoc):
+    tensor: AnyTensor
+
+
+dv = DocVec[AnyTensorDoc](
+    [AnyTensorDoc(tensor=torch.ones(16)) for _ in range(8)], tensor_type=TorchTensor
+)
+
+proto_message_dv = dv.to_protobuf()
+
+# deserialize to torch
+dv_from_proto_torch = DocVec[AnyTensorDoc].from_protobuf(
+    proto_message_dv, tensor_type=TorchTensor
+)
+assert dv_from_proto_torch.tensor_type == TorchTensor
+assert isinstance(dv_from_proto_torch.tensor, TorchTensor)
+
+# deserialize to numpy (default)
+dv_from_proto_numpy = DocVec[AnyTensorDoc].from_protobuf(proto_message_dv)
+assert dv_from_proto_numpy.tensor_type == NdArray
+assert isinstance(dv_from_proto_numpy.tensor, NdArray)
+```
+
 

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -280,19 +280,19 @@ def test_proto_tensor_type(tensor_type):
 @pytest.mark.proto
 @pytest.mark.tensorflow
 def test_proto_tensor_type_tf():
-    from docarray.typing import TensorflowTensor
+    from docarray.typing import TensorFlowTensor
 
     class InnerDoc(BaseDoc):
-        embedding: TensorflowTensor
+        embedding: TensorFlowTensor
 
     class MyDoc(BaseDoc):
-        tensor: TensorflowTensor
+        tensor: TensorFlowTensor
         inner: InnerDoc
         inner_v: DocVec[InnerDoc]
 
     def _get_rand_tens():
         arr = np.random.random(512)
-        return TensorflowTensor.from_ndarray(arr)
+        return TensorFlowTensor.from_ndarray(arr)
 
     da = DocVec[MyDoc](
         [
@@ -308,19 +308,19 @@ def test_proto_tensor_type_tf():
             ),
         ]
     )
-    assert isinstance(da.tensor, TensorflowTensor)
+    assert isinstance(da.tensor, TensorFlowTensor)
     assert da.tensor.shape == (2, 512)
-    assert isinstance(da.inner.embedding, TensorflowTensor)
+    assert isinstance(da.inner.embedding, TensorFlowTensor)
     assert da.inner.embedding.shape == (2, 512)
-    assert isinstance(da.inner_v[0].embedding, TensorflowTensor)
+    assert isinstance(da.inner_v[0].embedding, TensorFlowTensor)
     assert da.inner_v[0].embedding.shape == (1, 512)
 
     proto = da.to_protobuf()
-    da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorflowTensor)
+    da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)
 
-    assert isinstance(da_after.tensor, TensorflowTensor)
+    assert isinstance(da_after.tensor, TensorFlowTensor)
     assert (da.tensor == da_after.tensor).all()
-    assert isinstance(da_after.inner.embedding, TensorflowTensor)
+    assert isinstance(da_after.inner.embedding, TensorFlowTensor)
     assert (da.inner.embedding == da_after.inner.embedding).all()
-    assert isinstance(da_after.inner_v[0].embedding, TensorflowTensor)
+    assert isinstance(da_after.inner_v[0].embedding, TensorFlowTensor)
     assert (da.inner_v[0].embedding == da_after.inner_v[0].embedding).all()

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -321,10 +321,12 @@ def test_proto_tensor_type_tf():
     da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)
 
     assert isinstance(da_after.tensor, TensorFlowTensor)
-    assert tf.math.reduce_all(tf.equal(da.tensor, da_after.tensor))
+    assert tf.math.reduce_all(tf.equal(da.tensor.tensor, da_after.tensor.tensor))
     assert isinstance(da_after.inner.embedding, TensorFlowTensor)
-    assert tf.math.reduce_all(tf.equal(da.inner.embedding, da_after.inner.embedding))
+    assert tf.math.reduce_all(
+        tf.equal(da.inner.embedding.tensor, da_after.inner.embedding.tensor)
+    )
     assert isinstance(da_after.inner_v[0].embedding, TensorFlowTensor)
     assert tf.math.reduce_all(
-        tf.equal(da.inner_v[0].embedding, da_after.inner_v[0].embedding)
+        tf.equal(da.inner_v[0].embedding.tensor, da_after.inner_v[0].embedding.tensor)
     )

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -311,7 +311,7 @@ def test_proto_tensor_type_tf():
         ]
     )
     assert isinstance(da.tensor, TensorFlowTensor)
-    assert da.tensor.shape == (2, 512)
+    assert len(da.tensor) == 2
     assert isinstance(da.inner.embedding, TensorFlowTensor)
     assert len(da.inner.embedding) == 2
     assert isinstance(da.inner_v[0].embedding, TensorFlowTensor)

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -321,7 +321,7 @@ def test_proto_tensor_type_tf():
     da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)
 
     assert isinstance(da_after.tensor, TensorFlowTensor)
-    assert (da.tensor == da_after.tensor).all()
+    assert tf.math.reduce_all(da.tensor == da_after.tensor)
     assert isinstance(da_after.inner.embedding, TensorFlowTensor)
     assert tf.math.reduce_all(da.inner.embedding == da_after.inner.embedding)
     assert isinstance(da_after.inner_v[0].embedding, TensorFlowTensor)

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -321,8 +321,10 @@ def test_proto_tensor_type_tf():
     da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)
 
     assert isinstance(da_after.tensor, TensorFlowTensor)
-    assert tf.math.reduce_all(da.tensor == da_after.tensor)
+    assert tf.math.reduce_all(tf.equal(da.tensor, da_after.tensor))
     assert isinstance(da_after.inner.embedding, TensorFlowTensor)
-    assert tf.math.reduce_all(da.inner.embedding == da_after.inner.embedding)
+    assert tf.math.reduce_all(tf.equal(da.inner.embedding, da_after.inner.embedding))
     assert isinstance(da_after.inner_v[0].embedding, TensorFlowTensor)
-    assert tf.math.reduce_all(da.inner_v[0].embedding == da_after.inner_v[0].embedding)
+    assert tf.math.reduce_all(
+        tf.equal(da.inner_v[0].embedding, da_after.inner_v[0].embedding)
+    )

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -280,6 +280,8 @@ def test_proto_tensor_type(tensor_type):
 @pytest.mark.proto
 @pytest.mark.tensorflow
 def test_proto_tensor_type_tf():
+    import tensorflow as tf
+
     from docarray.typing import TensorFlowTensor
 
     class InnerDoc(BaseDoc):
@@ -311,9 +313,9 @@ def test_proto_tensor_type_tf():
     assert isinstance(da.tensor, TensorFlowTensor)
     assert da.tensor.shape == (2, 512)
     assert isinstance(da.inner.embedding, TensorFlowTensor)
-    assert da.inner.embedding.shape == (2, 512)
+    assert len(da.inner.embedding) == 2
     assert isinstance(da.inner_v[0].embedding, TensorFlowTensor)
-    assert da.inner_v[0].embedding.shape == (1, 512)
+    assert len(da.inner_v[0].embedding) == 1
 
     proto = da.to_protobuf()
     da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)
@@ -321,6 +323,6 @@ def test_proto_tensor_type_tf():
     assert isinstance(da_after.tensor, TensorFlowTensor)
     assert (da.tensor == da_after.tensor).all()
     assert isinstance(da_after.inner.embedding, TensorFlowTensor)
-    assert (da.inner.embedding == da_after.inner.embedding).all()
+    assert tf.math.reduce_all(da.inner.embedding == da_after.inner.embedding)
     assert isinstance(da_after.inner_v[0].embedding, TensorFlowTensor)
-    assert (da.inner_v[0].embedding == da_after.inner_v[0].embedding).all()
+    assert tf.math.reduce_all(da.inner_v[0].embedding == da_after.inner_v[0].embedding)

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -277,7 +277,6 @@ def test_proto_tensor_type(tensor_type):
     assert (da.inner_v[0].embedding == da_after.inner_v[0].embedding).all()
 
 
-@pytest.mark.proto
 @pytest.mark.tensorflow
 def test_proto_tensor_type_tf():
     import tensorflow as tf

--- a/tests/units/array/stack/test_proto.py
+++ b/tests/units/array/stack/test_proto.py
@@ -228,3 +228,99 @@ def test_proto_none_any_column():
 
     assert da_after._storage.any_columns['text'] == [None, None]
     assert da_after._storage.any_columns['d'] == [None, None]
+
+
+@pytest.mark.proto
+@pytest.mark.parametrize('tensor_type', [NdArray, TorchTensor])
+def test_proto_tensor_type(tensor_type):
+    class InnerDoc(BaseDoc):
+        embedding: tensor_type
+
+    class MyDoc(BaseDoc):
+        tensor: tensor_type
+        inner: InnerDoc
+        inner_v: DocVec[InnerDoc]
+
+    def _get_rand_tens():
+        arr = np.random.random(512)
+        return tensor_type.from_ndarray(arr) if tensor_type == TorchTensor else arr
+
+    da = DocVec[MyDoc](
+        [
+            MyDoc(
+                tensor=_get_rand_tens(),
+                inner=InnerDoc(embedding=_get_rand_tens()),
+                inner_v=DocVec[InnerDoc]([InnerDoc(embedding=_get_rand_tens())]),
+            ),
+            MyDoc(
+                tensor=_get_rand_tens(),
+                inner=InnerDoc(embedding=_get_rand_tens()),
+                inner_v=DocVec[InnerDoc]([InnerDoc(embedding=_get_rand_tens())]),
+            ),
+        ]
+    )
+    assert isinstance(da.tensor, tensor_type)
+    assert da.tensor.shape == (2, 512)
+    assert isinstance(da.inner.embedding, tensor_type)
+    assert da.inner.embedding.shape == (2, 512)
+    assert isinstance(da.inner_v[0].embedding, tensor_type)
+    assert da.inner_v[0].embedding.shape == (1, 512)
+
+    proto = da.to_protobuf()
+    da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=tensor_type)
+
+    assert isinstance(da_after.tensor, tensor_type)
+    assert (da.tensor == da_after.tensor).all()
+    assert isinstance(da_after.inner.embedding, tensor_type)
+    assert (da.inner.embedding == da_after.inner.embedding).all()
+    assert isinstance(da_after.inner_v[0].embedding, tensor_type)
+    assert (da.inner_v[0].embedding == da_after.inner_v[0].embedding).all()
+
+
+@pytest.mark.proto
+@pytest.mark.tensorflow
+def test_proto_tensor_type_tf():
+    from docarray.typing import TensorflowTensor
+
+    class InnerDoc(BaseDoc):
+        embedding: TensorflowTensor
+
+    class MyDoc(BaseDoc):
+        tensor: TensorflowTensor
+        inner: InnerDoc
+        inner_v: DocVec[InnerDoc]
+
+    def _get_rand_tens():
+        arr = np.random.random(512)
+        return TensorflowTensor.from_ndarray(arr)
+
+    da = DocVec[MyDoc](
+        [
+            MyDoc(
+                tensor=_get_rand_tens(),
+                inner=InnerDoc(embedding=_get_rand_tens()),
+                inner_v=DocVec[InnerDoc]([InnerDoc(embedding=_get_rand_tens())]),
+            ),
+            MyDoc(
+                tensor=_get_rand_tens(),
+                inner=InnerDoc(embedding=_get_rand_tens()),
+                inner_v=DocVec[InnerDoc]([InnerDoc(embedding=_get_rand_tens())]),
+            ),
+        ]
+    )
+    assert isinstance(da.tensor, TensorflowTensor)
+    assert da.tensor.shape == (2, 512)
+    assert isinstance(da.inner.embedding, TensorflowTensor)
+    assert da.inner.embedding.shape == (2, 512)
+    assert isinstance(da.inner_v[0].embedding, TensorflowTensor)
+    assert da.inner_v[0].embedding.shape == (1, 512)
+
+    proto = da.to_protobuf()
+    da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorflowTensor)
+
+    assert isinstance(da_after.tensor, TensorflowTensor)
+    assert (da.tensor == da_after.tensor).all()
+    assert isinstance(da_after.inner.embedding, TensorflowTensor)
+    assert (da.inner.embedding == da_after.inner.embedding).all()
+    assert isinstance(da_after.inner_v[0].embedding, TensorflowTensor)
+    assert (da.inner_v[0].embedding == da_after.inner_v[0].embedding).all()


### PR DESCRIPTION
This allows `DocVoc` to be deserilzed to a specific `tensor_type`, i.e. torch, tf, or numpy:

```python
# look at the unit test for more comprehensive example
class MyDoc(BaseDoc):
    tensor: TensorFlowTensor

da = DocVec[MyDoc](...)  # doesn't matter what tensor_type is here

proto = da.to_protobuf()
da_after = DocVec[MyDoc].from_protobuf(proto, tensor_type=TensorFlowTensor)

assert isinstance(da_after.tensor, TensorFlowTensor)
```
Note that the `tensor_type` passed to `from_protobuf()` does not need to match the tensor type from before serialization.
Since all tensor are represented the same way in the proto, any proto can be deserialized to any tensor type.

**TODO**:
- [x] docs