### PR TITLE
Hotfix/optional leaf object

### DIFF
--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -178,6 +178,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
+
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 
@@ -197,6 +198,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
+
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -178,7 +178,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
-
+        print('_get_field_annsotation23', is_pydantic_v2, field, cls._docarray_fields()[field].outer_type_)
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 
@@ -198,7 +198,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
-
+        print('_get_field_inner_type-is_pydantic_v2', field, is_pydantic_v2)
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 
@@ -539,6 +539,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param allow_pickle: allow pickle protocol
         :return: a document
         """
+        print('parse_raw', b)
         return super(BaseDocWithoutId, cls).parse_raw(
             b,
             content_type=content_type,
@@ -569,6 +570,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
             exclude = dict(**exclude)
             exclude.update({field: ... for field in docarray_exclude_fields})
 
+        print('docarray_exclude_fields', docarray_exclude_fields)
         return (
             exclude,
             original_exclude,

--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -178,7 +178,6 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
-        print('_get_field_annsotation23', is_pydantic_v2, field, cls._docarray_fields()[field].outer_type_)
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 
@@ -198,7 +197,6 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param field: name of the field
         :return:
         """
-        print('_get_field_inner_type-is_pydantic_v2', field, is_pydantic_v2)
         if is_pydantic_v2:
             annotation = cls._docarray_fields()[field].annotation
 
@@ -539,7 +537,6 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
         :param allow_pickle: allow pickle protocol
         :return: a document
         """
-        print('parse_raw', b)
         return super(BaseDocWithoutId, cls).parse_raw(
             b,
             content_type=content_type,
@@ -570,7 +567,6 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
             exclude = dict(**exclude)
             exclude.update({field: ... for field in docarray_exclude_fields})
 
-        print('docarray_exclude_fields', docarray_exclude_fields)
         return (
             exclude,
             original_exclude,

--- a/docarray/index/abstract.py
+++ b/docarray/index/abstract.py
@@ -761,9 +761,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
                 leaf_doc: BaseDoc = doc
                 for f in fields[:-1]:
                     leaf_doc = getattr(leaf_doc, f)
-                if leaf_doc is None:
-                    leaf_vals.append(None)
-                else:
+                if leaf_doc is not None:
                     leaf_vals.append(getattr(leaf_doc, fields[-1]))
             else:
                 leaf_vals.append(getattr(doc, col_name))
@@ -802,6 +800,7 @@ class BaseDocIndex(ABC, Generic[TSchema]):
                     self._get_values_by_column([doc], col_name)[0],
                     allow_passthrough=True,
                 )
+                if len(self._get_values_by_column([doc], col_name)) > 0 else self._to_numpy(None, allow_passthrough=True)
                 for doc in docs_seq
             )
 
@@ -1148,8 +1147,6 @@ class BaseDocIndex(ABC, Generic[TSchema]):
         for col_name, col in self._column_infos.items():
             if safe_issubclass(col.docarray_type, AnyDocArray):
                 col_data = column_to_data[col_name]
-                if col_data is None:
-                    continue
                 docs = [
                     doc for doc_list in col_data for doc in (doc_list if doc_list is not None else [])
                 ]

--- a/docarray/index/backends/elastic.py
+++ b/docarray/index/backends/elastic.py
@@ -432,6 +432,8 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         es_rows = self._client_mget(doc_ids)['docs']
 
         for row in es_rows:
+            if len(row) < 1:
+                continue
             if row['found']:
                 doc_dict = row['_source']
                 accumulated_docs.append(doc_dict)
@@ -565,7 +567,7 @@ class ElasticDocIndex(BaseDocIndex, Generic[TSchema]):
         resp = self._client_search(
             query={'term': {'parent_id': id}}, fields=['id'], _source=False
         )
-        ids = [hit['fields']['id'][0] for hit in resp['hits']['hits']]
+        ids = [hit['fields']['id'][0] if 'fields' in hit and 'id' in hit['fields'] else hit['_id'] for hit in resp['hits']['hits']]
         return ids
 
     ###############################################

--- a/docarray/index/backends/hnswlib.py
+++ b/docarray/index/backends/hnswlib.py
@@ -442,7 +442,7 @@ class HnswDocumentIndex(BaseDocIndex, Generic[TSchema]):
             raise ValueError(
                 'The Document id is None. To use DocumentIndex it needs to be set.'
             )
-        return int(hashlib.sha256(doc_id.encode('utf-8')).hexdigest(), 16) % 10**18
+        return int(hashlib.sha256(str(doc_id).encode('utf-8')).hexdigest(), 16) % 10**18
 
     def _load_index(self, col_name: str, col: '_ColumnInfo') -> hnswlib.Index:
         """Load an existing HNSW index from disk."""


### PR DESCRIPTION
This PR aims to improve `DocList` fields that are `Optional` or that are given `None` default value. Giving empty `[]` as default value would create entries in the subindex (with just the ID field, no other data), so I opted for `None`.

The biggest issue that this PR aims to solve is `DocList` type fields would be required no matter if they have a default value or are marked as `Optional`.