### PR TITLE
fix: qdrant unable to see index_name

### DIFF
--- a/docarray/index/backends/qdrant.py
+++ b/docarray/index/backends/qdrant.py
@@ -67,9 +67,6 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
 
     def __init__(self, db_config=None, **kwargs):
         """Initialize QdrantDocumentIndex"""
-        if db_config is not None and getattr(db_config, 'index_name'):
-            db_config.collection_name = db_config.index_name
-
         super().__init__(db_config=db_config, **kwargs)
         self._db_config: QdrantDocumentIndex.DBConfig = cast(
             QdrantDocumentIndex.DBConfig, self._db_config
@@ -101,7 +98,11 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
                 'To do so, use the syntax: QdrantDocumentIndex[DocumentType]'
             )
 
-        return self._db_config.collection_name or default_collection_name
+        return (
+            self._db_config.collection_name
+            or self._db_config.index_name
+            or default_collection_name
+        )
 
     @property
     def index_name(self):

--- a/docarray/index/backends/qdrant.py
+++ b/docarray/index/backends/qdrant.py
@@ -564,7 +564,7 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
 
     def _filter_by_parent_id(self, id: str) -> Optional[List[str]]:
         response, _ = self._client.scroll(
-            collection_name=self._db_config.collection_name,  # type: ignore
+            collection_name=self.collection_name,  # type: ignore
             scroll_filter=rest.Filter(
                 must=[
                     rest.FieldCondition(

--- a/tests/index/qdrant/test_configurations.py
+++ b/tests/index/qdrant/test_configurations.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+from pydantic import Field
+
+from docarray import BaseDoc
+from docarray.index import QdrantDocumentIndex
+from docarray.typing import NdArray
+from tests.index.qdrant.fixtures import start_storage, tmp_collection_name  # noqa: F401
+
+
+pytestmark = [pytest.mark.slow, pytest.mark.index]
+
+
+def test_configure_dim():
+    class Schema1(BaseDoc):
+        tens: NdArray = Field(dim=10)
+
+    index = QdrantDocumentIndex[Schema1](host='localhost')
+
+    docs = [Schema1(tens=np.random.random((10,))) for _ in range(10)]
+    index.index(docs)
+
+    assert index.num_docs() == 10
+
+    class Schema2(BaseDoc):
+        tens: NdArray[20]
+
+    index = QdrantDocumentIndex[Schema2](host='localhost')
+    docs = [Schema2(tens=np.random.random((20,))) for _ in range(10)]
+    index.index(docs)
+
+    assert index.num_docs() == 10
+
+
+def test_index_name():
+    class Schema(BaseDoc):
+        tens: NdArray = Field(dim=10)
+
+    index1 = QdrantDocumentIndex[Schema]()
+    assert index1.index_name == 'schema'
+
+    index2 = QdrantDocumentIndex[Schema](index_name='my_index')
+    assert index2.index_name == 'my_index'
+
+    index3 = QdrantDocumentIndex[Schema](collection_name='my_index')
+    assert index3.index_name == 'my_index'


### PR DESCRIPTION
qdrant doc index does not recognize index_name when passed

```python
from docarray import BaseDoc
from docarray.index import QdrantDocumentIndex

class SimpleSchema(BaseDoc):
    title: str

index = QdrantDocumentIndex[SimpleSchema](index_name='index_name')
print(index.index_name)
```

will print `simpleschema`