### PR TITLE
fix(qdrant): fix non-class type fields #1748

### DIFF
--- a/docarray/index/backends/qdrant.py
+++ b/docarray/index/backends/qdrant.py
@@ -269,7 +269,7 @@ class QdrantDocumentIndex(BaseDocIndex, Generic[TSchema]):
         :param python_type: a python type.
         :return: the corresponding database column type.
         """
-        if any(issubclass(python_type, vt) for vt in QDRANT_PY_VECTOR_TYPES):
+        if any(safe_issubclass(python_type, vt) for vt in QDRANT_PY_VECTOR_TYPES):
             return 'vector'
 
         if safe_issubclass(python_type, docarray.typing.id.ID):

--- a/tests/index/qdrant/test_configurations.py
+++ b/tests/index/qdrant/test_configurations.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 import pytest
 from pydantic import Field
@@ -6,7 +8,6 @@ from docarray import BaseDoc
 from docarray.index import QdrantDocumentIndex
 from docarray.typing import NdArray
 from tests.index.qdrant.fixtures import start_storage, tmp_collection_name  # noqa: F401
-
 
 pytestmark = [pytest.mark.slow, pytest.mark.index]
 
@@ -44,3 +45,12 @@ def test_index_name():
 
     index3 = QdrantDocumentIndex[Schema](collection_name='my_index')
     assert index3.index_name == 'my_index'
+
+
+def test_index_with_non_class_type():
+    class Schema(BaseDoc):
+        tens: NdArray = Field(dim=10)
+        list_field: List
+
+    index = QdrantDocumentIndex[Schema](host='localhost')
+    assert index.num_docs() == 0


### PR DESCRIPTION
**Issue Resolved:** Issue with Defining Index of Type `QdrantDocumentIndex` for Documents with Non-Class Type Fields

**Description:**
This pull request addresses the issue where defining an index of type `QdrantDocumentIndex` for documents containing fields with non-class types resulted in a `TypeError`. The issue has been resolved by replacing the usage of `issubclass` with `safe_issubclass`.