### PR TITLE
feat: update for inmemory index

### DIFF
--- a/tests/index/in_memory/test_index_get_del.py
+++ b/tests/index/in_memory/test_index_get_del.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from docarray import BaseDoc, DocList
+from docarray.index import InMemoryExactNNIndex
+from docarray.typing import NdArray
+
+
+class SimpleDoc(BaseDoc):
+    embedding: NdArray[128]
+    text: str
+
+
+def test_update_payload():
+    docs = DocList[SimpleDoc](
+        [SimpleDoc(embedding=np.random.rand(128), text=f'hey {i}') for i in range(100)]
+    )
+    index = InMemoryExactNNIndex[SimpleDoc]()
+    index.index(docs)
+
+    assert index.num_docs() == 100
+
+    for doc in docs:
+        doc.text += '_changed'
+
+    index.index(docs)
+    assert index.num_docs() == 100
+
+    res = index.find(query=docs[0], search_field='embedding', limit=100)
+    assert len(res.documents) == 100
+    for doc in res.documents:
+        assert '_changed' in doc.text
+
+
+def test_update_embedding():
+    docs = DocList[SimpleDoc](
+        [SimpleDoc(embedding=np.random.rand(128), text=f'hey {i}') for i in range(100)]
+    )
+    index = InMemoryExactNNIndex[SimpleDoc]()
+    index.index(docs)
+    assert index.num_docs() == 100
+
+    new_tensor = np.random.rand(128)
+    docs[0].embedding = new_tensor
+
+    index.index(docs[0])
+    assert index.num_docs() == 100
+
+    res = index.find(query=docs[0], search_field='embedding', limit=100)
+    assert len(res.documents) == 100
+    found = False
+    for doc in res.documents:
+        if doc.id == docs[0].id:
+            found = True
+            assert (doc.embedding == new_tensor).all()
+    assert found


### PR DESCRIPTION
Implements Update for `InMemoryExactNNIndex` by creating a mapping between document IDs and their corresponding positions in the DocList.

In terms of performance, we see significant ~130x (from 0.0266s to 0.0002s) improvement in get, and a slight increase in the index time - approx. from 3.50s to 3.57s; Other operation times stayed very similar. Experiment was made on 200 000 docs, vector dim 128.





