### PR TITLE
fix: skip annotations if not in __fields__

### DIFF
--- a/docarray/utils/create_dynamic_doc_class.py
+++ b/docarray/utils/create_dynamic_doc_class.py
@@ -51,6 +51,8 @@ def create_pure_python_type_model(model: Any) -> BaseDoc:
     """
     fields: Dict[str, Any] = {}
     for field_name, field in model.__annotations__.items():
+        if field_name not in model.__fields__:
+            continue
         field_info = model.__fields__[field_name].field_info
         try:
             if safe_issubclass(field, DocList):

--- a/tests/units/util/test_create_dynamic_code_class.py
+++ b/tests/units/util/test_create_dynamic_code_class.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, ClassVar
 
 import numpy as np
 import pytest
@@ -17,9 +17,11 @@ from docarray.utils.create_dynamic_doc_class import (
 def test_create_pydantic_model_from_schema(transformation):
     class Nested2Doc(BaseDoc):
         value: str
+        classvar: ClassVar[str] = 'classvar2'
 
     class Nested1Doc(BaseDoc):
         nested: Nested2Doc
+        classvar: ClassVar[str] = 'classvar1'
 
     class CustomDoc(BaseDoc):
         tensor: Optional[AnyTensor]
@@ -34,6 +36,7 @@ def test_create_pydantic_model_from_schema(transformation):
         lu: List[Union[str, int]] = [0, 1, 2]
         tags: Optional[Dict[str, Any]] = None
         nested: Nested1Doc
+        classvar: ClassVar[str] = 'classvar'
 
     CustomDocCopy = create_pure_python_type_model(CustomDoc)
     new_custom_doc_model = create_base_doc_from_schema(
@@ -87,6 +90,9 @@ def test_create_pydantic_model_from_schema(transformation):
     assert custom_partial_da[0].single_text.text == 'single hey ha'
     assert custom_partial_da[0].single_text.embedding.shape == (2,)
     assert original_back[0].nested.nested.value == 'hello world'
+    assert original_back[0].classvar == 'classvar'
+    assert original_back[0].nested.classvar == 'classvar1'
+    assert original_back[0].nested.nested.classvar == 'classvar2'
 
     assert len(original_back) == 1
     assert original_back[0].url == 'photo.jpg'


### PR DESCRIPTION
Porting https://github.com/docarray/docarray/pull/1777

@JoanFM 