### PR TITLE
fix: wip add default value to TextDoc

### DIFF
--- a/docarray/documents/base_predefined_doc.py
+++ b/docarray/documents/base_predefined_doc.py
@@ -35,6 +35,7 @@ class PredefinedDoc(BaseDoc, ABC):
 
         @classmethod
         def _docarray_default_value_validation(cls, value, model_validator, _):
+            # print(value)
             return model_validator(cls._docarray_custom_val(value))
 
     else:

--- a/docarray/documents/base_predefined_doc.py
+++ b/docarray/documents/base_predefined_doc.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from docarray.base_doc.doc import BaseDoc
+from docarray.utils._internal.pydantic import is_pydantic_v2
+
+if is_pydantic_v2:
+    from pydantic_core import CoreSchema, core_schema
+
+
+class PredefinedDoc(BaseDoc, ABC):
+    """
+    Custom class for handling predefined documents and can override their init and validation input.
+    """
+
+    @abstractmethod
+    @classmethod
+    def _docarray_custom_val(cls, value: Any) -> Dict[str, Any]:
+        ...
+
+    if is_pydantic_v2:
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source, handler) -> CoreSchema.CoreSchema:
+            if '__pydantic_core_schema__' in cls.__dict__:
+                if not cls.__pydantic_generic_metadata__['origin']:
+                    schema = cls.__pydantic_core_schema__
+
+            schema = handler(source)
+            return core_schema.general_wrap_validator_function(
+                function=cls._docarray_default_value_validation, schema=schema
+            )
+
+        @classmethod
+        def _docarray_default_value_validation(cls, value, model_validator, _):
+            return model_validator(cls._docarray_custom_val(value))
+
+    else:
+
+        @classmethod
+        def validate(cls, value: Any):
+            return super().validate(cls._docarray_custom_val(value))

--- a/docarray/documents/base_predefined_doc.py
+++ b/docarray/documents/base_predefined_doc.py
@@ -5,7 +5,7 @@ from docarray.base_doc.doc import BaseDoc
 from docarray.utils._internal.pydantic import is_pydantic_v2
 
 if is_pydantic_v2:
-    from pydantic_core import CoreSchema, core_schema
+    from pydantic_core import core_schema
 
 
 class PredefinedDoc(BaseDoc, ABC):
