### PR TITLE
fix: from_dataframe with numpy==1.26.1 and type handling in python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         pydantic-version: ["pydantic-v2", "pydantic-v1"]
         test-path: [tests/integrations, tests/units, tests/documentation]
     steps:
@@ -112,6 +112,11 @@ jobs:
           ./scripts/install_pydantic_v2.sh ${{ matrix.pydantic-version }}
           poetry run pip uninstall -y torch
           poetry run pip install torch
+#         Issue https://github.com/docarray/docarray/issues/1821 occurs with a numpy version
+#         that is only supported in pyton 3.9 and up.
+#         Poetry cannot lock to that version because we support python 3.8.
+#         Therefore, we install this version manually to test for the error in the CI.
+          poetry run pip install numpy==1.26.1
           sudo apt-get update
           sudo apt-get install --no-install-recommends ffmpeg
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,6 @@ jobs:
           ./scripts/install_pydantic_v2.sh ${{ matrix.pydantic-version }}
           poetry run pip uninstall -y torch
           poetry run pip install torch
-#         Issue https://github.com/docarray/docarray/issues/1821 occurs with a numpy version
-#         that is only supported in pyton 3.9 and up.
-#         Poetry cannot lock to that version because we support python 3.8.
-#         Therefore, we install this version manually to test for the error in the CI.
           poetry run pip install numpy==1.26.1
           sudo apt-get update
           sudo apt-get install --no-install-recommends ffmpeg

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -22,7 +22,7 @@ import orjson
 import typing_extensions
 from pydantic import BaseModel, Field
 from pydantic.fields import FieldInfo
-from typing_inspect import is_optional_type
+from typing_inspect import get_args, is_optional_type
 
 from docarray.utils._internal.pydantic import is_pydantic_v2
 
@@ -185,7 +185,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
             if is_optional_type(
                 annotation
             ):  # this is equivalent to `outer_type_` in pydantic v1
-                return annotation.__args__[0]
+                return get_args(annotation)[0]
             else:
                 return annotation
         else:
@@ -205,12 +205,12 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
             if is_optional_type(
                 annotation
             ):  # this is equivalent to `outer_type_` in pydantic v1
-                return annotation.__args__[0]
+                return get_args(annotation)[0]
             elif annotation == Tuple:
-                if len(annotation.__args__) == 0:
+                if len(get_args(annotation)) == 0:
                     return Any
                 else:
-                    annotation.__args__[0]
+                    get_args(annotation)[0]
             else:
                 return annotation
         else:

--- a/docarray/base_doc/mixins/io.py
+++ b/docarray/base_doc/mixins/io.py
@@ -336,7 +336,7 @@ class IOMixin(Iterable[Tuple[str, Any]]):
                     field_type = None
 
                 if isinstance(field_type, GenericAlias):
-                    field_type = field_type.__args__[0]
+                    field_type = get_args(field_type)[0]
 
                 return_field = arg_to_container[content_key](
                     cls._get_content_from_node_proto(node, field_type=field_type)

--- a/docarray/display/document_summary.py
+++ b/docarray/display/document_summary.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Type, Union
+from typing import Any, List, Optional, Type, Union, get_args
 
 from rich.highlighter import RegexHighlighter
 from rich.theme import Theme
@@ -83,7 +83,7 @@ class DocumentSummary:
 
                 if is_union_type(field_type) or is_optional_type(field_type):
                     sub_tree = Tree(node_name, highlight=True)
-                    for arg in field_type.__args__:
+                    for arg in get_args(field_type):
                         if safe_issubclass(arg, BaseDoc):
                             sub_tree.add(
                                 DocumentSummary._get_schema(

--- a/tests/units/array/test_array_from_to_pandas.py
+++ b/tests/units/array/test_array_from_to_pandas.py
@@ -136,7 +136,8 @@ def test_union_type_error():
 
 
 @pytest.mark.parametrize('tensor_type', [NdArray, TorchTensor])
-def test_from_to_pandas_tensor_type(tensor_type):
+@pytest.mark.parametrize('tensor_len', [0, 5])
+def test_from_to_pandas_tensor_type(tensor_type, tensor_len):
     class MyDoc(BaseDoc):
         embedding: tensor_type
         text: str
@@ -145,9 +146,13 @@ def test_from_to_pandas_tensor_type(tensor_type):
     da = DocVec[MyDoc](
         [
             MyDoc(
-                embedding=[1, 2, 3, 4, 5], text='hello', image=ImageDoc(url='aux.png')
+                embedding=list(range(tensor_len)),
+                text='hello',
+                image=ImageDoc(url='aux.png'),
             ),
-            MyDoc(embedding=[5, 4, 3, 2, 1], text='hello world', image=ImageDoc()),
+            MyDoc(
+                embedding=list(range(tensor_len)), text='hello world', image=ImageDoc()
+            ),
         ],
         tensor_type=tensor_type,
     )

--- a/tests/units/typing/tensor/test_ndarray.py
+++ b/tests/units/typing/tensor/test_ndarray.py
@@ -200,9 +200,9 @@ def test_parametrized_instance():
 def test_parametrized_equality():
     t1 = parse_obj_as(NdArray[128], np.zeros(128))
     t2 = parse_obj_as(NdArray[128], np.zeros(128))
-    t3 = parse_obj_as(NdArray[256], np.zeros(256))
+    t3 = parse_obj_as(NdArray[128], np.ones(128))
     assert (t1 == t2).all()
-    assert not t1 == t3
+    assert not (t1 == t3).any()
 
 
 def test_parametrized_operations():


### PR DESCRIPTION
We perform a check that doesn't work anymore with new versions of numpy, because they switches equality semantics to broadcast over every element in the array.

This PR fixes that by treating np arrays as a special cases in the affected check. It also does the same for tf, torch, and jax, just because == semantics on tensor-like objects can always be a bit surprising.

The numpy version in question (`1.26.1`) doesn't support Python 3.8 or down, but we do. Therefore, poetry can't lock to that version. To circumvent this, I am here manually installing the "problematic" numpy version in the CI. For the same reason **I am bumping some tests to run on Python 3.9**.

No new tests since the existing tests already fail with the numpy version in question, and are fixed by the fix (see failing check of the CI run after the new numpy version, but before the fix was pushed, [here](https://github.com/docarray/docarray/actions/runs/6560445470/job/17818195764?pr=1823)).

**Also includes a fix to handle typing changes in python 3.9 and above**, by using the `get_args` helper instead of `.__args__`.

closes #1821 