### PR TITLE
fix: weaviate handles lowercase index names

### DIFF
--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -257,6 +257,15 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
             }
         )
 
+        def __post_init__(self):
+            # To prevent errors, it is important to capitalize the provided index name
+            # when working with Weaviate, as it stores index names in a capitalized format.
+            self.index_name = (
+                self.index_name[0].upper() + self.index_name[1:]
+                if self.index_name
+                else None
+            )
+
     @dataclass
     class RuntimeConfig(BaseDocIndex.RuntimeConfig):
         """Dataclass that contains all "dynamic" configurations of WeaviateDocumentIndex."""

--- a/docarray/index/backends/weaviate.py
+++ b/docarray/index/backends/weaviate.py
@@ -260,6 +260,7 @@ class WeaviateDocumentIndex(BaseDocIndex, Generic[TSchema]):
         def __post_init__(self):
             # To prevent errors, it is important to capitalize the provided index name
             # when working with Weaviate, as it stores index names in a capitalized format.
+            # Can't use .capitalize() because it modifies the whole string (See test).
             self.index_name = (
                 self.index_name[0].upper() + self.index_name[1:]
                 if self.index_name

--- a/tests/index/weaviate/test_column_config_weaviate.py
+++ b/tests/index/weaviate/test_column_config_weaviate.py
@@ -48,3 +48,9 @@ def test_index_name():
 
     index = WeaviateDocumentIndex[StringDoc]()
     assert index.index_name == StringDoc.__name__
+
+    index = WeaviateDocumentIndex[StringDoc](index_name='Index_name')
+    assert index.index_name == 'Index_name'
+
+    index = WeaviateDocumentIndex[StringDoc](index_name='Index_name')
+    assert index.index_name == 'Index_name'

--- a/tests/index/weaviate/test_column_config_weaviate.py
+++ b/tests/index/weaviate/test_column_config_weaviate.py
@@ -49,8 +49,8 @@ def test_index_name():
     index = WeaviateDocumentIndex[StringDoc]()
     assert index.index_name == StringDoc.__name__
 
-    index = WeaviateDocumentIndex[StringDoc](index_name='Index_name')
-    assert index.index_name == 'Index_name'
+    index = WeaviateDocumentIndex[StringDoc](index_name='BaseDoc')
+    assert index.index_name == 'BaseDoc'
 
-    index = WeaviateDocumentIndex[StringDoc](index_name='Index_name')
+    index = WeaviateDocumentIndex[StringDoc](index_name='index_name')
     assert index.index_name == 'Index_name'


### PR DESCRIPTION
WeaviateDocumentIndex capitalizes the index name when creating an index, so if we pass lowercase index name, there's a mismatch leading to various errors

```python
from docarray import BaseDoc, DocList
from docarray.index import WeaviateDocumentIndex
from docarray.typing import NdArray
from pydantic import Field
import numpy as np

# Define the document schema.
class MyDoc(BaseDoc):
    title: str
    embedding: NdArray[128] = Field(is_embedding=True)

# Create dummy documents.
docs = DocList[MyDoc](MyDoc(title=f'title #{i}', embedding=np.random.rand(128)) for i in range(10))

# Initialize a new WeaviateDocumentIndex instance and add the documents to the index.
doc_index = WeaviateDocumentIndex[MyDoc](index_name='zdzd')
doc_index.index(docs)

# Perform a vector search.
query = np.ones(128)
retrieved_docs = doc_index.find(query, limit=10)
```

> File "/Users/jinaai/Desktop/docarray/docarray/index/backends/weaviate.py", line 354, in find
> docs, scores = self._find(
> File "/Users/jinaai/Desktop/docarray/docarray/index/backends/weaviate.py", line 408, in _find
> results["data"]["Get"][index_name], score_name
> KeyError: 'zdzd'
> 

Solution: add a post_init function that capitalizes the first letter of the index name
