### PR TITLE
fix: docvec equality if tensors are involved

### DIFF
--- a/docarray/array/doc_vec/column_storage.py
+++ b/docarray/array/doc_vec/column_storage.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from docarray.array.list_advance_indexing import ListAdvancedIndexing
+from docarray.helper import _is_tensor, _tensor_equals
 from docarray.typing import NdArray
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
@@ -102,7 +103,13 @@ class ColumnStorage:
             for key_self in col_map_self.keys():
                 if key_self == 'id':
                     continue
-                if col_map_self[key_self] != col_map_other[key_self]:
+
+                val1, val2 = col_map_self[key_self], col_map_other[key_self]
+                if _is_tensor(val1) or _is_tensor(val2):
+                    values_are_equal = _tensor_equals(val1, val2)
+                else:
+                    values_are_equal = val1 == val2
+                if not values_are_equal:
                     return False
         return True
 

--- a/docarray/array/doc_vec/column_storage.py
+++ b/docarray/array/doc_vec/column_storage.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 from docarray.array.list_advance_indexing import ListAdvancedIndexing
-from docarray.helper import _is_tensor, _tensor_equals
 from docarray.typing import NdArray
 from docarray.typing.tensor.abstract_tensor import AbstractTensor
 
@@ -105,8 +104,10 @@ class ColumnStorage:
                     continue
 
                 val1, val2 = col_map_self[key_self], col_map_other[key_self]
-                if _is_tensor(val1) or _is_tensor(val2):
-                    values_are_equal = _tensor_equals(val1, val2)
+                if isinstance(val1, AbstractTensor):
+                    values_are_equal = val1.get_comp_backend().equal(val1, val2)
+                elif isinstance(val2, AbstractTensor):
+                    values_are_equal = val2.get_comp_backend().equal(val1, val2)
                 else:
                     values_are_equal = val1 == val2
                 if not values_are_equal:

--- a/docarray/computation/abstract_comp_backend.py
+++ b/docarray/computation/abstract_comp_backend.py
@@ -157,6 +157,19 @@ class AbstractComputationalBackend(ABC, typing.Generic[TTensor]):
         """
         ...
 
+    @classmethod
+    @abstractmethod
+    def equal(cls, tensor1: 'TTensor', tensor2: 'TTensor') -> bool:
+        """
+        Check if two tensors are equal.
+
+        :param tensor1: the first tensor
+        :param tensor2: the second tensor
+        :return: True if two tensors are equal, False otherwise.
+            If one or more of the inputs is not a tensor of this framework, return False.
+        """
+        ...
+
     class Retrieval(ABC, typing.Generic[TTensorRetrieval]):
         """
         Abstract class for retrieval and ranking functionalities

--- a/docarray/computation/numpy_backend.py
+++ b/docarray/computation/numpy_backend.py
@@ -111,6 +111,21 @@ class NumpyCompBackend(AbstractNumpyBasedBackend):
 
         return np.clip(r, *((a, b) if a < b else (b, a)))
 
+    @classmethod
+    def equal(cls, tensor1: 'np.ndarray', tensor2: 'np.ndarray') -> bool:
+        """
+        Check if two tensors are equal.
+
+        :param tensor1: the first array
+        :param tensor2: the second array
+        :return: True if two arrays are equal, False otherwise.
+            If one or more of the inputs is not an ndarray, return False.
+        """
+        are_np_arrays = isinstance(tensor1, np.ndarray) and isinstance(
+            tensor2, np.ndarray
+        )
+        return are_np_arrays and np.array_equal(tensor1, tensor2)
+
     class Retrieval(AbstractComputationalBackend.Retrieval[np.ndarray]):
         """
         Abstract class for retrieval and ranking functionalities

--- a/docarray/computation/tensorflow_backend.py
+++ b/docarray/computation/tensorflow_backend.py
@@ -133,7 +133,8 @@ class TensorFlowCompBackend(AbstractNumpyBasedBackend[TensorFlowTensor]):
         """
         t1, t2 = getattr(tensor1, 'tensor', None), getattr(tensor2, 'tensor', None)
         if tf.is_tensor(t1) and tf.is_tensor(t2):
