### PR TITLE
fix: allow nested model dump via docvec

### DIFF
--- a/docarray/typing/tensor/image/image_tensor.py
+++ b/docarray/typing/tensor/image/image_tensor.py
@@ -103,7 +103,6 @@ class ImageTensor(AnyTensor, AbstractImageTensor):
             return ImageNdArray._docarray_validate(value)
         except Exception:  # noqa
             pass
-        breakpoint()
         raise TypeError(
             f"Expected one of [torch.Tensor, tensorflow.Tensor, numpy.ndarray] "
             f"compatible type, got {type(value)}"

--- a/docarray/typing/tensor/image/image_tensor.py
+++ b/docarray/typing/tensor/image/image_tensor.py
@@ -103,6 +103,7 @@ class ImageTensor(AnyTensor, AbstractImageTensor):
             return ImageNdArray._docarray_validate(value)
         except Exception:  # noqa
             pass
+        breakpoint()
         raise TypeError(
             f"Expected one of [torch.Tensor, tensorflow.Tensor, numpy.ndarray] "
             f"compatible type, got {type(value)}"

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -22,7 +22,6 @@ def nested_doc_cls():
     return MyDocNested
 
 
-@pytest.mark.skipif(is_pydantic_v2, reason="Not working with pydantic v2")
 @pytest.mark.parametrize('doc_vec', [False, True])
 def test_to_from_pandas_df(nested_doc_cls, doc_vec):
     da = DocList[nested_doc_cls](


### PR DESCRIPTION
# Context

DocVec nested document could not serialize correctly using `model_dump` from pydantic v2. 

This pr fix it by recursively deep copying the document whereas before it was just done at level 1 