### PR TITLE
feat: InMemoryExactNNIndex pre filtering

### DIFF
--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -291,11 +291,6 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
             raise ValueError(
                 f'args and kwargs not supported for `execute_query` on {type(self)}'
             )
-        # find_res = _execute_find_and_filter_query(
-        #     doc_index=self,
-        #     query=query,
-        #     reverse_order=True,
-        # )
         find_res = self._hybrid_search(query)
         return find_res
 
@@ -331,6 +326,10 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 out_docs = filter_docs(out_docs, op_kwargs['filter_query'])
             else:
                 raise ValueError(f'Query operation is not supported: {op}')
+
+        # if limit was not provided, use the default
+        if limit == sys.maxsize:
+            limit = 10
 
         out_docs = out_docs[:limit]
         scores_and_docs = zip([doc_to_score[doc.id] for doc in out_docs], out_docs)

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -294,9 +294,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
 
     def _find_and_filter(self, query: List[Tuple[str, Dict]]) -> FindResult:
         """
-        Executes a hybrid search on documents based on the provided query.
-
-        The function performs search operations such as 'find' and 'filter' in the order
+        The function executes search operations such as 'find' and 'filter' in the order
         they appear in the query. The 'find' operation performs a vector similarity search.
         The 'filter' operation filters out documents based on a filter query.
         The documents are finally sorted based on their scores.
@@ -320,7 +318,8 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
                 doc_to_score.update(zip(out_docs.id, scores))
             elif op == 'filter':
                 out_docs = filter_docs(out_docs, op_kwargs['filter_query'])
-                out_docs = out_docs[: op_kwargs.get('limit', len(out_docs))]
+                if 'limit' in op_kwargs:
+                    out_docs = out_docs[: op_kwargs['limit']]
             else:
                 raise ValueError(f'Query operation is not supported: {op}')
 

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -291,10 +291,10 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
             raise ValueError(
                 f'args and kwargs not supported for `execute_query` on {type(self)}'
             )
-        find_res = self._hybrid_search(query)
+        find_res = self._find_and_filter(query)
         return find_res
 
-    def _hybrid_search(self, query: List[Tuple[str, Dict]]) -> FindResult:
+    def _find_and_filter(self, query: List[Tuple[str, Dict]]) -> FindResult:
         """
         Executes a hybrid search on documents based on the provided query.
 

--- a/docarray/index/backends/in_memory.py
+++ b/docarray/index/backends/in_memory.py
@@ -291,8 +291,7 @@ class InMemoryExactNNIndex(BaseDocIndex, Generic[TSchema]):
             raise ValueError(
                 f'args and kwargs not supported for `execute_query` on {type(self)}'
             )
