### PR TITLE
fix: fix dynamic class creation with doubly nested schemas 

### DIFF
--- a/docarray/utils/create_dynamic_doc_class.py
+++ b/docarray/utils/create_dynamic_doc_class.py
@@ -1,10 +1,11 @@
-from docarray import DocList, BaseDoc
-from docarray.typing import AnyTensor
+from typing import Any, Dict, List, Optional, Type, Union
+
 from pydantic import create_model
 from pydantic.fields import FieldInfo
-from typing import Dict, List, Any, Union, Optional, Type
-from docarray.utils._internal._typing import safe_issubclass
 
+from docarray import BaseDoc, DocList
+from docarray.typing import AnyTensor
+from docarray.utils._internal._typing import safe_issubclass
 
 RESERVED_KEYS = [
     'type',
@@ -190,7 +191,7 @@ def _get_field_type_from_schema(
             cached_models=cached_models,
             is_tensor=tensor_shape is not None,
             num_recursions=num_recursions + 1,
-            definitions=definitions
+            definitions=definitions,
         )
     else:
         if num_recursions > 0:
@@ -205,7 +206,10 @@ def _get_field_type_from_schema(
 
 
 def create_base_doc_from_schema(
-    schema: Dict[str, Any], base_doc_name: str, cached_models: Optional[Dict] = None, definitions: Optional[Dict] = None,
+    schema: Dict[str, Any],
+    base_doc_name: str,
+    cached_models: Optional[Dict] = None,
+    definitions: Optional[Dict] = None,
 ) -> Type:
     """
     Dynamically create a `BaseDoc` subclass from a `schema` of another `BaseDoc`.

--- a/tests/units/util/test_create_dynamic_code_class.py
+++ b/tests/units/util/test_create_dynamic_code_class.py
@@ -1,15 +1,16 @@
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
 import pytest
-from typing import List, Dict, Union, Any
+from pydantic import Field
+
+from docarray import BaseDoc, DocList
+from docarray.documents import TextDoc
+from docarray.typing import AnyTensor, ImageUrl
 from docarray.utils.create_dynamic_doc_class import (
     create_base_doc_from_schema,
     create_pure_python_type_model,
 )
-import numpy as np
-from typing import Optional
-from docarray import BaseDoc, DocList
-from docarray.typing import AnyTensor, ImageUrl
-from docarray.documents import TextDoc
-from pydantic import Field
 
 
 @pytest.mark.parametrize('transformation', ['proto', 'json'])


### PR DESCRIPTION
the following case results in a KeyError:

```python
from docarray import BaseDoc
from docarray.utils.create_dynamic_doc_class import create_base_doc_from_schema


class Nested2(BaseDoc):
    value: str


class Nested1(BaseDoc):
    nested: Nested2


class RootDoc(BaseDoc):
    nested: Nested1


new_my_doc_cls = create_base_doc_from_schema(RootDoc.schema(), 'RootDoc')

```

the reason is, `create_base_doc_from_schema` will keep referring to `definitions` field of the traversed schema when creating its corresponding model. However, the `definitions` field only exists for the root schema