-            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))
+            # mypy doesn't know that tf.is_tensor implies that t1, t2 are not None
+            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))  # type: ignore
         return False
 
     class Retrieval(AbstractComputationalBackend.Retrieval[TensorFlowTensor]):

--- a/docarray/computation/tensorflow_backend.py
+++ b/docarray/computation/tensorflow_backend.py
@@ -121,6 +121,21 @@ class TensorFlowCompBackend(AbstractNumpyBasedBackend[TensorFlowTensor]):
         normalized = tnp.clip(i, *((a, b) if a < b else (b, a)))
         return cls._cast_output(tf.cast(normalized, tensor.tensor.dtype))
 
+    @classmethod
+    def equal(cls, tensor1: 'TensorFlowTensor', tensor2: 'TensorFlowTensor') -> bool:
+        """
+        Check if two tensors are equal.
+
+        :param tensor1: the first tensor
+        :param tensor2: the second tensor
+        :return: True if two tensors are equal, False otherwise.
+            If one or more of the inputs is not a TensorFlowTensor, return False.
+        """
+        t1, t2 = getattr(tensor1, 'tensor', None), getattr(tensor2, 'tensor', None)
+        if tf.is_tensor(t1) and tf.is_tensor(t2):
+            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))
+        return False
+
     class Retrieval(AbstractComputationalBackend.Retrieval[TensorFlowTensor]):
         """
         Abstract class for retrieval and ranking functionalities

--- a/docarray/computation/torch_backend.py
+++ b/docarray/computation/torch_backend.py
@@ -114,6 +114,21 @@ class TorchCompBackend(AbstractComputationalBackend[torch.Tensor]):
         return tensor.reshape(shape)
 
     @classmethod
+    def equal(cls, tensor1: 'torch.Tensor', tensor2: 'torch.Tensor') -> bool:
+        """
+        Check if two tensors are equal.
+
+        :param tensor1: the first tensor
+        :param tensor2: the second tensor
+        :return: True if two tensors are equal, False otherwise.
+            If one or more of the inputs is not a torch.Tensor, return False.
+        """
+        are_torch = isinstance(tensor1, torch.Tensor) and isinstance(
+            tensor2, torch.Tensor
+        )
+        return are_torch and torch.equal(tensor1, tensor2)
+
+    @classmethod
     def detach(cls, tensor: 'torch.Tensor') -> 'torch.Tensor':
         """
         Returns the tensor detached from its current graph.

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -301,7 +301,7 @@ def _tensor_equals(tens1: Any, tens2: Any) -> bool:
 
         t1, t2 = getattr(tens1, 'tensor', None), getattr(tens2, 'tensor', None)
         if tf.is_tensor(t1) and tf.is_tensor(t2):
-            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))
+            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))  # type: ignore
 
     are_np_arrays = isinstance(tens1, np.ndarray) and isinstance(tens2, np.ndarray)
     if are_np_arrays:

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -299,7 +299,9 @@ def _tensor_equals(tens1: Any, tens2: Any) -> bool:
         import tensorflow as tf  # type: ignore
 
         if tf.is_tensor(tens1) and tf.is_tensor(tens2):
-            return tf.math.reduce_all(tf.equal(tens1, tens2))
+            return tens1.shape == tens2.shape and tf.math.reduce_all(
+                tf.equal(tens1, tens2)
+            )
 
     are_np_arrays = isinstance(tens1, np.ndarray) and isinstance(tens2, np.ndarray)
     if are_np_arrays:

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -275,7 +275,8 @@ def _is_tensor(x: Any) -> bool:
     if is_tf_available():
         import tensorflow as tf  # type: ignore
 
-        if tf.is_tensor(x):
+        t = getattr(x, 'tensor', None)
+        if tf.is_tensor(t):
             return True
 
     if isinstance(x, np.ndarray):
@@ -298,10 +299,9 @@ def _tensor_equals(tens1: Any, tens2: Any) -> bool:
     if is_tf_available():
         import tensorflow as tf  # type: ignore
 