@@ -13,15 +13,17 @@ class PredefinedDoc(BaseDoc, ABC):
     Custom class for handling predefined documents and can override their init and validation input.
     """
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def _docarray_custom_val(cls, value: Any) -> Dict[str, Any]:
         ...
 
     if is_pydantic_v2:
 
         @classmethod
-        def __get_pydantic_core_schema__(cls, source, handler) -> CoreSchema.CoreSchema:
+        def __get_pydantic_core_schema__(
+            cls, source, handler
+        ) -> core_schema.CoreSchema:
             if '__pydantic_core_schema__' in cls.__dict__:
                 if not cls.__pydantic_generic_metadata__['origin']:
                     schema = cls.__pydantic_core_schema__

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -5,6 +5,10 @@ from pydantic import Field
 from docarray.base_doc import BaseDoc
 from docarray.typing import TextUrl
 from docarray.typing.tensor.embedding import AnyEmbedding
+from docarray.utils._internal.pydantic import is_pydantic_v2
+
+if is_pydantic_v2:
+    from pydantic_core import core_schema
 
 T = TypeVar('T', bound='TextDoc')
 
@@ -124,19 +128,64 @@ class TextDoc(BaseDoc):
         default=None,
     )
 
-    def __init__(self, text: Optional[str] = None, **kwargs):
-        if 'text' not in kwargs:
-            kwargs['text'] = text
-        super().__init__(**kwargs)
+    if is_pydantic_v2:
 
-    @classmethod
-    def validate(
-        cls: Type[T],
-        value: Union[str, Any],
-    ) -> T:
-        if isinstance(value, str):
-            value = cls(text=value)
-        return super().validate(value)
+        def __init__(__pydantic_self__, *arg, **data) -> None:  # type: ignore
+            """Custom init function that allow validation without a dict as input but just a default value"""
+            # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
+
+            __tracebackhide__ = True
+
+            if len(arg) == 1 and not data:
+                data = {'text': arg[0]}
+            elif len(arg) > 1:
+                raise TypeError(
+                    f'__init__() takes 1 positional argument but {len(arg)} were given'
+                )
+
+            __pydantic_self__.__pydantic_validator__.validate_python(
+                data, self_instance=__pydantic_self__
+            )
+
+    else:
+
+        def __init__(self, text: Optional[str] = None, **kwargs):
+            if 'text' not in kwargs:
+                kwargs['text'] = text
+            super().__init__(**kwargs)
+
+    if is_pydantic_v2:
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source, handler
+        ) -> core_schema.CoreSchema:
+            if '__pydantic_core_schema__' in cls.__dict__:
+                if not cls.__pydantic_generic_metadata__['origin']:
+                    schema = cls.__pydantic_core_schema__
+
+            schema = handler(source)
+            return core_schema.general_wrap_validator_function(
+                function=cls._docarray_default_value_validation, schema=schema
+            )
+
+        @classmethod
+        def _docarray_default_value_validation(cls, value, model_validator, _):
+            if not isinstance(value, dict):
+                value = {'text': value}
+            return model_validator(value)
+
+    else:
+
+        @classmethod
+        def validate(
+            cls: Type[T],
+            value: Union[str, Any],
+        ) -> T:
+            if isinstance(value, str):
+                value = {'text': value}
+
+            return super().validate(value)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, str):

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -145,6 +145,8 @@ class TextDoc(PredefinedDoc):
     def _docarray_custom_val(cls, value: Any) -> Dict[str, Any]:
         if not isinstance(value, dict):
             new_value = {'text': value}
+        else:
+            new_value = value
         return new_value
 
     def __eq__(self, other: Any) -> bool:

--- a/docarray/documents/text.py
+++ b/docarray/documents/text.py
@@ -147,6 +147,7 @@ class TextDoc(PredefinedDoc):
             new_value = {'text': value}
         else:
             new_value = value
+        print(new_value)
         return new_value
 
     def __eq__(self, other: Any) -> bool:

--- a/tests/integrations/predefined_document/test_text.py
+++ b/tests/integrations/predefined_document/test_text.py
@@ -23,3 +23,14 @@ def test_doc():
 
     assert doc.text1.text == 'hello'
     assert doc.text2.text == 'world'
+
+
+def test_doc_2():
+    class MyDoc(BaseDoc):
+        text1: TextDoc
+        text2: TextDoc
+
+    doc = MyDoc(text1='hello1', text2='hello2')
+
+    assert doc.text1.text == 'hello1'
+    assert doc.text2.text == 'hello2'

--- a/tests/integrations/predefined_document/test_text.py
+++ b/tests/integrations/predefined_document/test_text.py
@@ -1,24 +1,19 @@
-import pytest
 from pydantic import parse_obj_as
 
 from docarray import BaseDoc
 from docarray.documents import TextDoc
-from docarray.utils._internal.pydantic import is_pydantic_v2
 
 
-@pytest.mark.skipif(is_pydantic_v2, reason="Not working with pydantic v2 for now")
 def test_simple_init():
     t = TextDoc(text='hello')
     assert t.text == 'hello'
 
 
-@pytest.mark.skipif(is_pydantic_v2, reason="Not working with pydantic v2 for now")
 def test_str_init():
     t = parse_obj_as(TextDoc, 'hello')
     assert t.text == 'hello'
 
 
-@pytest.mark.skipif(is_pydantic_v2, reason="Not working with pydantic v2 for now")
 def test_doc():
     class MyDoc(BaseDoc):
         text1: TextDoc

--- a/tests/units/document/test_predefined_docs.py
+++ b/tests/units/document/test_predefined_docs.py
@@ -1,0 +1,25 @@
+from pydantic import parse_obj_as
+
+from docarray import BaseDoc
+from docarray.documents import TextDoc
+
+
+def test_nested_defaut_value():
+    class MyDocument(BaseDoc):
+        caption: TextDoc
+
+    doc = MyDocument(caption='A tiger in the jungle')
+
+    assert doc.caption.text == 'A tiger in the jungle'
+
+
+def test_parse_default_val():
+
+    doc = parse_obj_as(TextDoc, 'A tiger in the jungle')
+    assert doc.text == 'A tiger in the jungle'
+
+
+def test_parse_default_val_init():
+
+    doc = TextDoc('A tiger in the jungle')
+    assert doc.text == 'A tiger in the jungle'


### PR DESCRIPTION
# Context

Allow in pydantic v2 to do 

```python
 class MyDocument(BaseDoc):
        caption: TextDoc
MyDocument(caption='A tiger in the jungle')
```

or to do 
```python
TextDoc('hello')
```

should fix : https://github.com/docarray/docarray/issues/1787