### PR TITLE
fix: avoid converting doclists in the base index

### DIFF
--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -578,7 +578,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
         self._logger.debug(f'Executing `filter` for the query {filter_query}')
         docs = self._filter(filter_query, limit=limit, **kwargs)
 
-        if isinstance(docs, List):
+        if isinstance(docs, List) and not isinstance(docs, DocList):
             docs = self._dict_list_to_docarray(docs)
 
         return docs
@@ -656,7 +656,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
             query_text, search_field=search_field, limit=limit, **kwargs
         )
 
-        if isinstance(docs, List):
+        if isinstance(docs, List) and not isinstance(docs, DocList):
             docs = self._dict_list_to_docarray(docs)
 
         return FindResult(documents=docs, scores=scores)

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -357,7 +357,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             query_vec_np, search_field=search_field, limit=limit, **kwargs
         )
 
-        if isinstance(docs, List):
+        if isinstance(docs, List) and not isinstance(docs, DocList):
             docs = self._dict_list_to_docarray(docs)
 
         return FindResult(documents=docs, scores=scores)


### PR DESCRIPTION
```python
if isinstance(docs, List):
    docs = self._dict_list_to_docarray(docs)

```

_dict_list_to_docarray expects a list of dictionaries which is then transformed into a DocList. However, since DocList extends List, the condition is true even if docs is already a DocList, which then leads to an error.

We already fixed this in one place but there are other parts too that need an extra check.

Found while working on milvus pr