### PR TITLE
refactor: implementation of InMemoryExactNNIndex follows DBConfig way

### DIFF
--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import (
@@ -55,7 +54,6 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         """Initialize InMemoryExactNNIndex"""
         super().__init__(db_config=db_config, **kwargs)
         self._runtime_config = self.RuntimeConfig()
-        self._db_config = cast(InMemoryExactNNIndex.DBConfig, self._db_config)
         self._db_config = cast(InMemoryExactNNIndex.DBConfig, self._db_config)
         self._index_file_path = self._db_config.index_file_path
 
@@ -449,7 +447,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
         DEFAULT_INDEX_FILE_PATH = 'in_memory_index.bin'
         file_to_save = self._index_file_path or file
         if file_to_save is None:
-            warnings.warn(
+            self._logger.warning(
                 f'persisting index to {DEFAULT_INDEX_FILE_PATH} because no `index_file_path` has been used inside DBConfig and no `file` has been passed as argument'
             )
         file_to_save = file_to_save or 'in_memory_index.bin'  # to keep

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -136,6 +136,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
     @dataclass
     class DBConfig(BaseDocIndex.DBConfig):
         """Dataclass that contains all "static" configurations of InMemoryExactNNIndex."""
+
         index_file_path: Optional[str] = None
         default_column_config: Dict[Type, Dict[str, Any]] = field(
             default_factory=lambda: defaultdict(
@@ -450,7 +451,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
             self._logger.warning(
                 f'persisting index to {DEFAULT_INDEX_FILE_PATH} because no `index_file_path` has been used inside DBConfig and no `file` has been passed as argument'
             )
-        file_to_save = file_to_save or 'in_memory_index.bin'  # to keep
+        file_to_save = file_to_save or DEFAULT_INDEX_FILE_PATH
         self._docs.save_binary(file=file_to_save)
 
     def _get_root_doc_id(self, id: str, root: str, sub: str) -> str:

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import (
@@ -48,30 +49,31 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
     def __init__(
         self,
         docs: Optional[DocList] = None,
-        index_file_path: Optional[str] = None,
+        db_config=None,
         **kwargs,
     ):
         """Initialize InMemoryExactNNIndex"""
-        if 'db_config' in kwargs:
-            kwargs.pop('db_config')
-        super().__init__(db_config=None, **kwargs)
+        super().__init__(db_config=db_config, **kwargs)
         self._runtime_config = self.RuntimeConfig()
+        self._db_config = cast(InMemoryExactNNIndex.DBConfig, self._db_config)
+        self._db_config = cast(InMemoryExactNNIndex.DBConfig, self._db_config)
+        self._index_file_path = self._db_config.index_file_path
 
-        if docs and index_file_path:
+        if docs and self._index_file_path:
             raise ValueError(
                 'Initialize `InMemoryExactNNIndex` with either `docs` or '
                 '`index_file_path`, not both. Provide `docs` for a fresh index, or '
                 '`index_file_path` to use an existing file.'
             )
 
-        if index_file_path:
-            if os.path.exists(index_file_path):
+        if self._index_file_path:
+            if os.path.exists(self._index_file_path):
                 self._logger.info(
-                    f'Loading index from a binary file: {index_file_path}'
+                    f'Loading index from a binary file: {self._index_file_path}'
                 )
                 self._docs = DocList.__class_getitem__(
                     cast(Type[BaseDoc], self._schema)
-                ).load_binary(file=index_file_path)
+                ).load_binary(file=self._index_file_path)
 
                 data_by_columns = self._get_col_value_dict(self._docs)
                 self._update_subindex_data(self._docs)
@@ -79,7 +81,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
 
             else:
                 self._logger.warning(
-                    f'Index file does not exist: {index_file_path}. '
+                    f'Index file does not exist: {self._index_file_path}. '
                     f'Initializing empty InMemoryExactNNIndex.'
                 )
                 self._docs = DocList.__class_getitem__(
@@ -137,7 +139,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
     class DBConfig(BaseDocIndex.DBConfig):
         """Dataclass that contains all "static" configurations of InMemoryExactNNIndex."""
 
-        pass
+        index_file_path: Optional[str] = None
 
     @dataclass
     class RuntimeConfig(BaseDocIndex.RuntimeConfig):
@@ -442,9 +444,16 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 f"item must be an instance of BaseDoc or its subclass, not '{type(item).__name__}'"
             )
 
-    def persist(self, file: str = 'in_memory_index.bin') -> None:
+    def persist(self, file: Optional[str] = None) -> None:
         """Persist InMemoryExactNNIndex into a binary file."""
-        self._docs.save_binary(file=file)
+        DEFAULT_INDEX_FILE_PATH = 'in_memory_index.bin'
+        file_to_save = self._index_file_path or file
+        if file_to_save is None:
+            warnings.warn(
+                f'persisting index to {DEFAULT_INDEX_FILE_PATH} because no `index_file_path` has been used inside DBConfig and no `file` has been passed as argument'
+            )
+        file_to_save = file_to_save or 'in_memory_index.bin'  # to keep
+        self._docs.save_binary(file=file_to_save)
 
     def _get_root_doc_id(self, id: str, root: str, sub: str) -> str:
         """Get the root_id given the id of a subindex Document and the root and subindex name

--- a/docs/user_guide/storing/index_in_memory.md
+++ b/docs/user_guide/storing/index_in_memory.md
@@ -29,14 +29,20 @@ docs = DocList[MyDoc](MyDoc() for _ in range(10))
 doc_index = InMemoryExactNNIndex[MyDoc]()
 doc_index.index(docs)
 
-# or in one step:
+# or in one step, create with inserted docs.
 doc_index = InMemoryExactNNIndex[MyDoc](docs)
 ```
 
-Additionally, you can preserve your index as a binary file and instantiate a new one using this file:
+Alternatively, you can pass an `index_file_path` argument to make sure that the index can be restored if persisted from that specific file.
 ```python
 # Save your existing index as a binary file
-doc_index.persist('docs.bin')
+docs = DocList[MyDoc](MyDoc() for _ in range(10))
+
+doc_index = InMemoryExactNNIndex[MyDoc](index_file_path='docs.bin')
+doc_index.index(docs)
+
+# or in one step:
+doc_index.persist()
 
 # Initialize a new document index using the saved binary file
 new_doc_index = InMemoryExactNNIndex[MyDoc](index_file_path='docs.bin')
@@ -46,8 +52,8 @@ new_doc_index = InMemoryExactNNIndex[MyDoc](index_file_path='docs.bin')
 
 This section lays out the configurations and options that are specific to [InMemoryExactNNIndex][docarray.index.backends.in_memory.InMemoryExactNNIndex].
 
-The `DBConfig` of [InMemoryExactNNIndex][docarray.index.backends.in_memory.InMemoryExactNNIndex] contains only one entry:
-the default mapping from Python types to column configurations.
+The `DBConfig` of [InMemoryExactNNIndex][docarray.index.backends.in_memory.InMemoryExactNNIndex] contains two entries:
+`index_file_path` and `default_column_mapping`, the default mapping from Python types to column configurations.
 
 You can see in the [section below](#field-wise-configurations) how to override configurations for specific fields.
 If you want to set configurations globally, i.e. for all vector fields in your Documents, you can do that using `DBConfig` or passing it at `__init__`::
@@ -55,12 +61,14 @@ If you want to set configurations globally, i.e. for all vector fields in your D
 ```python
 from collections import defaultdict
 from docarray.typing import AbstractTensor
-new_doc_index = InMemoryExactNNIndex[MyDoc](default_column_config=defaultdict(
-                                                    dict,
-                                                    {
-                                                        AbstractTensor: {'space': 'cosine_sim'},
-                                                    },
-                                                ))
+new_doc_index = InMemoryExactNNIndex[MyDoc](
+    default_column_config=defaultdict(
+        dict,
+        {
+            AbstractTensor: {'space': 'cosine_sim'},
+        },
+    )
+)
 ```
 
 This will set the default configuration for all vector fields to the one specified in the example above.


### PR DESCRIPTION
The InMemoryExactNNIndexer gets an attribute in `__init__` instead of following the pattern of using `DBConfig`.

Waiting for #1648 to be merged updating Documentation