### PR TITLE
fix: pass limit as integer

### DIFF
--- a/docarray/utils/find.py
+++ b/docarray/utils/find.py
@@ -226,7 +226,7 @@ def find_batched(
     metric_fn = getattr(comp_backend.Metrics, metric)
     dists = metric_fn(query_embeddings, index_embeddings, device=device)
     top_scores, top_indices = comp_backend.Retrieval.top_k(
-        dists, k=limit, device=device, descending=descending
+        dists, k=int(limit), device=device, descending=descending
     )
 
     batched_docs: List[DocList] = []

--- a/tests/units/util/test_find.py
+++ b/tests/units/util/test_find.py
@@ -295,7 +295,7 @@ def test_find_union():
         index,
         query,
         search_field='embedding',
-        limit=7,
+        limit=7.0,
     )
     assert len(top_k) == 7
     assert len(scores) == 7
@@ -371,7 +371,7 @@ def test_find_nested_union_optional():
         index,
         query,
         search_field='embedding2',
-        limit=7,
+        limit=7.0,
     )
     assert len(top_k) == 7
     assert len(scores) == 7


### PR DESCRIPTION
I was trying to wrap the InMemoryExactNNIndexer as an Executor in Jina and passing limits as parameters they are passed as `floats` because of protobuf. So it would be good for us to have this change applied otherwise it raises an exception