-        if tf.is_tensor(tens1) and tf.is_tensor(tens2):
-            return tens1.shape == tens2.shape and tf.math.reduce_all(
-                tf.equal(tens1, tens2)
-            )
+        t1, t2 = getattr(tens1, 'tensor', None), getattr(tens2, 'tensor', None)
+        if tf.is_tensor(t1) and tf.is_tensor(t2):
+            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))
 
     are_np_arrays = isinstance(tens1, np.ndarray) and isinstance(tens2, np.ndarray)
     if are_np_arrays:

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -15,10 +15,7 @@ from typing import (
     Union,
 )
 
-import numpy as np
-
 from docarray.utils._internal._typing import safe_issubclass
-from docarray.utils._internal.misc import is_tf_available, is_torch_available
 
 if TYPE_CHECKING:
     from docarray import BaseDoc
@@ -259,52 +256,3 @@ def _shallow_copy_doc(doc):
         setattr(shallow_copy, field_name, val)
 
     return shallow_copy
-
-
-def _is_tensor(x: Any) -> bool:
-    """
-    Determines whether `x` is either np.ndarray, torch.tensor, or tf.tensor
-    """
-
-    if is_torch_available():
-        import torch
-
-        if isinstance(x, torch.Tensor):
-            return True
-
-    if is_tf_available():
-        import tensorflow as tf  # type: ignore
-
-        t = getattr(x, 'tensor', None)
-        if tf.is_tensor(t):
-            return True
-
-    if isinstance(x, np.ndarray):
-        return True
-
-    return False
-
-
-def _tensor_equals(tens1: Any, tens2: Any) -> bool:
-    """
-    Determines if two {torch, tf, np} tensors are equal.
-    If at least one of them is not a tensor, of if they are tensors of different frameworks, False is returned.
-    """
-    if is_torch_available():
-        import torch
-
-        if isinstance(tens1, torch.Tensor) and isinstance(tens2, torch.Tensor):
-            return torch.equal(tens1, tens2)
-
-    if is_tf_available():
-        import tensorflow as tf  # type: ignore
-
-        t1, t2 = getattr(tens1, 'tensor', None), getattr(tens2, 'tensor', None)
-        if tf.is_tensor(t1) and tf.is_tensor(t2):
-            return t1.shape == t2.shape and tf.math.reduce_all(tf.equal(t1, t1))  # type: ignore
-
-    are_np_arrays = isinstance(tens1, np.ndarray) and isinstance(tens2, np.ndarray)
-    if are_np_arrays:
-        return np.array_equal(tens1, tens2)
-
-    return False

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -273,7 +273,7 @@ def _is_tensor(x: Any) -> bool:
             return True
 
     if is_tf_available():
-        import tensorflow as tf
+        import tensorflow as tf  # type: ignore
 
         if tf.is_tensor(x):
             return True
@@ -296,7 +296,7 @@ def _tensor_equals(tens1: Any, tens2: Any) -> bool:
             return torch.equal(tens1, tens2)
 
     if is_tf_available():
-        import tensorflow as tf
+        import tensorflow as tf  # type: ignore
 
         if tf.is_tensor(tens1) and tf.is_tensor(tens2):
             return tf.math.reduce_all(tf.equal(tens1, tens2))

--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -15,7 +15,10 @@ from typing import (
     Union,
 )
 
+import numpy as np
+
 from docarray.utils._internal._typing import safe_issubclass
+from docarray.utils._internal.misc import is_tf_available, is_torch_available
 
 if TYPE_CHECKING:
     from docarray import BaseDoc
@@ -256,3 +259,50 @@ def _shallow_copy_doc(doc):
         setattr(shallow_copy, field_name, val)
 
     return shallow_copy
+
+
+def _is_tensor(x: Any) -> bool:
+    """
+    Determines whether `x` is either np.ndarray, torch.tensor, or tf.tensor
+    """
+
+    if is_torch_available():
+        import torch
+
+        if isinstance(x, torch.Tensor):
+            return True
+
+    if is_tf_available():
+        import tensorflow as tf
+
+        if tf.is_tensor(x):
+            return True
+
+    if isinstance(x, np.ndarray):
+        return True
+
+    return False
+
+
+def _tensor_equals(tens1: Any, tens2: Any) -> bool:
+    """
+    Determines if two {torch, tf, np} tensors are equal.
+    If at least one of them is not a tensor, of if they are tensors of different frameworks, False is returned.
+    """
+    if is_torch_available():
+        import torch
+
+        if isinstance(tens1, torch.Tensor) and isinstance(tens2, torch.Tensor):
+            return torch.equal(tens1, tens2)
+
+    if is_tf_available():
+        import tensorflow as tf
+
+        if tf.is_tensor(tens1) and tf.is_tensor(tens2):
+            return tf.math.reduce_all(tf.equal(tens1, tens2))
+
+    are_np_arrays = isinstance(tens1, np.ndarray) and isinstance(tens2, np.ndarray)
+    if are_np_arrays:
+        return np.array_equal(tens1, tens2)
+
+    return False

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -598,6 +598,25 @@ def test_doc_vec_equality():
     assert da == da2.to_doc_vec()
 
 
