### PR TITLE
docs: fix sign commit commad in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Commits need to be signed. Indeed, the DocArray repo enforces the [Developer Cer
 To sign your commits you need to [use the `-s` argument](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) when committing:
 
 ```
-git commit -m -s 'feat: add a new feature'
+git commit -S -m 'feat: add a new feature'
 ```
 
 #### What if I mess up?


### PR DESCRIPTION
![Screenshot_3](https://github.com/docarray/docarray/assets/68547750/84454e8f-85f2-44f7-a1ed-4d1170f7d2ce)

The command is not correct in the CONTRIBRUTING.md file
in this commit the command is corrected in the file