### PR TITLE
Fixed incorrect type hint in hnswlib.py

### DIFF
--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -641,7 +641,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
         queries: np.ndarray,
         limit: int,
         search_field: str = '',
-        hashed_ids: Optional[Set[str]] = None,
+        hashed_ids: Optional[Set[int]] = None,
     ) -> _FindResultBatched:
         """
         Executes a search and filter operation on the database.


### PR DESCRIPTION
The `filter` parameter in `knn_query(data, k = 1, num_threads = -1, filter = None)` accepts an iterable of `int`, instead of `str`.

Accordingly, `hashed_ids` in `_search_and_filter(self, queries, limit, search_field = '', hashed_ids = None,` shall be `Optional[Set[int]]`.