+@pytest.mark.parametrize('tensor_type', [TorchTensor, NdArray])
+def test_doc_vec_equality_tensor(tensor_type):
+    class Text(BaseDoc):
+        tens: tensor_type
+
+    da = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=tensor_type
+    )
+    da2 = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=tensor_type
+    )
+    assert da == da2
+
+    da2 = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4, 5]) for _ in range(10)], tensor_type=tensor_type
+    )
+    assert da != da2
+
+
 def test_doc_vec_nested(batch_nested_doc):
     batch, Doc, Inner = batch_nested_doc
     batch2 = DocVec[Doc]([Doc(inner=Inner(hello='hello')) for _ in range(10)])

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -617,6 +617,27 @@ def test_doc_vec_equality_tensor(tensor_type):
     assert da != da2
 
 
+@pytest.mark.tensorflow
+def test_doc_vec_equality_tf(tensor_type):
+    from docarray.typing import TensorflowTensor
+
+    class Text(BaseDoc):
+        tens: TensorflowTensor
+
+    da = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorflowTensor
+    )
+    da2 = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorflowTensor
+    )
+    assert da == da2
+
+    da2 = DocVec[Text](
+        [Text(tens=[1, 2, 3, 4, 5]) for _ in range(10)], tensor_type=TensorflowTensor
+    )
+    assert da != da2
+
+
 def test_doc_vec_nested(batch_nested_doc):
     batch, Doc, Inner = batch_nested_doc
     batch2 = DocVec[Doc]([Doc(inner=Inner(hello='hello')) for _ in range(10)])

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -619,21 +619,21 @@ def test_doc_vec_equality_tensor(tensor_type):
 
 @pytest.mark.tensorflow
 def test_doc_vec_equality_tf():
-    from docarray.typing import TensorflowTensor
+    from docarray.typing import TensorFlowTensor
 
     class Text(BaseDoc):
-        tens: TensorflowTensor
+        tens: TensorFlowTensor
 
     da = DocVec[Text](
-        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorflowTensor
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorFlowTensor
     )
     da2 = DocVec[Text](
-        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorflowTensor
+        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TensorFlowTensor
     )
     assert da == da2
 
     da2 = DocVec[Text](
-        [Text(tens=[1, 2, 3, 4, 5]) for _ in range(10)], tensor_type=TensorflowTensor
+        [Text(tens=[1, 2, 3, 4, 5]) for _ in range(10)], tensor_type=TensorFlowTensor
     )
     assert da != da2
 

--- a/tests/units/array/stack/test_array_stacked.py
+++ b/tests/units/array/stack/test_array_stacked.py
@@ -618,7 +618,7 @@ def test_doc_vec_equality_tensor(tensor_type):
 
 
 @pytest.mark.tensorflow
-def test_doc_vec_equality_tf(tensor_type):
+def test_doc_vec_equality_tf():
     from docarray.typing import TensorflowTensor
 
     class Text(BaseDoc):


### PR DESCRIPTION
Before this, DocVec equality checks that involved a tensor would fail by raising and Exception:

```python
    class Text(BaseDoc):
        tens: TorchTensor

    da = DocVec[Text](
        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TorchTensor
    )
    da2 = DocVec[Text](
        [Text(tens=[1, 2, 3, 4]) for _ in range(10)], tensor_type=TorchTensor
    )
    assert da == da2  # would raise
```
```terminal
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

This is because checks of the form `tens1 == tens2` return a boolean tensor, not a single bool, which breaks an assumption in the previous implementation.

This PR solved that by introducing a helper function that let's us compare tensors and get a single bool as output.