### PR TITLE
fix: tensor equals type raises exception

### DIFF
--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -59,8 +59,8 @@ class _ParametrizedMeta(type):
 
     def _equals_special_case(cls, other):
         is_type = isinstance(other, type)
-        is_tensor = is_type and AbstractTensor in other.mro()
-        same_parents = is_tensor and cls.mro()[1:] == other.mro()[1:]
+        is_tensor = is_type and AbstractTensor in other.__mro__
+        same_parents = is_tensor and cls.mro()[1:] == other.__mro__[1:]
 
         subclass_target_shape = getattr(other, '__docarray_target_shape__', False)
         self_target_shape = getattr(cls, '__docarray_target_shape__', False)
@@ -92,9 +92,11 @@ class _ParametrizedMeta(type):
                     return False
                 return any(
                     safe_issubclass(candidate, _cls.__unparametrizedcls__)
-                    for candidate in type(instance).mro()
+                    for candidate in type(instance).__mro__
                 )
-            return any(issubclass(candidate, cls) for candidate in type(instance).mro())
+            return any(
+                issubclass(candidate, cls) for candidate in type(instance).__mro__
+            )
         return super().__instancecheck__(instance)
 
     def __eq__(cls, other):

--- a/docarray/typing/tensor/abstract_tensor.py
+++ b/docarray/typing/tensor/abstract_tensor.py
@@ -60,7 +60,7 @@ class _ParametrizedMeta(type):
     def _equals_special_case(cls, other):
         is_type = isinstance(other, type)
         is_tensor = is_type and AbstractTensor in other.__mro__
-        same_parents = is_tensor and cls.mro()[1:] == other.__mro__[1:]
+        same_parents = is_tensor and cls.__mro__[1:] == other.__mro__[1:]
 
         subclass_target_shape = getattr(other, '__docarray_target_shape__', False)
         self_target_shape = getattr(cls, '__docarray_target_shape__', False)

--- a/tests/units/typing/tensor/test_tensor.py
+++ b/tests/units/typing/tensor/test_tensor.py
@@ -44,4 +44,5 @@ def test_tensorflow_to_any_tensor():
 
 
 def test_equals_type():
+    # see https://github.com/docarray/docarray/pull/1739
     assert not (TorchTensor == type)

--- a/tests/units/typing/tensor/test_tensor.py
+++ b/tests/units/typing/tensor/test_tensor.py
@@ -41,3 +41,7 @@ def test_tensorflow_to_any_tensor():
     assert isinstance(doc.tensor, TensorFlowTensor)
     assert isinstance(doc.tensor.tensor, tf.Tensor)
     assert tnp.allclose(doc.tensor.tensor, tf.zeros((1000, 2)))
+
+
+def test_equals_type():
+    assert not (TorchTensor == type)


### PR DESCRIPTION
Currently the following raises and exception:
```python
from docarray.typing import TorchTensor

TorchTensor == type
```

```terminal
Traceback (most recent call last):
  File "/home/johannes/.config/JetBrains/PyCharmCE2023.2/scratches/scratch_183.py", line 3, in <module>
    TorchTensor == type
  File "/home/johannes/Documents/jina/docarrayv2/docarray/typing/tensor/abstract_tensor.py", line 101, in __eq__
    if cls._equals_special_case(other):
  File "/home/johannes/Documents/jina/docarrayv2/docarray/typing/tensor/abstract_tensor.py", line 62, in _equals_special_case
    is_tensor = is_type and AbstractTensor in other.mro()
TypeError: descriptor 'mro' of 'type' object needs an argument
```

This fixes that