-        find_res = self._find_and_filter(query)
-        return find_res
+        return self._find_and_filter(query)
 
     def _find_and_filter(self, query: List[Tuple[str, Dict]]) -> FindResult:
         """

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -164,7 +164,7 @@ def test_with_text_doc_torch():
         assert len(r) == 5
 
 
-def test_hybrid_search_pre_filtering(doc_index):
+def test_query_builder_pre_filtering(doc_index):
     q = (
         doc_index.build_query()
         .filter(filter_query={'price': {'$lte': 3}})
@@ -179,7 +179,7 @@ def test_hybrid_search_pre_filtering(doc_index):
         assert doc.price <= 3
 
 
-def test_hybrid_search_post_filtering(doc_index):
+def test_query_builder_post_filtering(doc_index):
     q = (
         doc_index.build_query()
         .find(query=np.ones(10), search_field='tensor', limit=5)
@@ -194,7 +194,7 @@ def test_hybrid_search_post_filtering(doc_index):
         assert doc.price > 7
 
 
-def test_hybrid_search_pre_post_filtering(doc_index):
+def test_query_builder_pre_post_filtering(doc_index):
     q = (
         doc_index.build_query()
         .filter(filter_query={'price': {'$lte': 3}})
@@ -207,6 +207,23 @@ def test_hybrid_search_pre_post_filtering(doc_index):
 
     assert len(docs) == 1
     assert docs[0].text == 'hello 1' and docs[0].price <= 3
+
+
+def test_find_and_filter(doc_index):
+    q = (
+        doc_index.build_query()
+        .filter(filter_query={'price': {'$lt': 3}})
+        .find(query=np.ones(10), search_field='tensor')
+        .filter(filter_query={'text': {'$neq': 'hello 2'}})
+        .build()
+    )
+
+    docs, scores = doc_index._find_and_filter(q)
+
+    assert len(docs) == 2
+    for doc in docs:
+        assert doc.text in ['hello 1', 'hello 0']
+        assert doc.price < 3
 
 
 def test_filter(doc_index):

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -182,16 +182,16 @@ def test_query_builder_pre_filtering(doc_index):
 def test_query_builder_post_filtering(doc_index):
     q = (
         doc_index.build_query()
-        .find(query=np.ones(10), search_field='tensor', limit=5)
-        .filter(filter_query={'price': {'$gt': 7}})
+        .find(query=np.ones(10), search_field='tensor')
+        .filter(filter_query={'price': {'$gt': 3}}, limit=5)
         .build()
     )
 
     docs, scores = doc_index.execute_query(q)
 
-    assert len(docs) == 2
+    assert len(docs) == 5
     for doc in docs:
-        assert doc.price > 7
+        assert doc.price > 3
 
 
 def test_query_builder_pre_post_filtering(doc_index):

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -15,7 +15,6 @@ from docarray.utils._internal.misc import is_tf_available
 tf_available = is_tf_available()
 if tf_available:
     import tensorflow as tf
-    from docarray.typing import TensorFlowTensor
 
 
 class SchemaDoc(BaseDoc):
@@ -165,37 +164,49 @@ def test_with_text_doc_torch():
         assert len(r) == 5
 
 
-def test_concatenated_queries(doc_index):
-    query = SchemaDoc(text='query', price=0, tensor=np.ones(10))
-
+def test_hybrid_search_pre_filtering(doc_index):
     q = (
         doc_index.build_query()
-        .find(query=query, search_field='tensor', limit=5)
-        .filter(filter_query={'price': {'$neq': 5}})
+        .filter(filter_query={'price': {'$lte': 3}})
+        .find(query=np.ones(10), search_field='tensor', limit=5)
         .build()
     )
 
     docs, scores = doc_index.execute_query(q)
 
     assert len(docs) == 4
+    for doc in docs:
+        assert doc.price <= 3
 
 
-@pytest.mark.parametrize(
-    'find_limit, filter_limit, expected_docs', [(10, 3, 3), (5, None, 1)]
-)
-def test_query_builder_limits(doc_index, find_limit, filter_limit, expected_docs):
-    query = SchemaDoc(text='query', price=3, tensor=np.array([3] * 10))
-
+def test_hybrid_search_post_filtering(doc_index):
     q = (
         doc_index.build_query()
-        .find(query=query, search_field='tensor', limit=find_limit)
-        .filter(filter_query={'price': {'$lte': 5}}, limit=filter_limit)
+        .find(query=np.ones(10), search_field='tensor', limit=5)
+        .filter(filter_query={'price': {'$gt': 7}})
         .build()
     )
 
     docs, scores = doc_index.execute_query(q)
 
-    assert len(docs) == expected_docs
+    assert len(docs) == 2
+    for doc in docs:
+        assert doc.price > 7
+
+
+def test_hybrid_search_pre_post_filtering(doc_index):
+    q = (
+        doc_index.build_query()
+        .filter(filter_query={'price': {'$lte': 3}})
+        .find(query=np.ones(10), search_field='tensor')
+        .filter(filter_query={'text': {'$eq': 'hello 1'}})
+        .build()
+    )
+
+    docs, scores = doc_index.execute_query(q)
+
+    assert len(docs) == 1
+    assert docs[0].text == 'hello 1' and docs[0].price <= 3
 
 
 def test_filter(doc_index):

--- a/tests/index/in_memory/test_in_memory.py
+++ b/tests/index/in_memory/test_in_memory.py
@@ -209,23 +209,6 @@ def test_query_builder_pre_post_filtering(doc_index):
     assert docs[0].text == 'hello 1' and docs[0].price <= 3
 
 
-def test_find_and_filter(doc_index):
-    q = (
-        doc_index.build_query()
-        .filter(filter_query={'price': {'$lt': 3}})
-        .find(query=np.ones(10), search_field='tensor')
-        .filter(filter_query={'text': {'$neq': 'hello 2'}})
-        .build()
-    )
-
-    docs, scores = doc_index._find_and_filter(q)
-
-    assert len(docs) == 2
-    for doc in docs:
-        assert doc.text in ['hello 1', 'hello 0']
-        assert doc.price < 3
-
-
 def test_filter(doc_index):
     docs = doc_index.filter({'price': {'$eq': 3}})
     assert len(docs) == 1


### PR DESCRIPTION
Support arbitrary number of find/filter operations for `InMemoryExactNNIndex`, enabling pre+post filtering

From now on, you can build queries like this:
```python
query = (
    doc_index.build_query()
    .filter(filter_query={'price': {'$lte': 3}})
    .find(query=np.ones(10), search_field='tensor')
    .filter(filter_query={'text': {'$eq': 'hello 1'}})
    .build()
)
```

Note:
**how limits work**
Since developers could provide `limit` in any component of the query, and we also had an internal default value for `find`, the results were confusing. What I'm doing is the following: I'm not applying any limits during the operations, but I'm remembering the lowest one provided, and apply that limit in the end. 
