### PR TITLE
fix: make DocList.to_json() return str instead of bytes

### DIFF
--- a/docarray/array/doc_list/io.py
+++ b/docarray/array/doc_list/io.py
@@ -327,11 +327,11 @@ class IOMixinDocList(Iterable[T_doc]):
         json_docs = orjson.loads(file)
         return cls([cls.doc_type(**v) for v in json_docs])
 
-    def to_json(self) -> bytes:
+    def to_json(self) -> str:
         """Convert the object into JSON bytes. Can be loaded via `.from_json`.
         :return: JSON serialization of `DocList`
         """
-        return orjson_dumps(self)
+        return orjson_dumps(self).decode('UTF-8')
 
     @classmethod
     def from_csv(

--- a/docarray/array/doc_list/io.py
+++ b/docarray/array/doc_list/io.py
@@ -183,7 +183,7 @@ class IOMixinDocList(Iterable[T_doc]):
             elif protocol == 'pickle-array':
                 f.write(pickle.dumps(self))
             elif protocol == 'json-array':
-                f.write(self.to_json())
+                f.write(self.to_json().encode())
             elif protocol in SINGLE_PROTOCOLS:
                 f.write(
                     b''.join(

--- a/docs/user_guide/sending/serialization.md
+++ b/docs/user_guide/sending/serialization.md
@@ -75,7 +75,7 @@ dl = DocList[SimpleDoc]([SimpleDoc(text=f'doc {i}') for i in range(2)])
 with open('simple-dl.json', 'wb') as f:
     json_dl = dl.to_json()
     print(json_dl)
-    f.write(json_dl)
+    f.write(json_dl.encode())
 
 with open('simple-dl.json', 'r') as f:
     dl_load_from_json = DocList[SimpleDoc].from_json(f.read())
@@ -83,7 +83,7 @@ with open('simple-dl.json', 'r') as f:
 ```
 
 ```output
-b'[{"id":"5540e72d407ae81abb2390e9249ed066","text":"doc 0"},{"id":"fbe9f80d2fa03571e899a2887af1ac1b","text":"doc 1"}]'
+'[{"id":"5540e72d407ae81abb2390e9249ed066","text":"doc 0"},{"id":"fbe9f80d2fa03571e899a2887af1ac1b","text":"doc 1"}]'
 ```
 
 ### Protobuf
@@ -277,7 +277,7 @@ dv = DocVec[SimpleDoc](
 with open('simple-dv.json', 'wb') as f:
     json_dv = dv.to_json()
     print(json_dv)
-    f.write(json_dv)
+    f.write(json_dv.encode())
 
 with open('simple-dv.json', 'r') as f:
     dv_load_from_json = DocVec[SimpleDoc].from_json(f.read(), tensor_type=TorchTensor)
@@ -285,7 +285,7 @@ with open('simple-dv.json', 'r') as f:
 ```
 
 ```output
-b'{"tensor_columns":{},"doc_columns":{},"docs_vec_columns":{},"any_columns":{"id":["005a208a0a9a368c16bf77913b710433","31d65f02cb94fc9756c57b0dbaac3a2c"],"text":["doc 0","doc 1"]}}'
+'{"tensor_columns":{},"doc_columns":{},"docs_vec_columns":{},"any_columns":{"id":["005a208a0a9a368c16bf77913b710433","31d65f02cb94fc9756c57b0dbaac3a2c"],"text":["doc 0","doc 1"]}}'
 <DocVec[SimpleDoc] (length=2)>
 ```
 

--- a/tests/units/array/test_array_from_to_json.py
+++ b/tests/units/array/test_array_from_to_json.py
@@ -78,9 +78,9 @@ def test_from_to_json_docvec(tensor_type):
         return vec
 
     v = generate_docs(tensor_type)
-    bytes_ = v.to_json()
+    json_str = v.to_json()
 
-    v_after = DocVec[v.doc_type].from_json(bytes_, tensor_type=tensor_type)
+    v_after = DocVec[v.doc_type].from_json(json_str, tensor_type=tensor_type)
 
     assert v_after.tensor_type == v.tensor_type
     assert set(v_after._storage.columns.keys()) == set(v._storage.columns.keys())
@@ -125,9 +125,9 @@ def test_from_to_json_docvec_tf():
         return vec
 
     v = generate_docs()
-    bytes_ = v.to_json()
+    json_str = v.to_json()
 
-    v_after = DocVec[v.doc_type].from_json(bytes_, tensor_type=TensorFlowTensor)
+    v_after = DocVec[v.doc_type].from_json(json_str, tensor_type=TensorFlowTensor)
 
     assert v_after.tensor_type == v.tensor_type
     assert set(v_after._storage.columns.keys()) == set(v._storage.columns.keys())


### PR DESCRIPTION
**💥 Contains breaking change**

This changes the return type of `DocList.to_json()` *and* `DocVec.to_json()` from bytes to str, by decoding the bytes output obtained from the `orjson` library.
This is done to make it consistent with `to_json()` on `BaseDoc` and in pydantic.

`from_json()` does not need to be touched, since orjson happily accepts strings as well.

This decoding step incurs a small performance penalty:
![image](https://github.com/docarray/docarray/assets/44071807/4ff590df-c494-40a3-8bb1-850c02ed273e)

Running this multiple times I saw a **`to_json()` performance penalty of 8-15%**, depending on the run.
The **`to_json()`/`from_json()` roundrip penalty was consistently single digit percent**, presumably because the  `from_json()` call dominates this runtime.

**Note** the **breaking change** this induces in cases like the one shown in the documentation that is also changed as part of this PR.
Also note that in the scenario there, after this change, a bytes object will be decoded to string, only to be encoded into bytes again.

closes #1766 