### PR TITLE
fix: fix storage issue in torchtensor class

### DIFF
--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -292,15 +292,15 @@ class TorchTensor(
             torch.Tensor if t in docarray_torch_tensors else t for t in types
         )
         return super().__torch_function__(func, types_, args, kwargs)
-    
+
     def __deepcopy__(self, memo):
         """
         Custom implementation of deepcopy for TorchTensor to avoid storage sharing issues.
         """
         # Create a new tensor with the same data and properties
-        new_tensor = self.clone()  
+        new_tensor = self.clone()
         # Set the class to the custom TorchTensor class
-        new_tensor.__class__ = self.__class__  
+        new_tensor.__class__ = self.__class__
         return new_tensor
 
     @classmethod

--- a/docarray/typing/tensor/torch_tensor.py
+++ b/docarray/typing/tensor/torch_tensor.py
@@ -292,6 +292,16 @@ class TorchTensor(
             torch.Tensor if t in docarray_torch_tensors else t for t in types
         )
         return super().__torch_function__(func, types_, args, kwargs)
+    
+    def __deepcopy__(self, memo):
+        """
+        Custom implementation of deepcopy for TorchTensor to avoid storage sharing issues.
+        """
+        # Create a new tensor with the same data and properties
+        new_tensor = self.clone()  
+        # Set the class to the custom TorchTensor class
+        new_tensor.__class__ = self.__class__  
+        return new_tensor
 
     @classmethod
     def _docarray_from_ndarray(cls: Type[T], value: np.ndarray) -> T:

--- a/tests/integrations/typing/test_torch_tensor.py
+++ b/tests/integrations/typing/test_torch_tensor.py
@@ -28,6 +28,7 @@ def test_set_torch_embedding():
     assert isinstance(d.embedding, torch.Tensor)
     assert (d.embedding == torch.zeros((128,))).all()
 
+
 def test_torchtensor_deepcopy():
     # Setup
     original_tensor_float = TorchTensor(torch.rand(10))

--- a/tests/integrations/typing/test_torch_tensor.py
+++ b/tests/integrations/typing/test_torch_tensor.py
@@ -1,4 +1,6 @@
 import torch
+from docarray.typing.tensor.torch_tensor import TorchTensor
+import copy
 
 from docarray import BaseDoc
 from docarray.typing import TorchEmbedding, TorchTensor
@@ -25,3 +27,18 @@ def test_set_torch_embedding():
     assert isinstance(d.embedding, TorchEmbedding)
     assert isinstance(d.embedding, torch.Tensor)
     assert (d.embedding == torch.zeros((128,))).all()
+
+def test_torchtensor_deepcopy():
+    # Setup
+    original_tensor_float = TorchTensor(torch.rand(10))
+    original_tensor_int = TorchTensor(torch.randint(0, 100, (10,)))
+
+    # Exercise
+    copied_tensor_float = copy.deepcopy(original_tensor_float)
+    copied_tensor_int = copy.deepcopy(original_tensor_int)
+
+    # Verify
+    assert torch.equal(original_tensor_float, copied_tensor_float)
+    assert original_tensor_float is not copied_tensor_float
+    assert torch.equal(original_tensor_int, copied_tensor_int)
+    assert original_tensor_int is not copied_tensor_int


### PR DESCRIPTION
Issue no : #1831 

The primary purpose of adding the __deepcopy__ method is to provide a more controlled and tailored approach to deep copying instances of the TorchTensor class. This helps prevent any unexpected behaviors arising from shared references to the same memory.