### PR TITLE
Adds QueryBuilder to MongoDBAtlasDocumentIndex

### DIFF
--- a/docarray/index/backends/helper.py
+++ b/docarray/index/backends/helper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Type, cast
+from typing import Any, Dict, List, Tuple, Type, cast, Set
 
 from docarray import BaseDoc, DocList
 from docarray.index.abstract import BaseDocIndex
@@ -14,6 +14,43 @@ def _collect_query_args(method_name: str):  # TODO: use partialmethod instead
                 f'`{type(self)}.{method_name}`.'
                 f' Use keyword arguments instead.'
             )
+        updated_query = self._queries + [(method_name, kwargs)]
+        return type(self)(updated_query)
+
+    return inner
+
+
+def _collect_query_required_args(method_name: str, required_args: Set[str] = None):
+    """
+    Returns a function that ensures required keyword arguments are provided.
+
+    :param method_name: The name of the method for which the required arguments are being checked.
+    :type method_name: str
+    :param required_args: A set containing the names of required keyword arguments. Defaults to None.
+    :type required_args: Optional[Set[str]]
+    :return: A function that checks for required keyword arguments before executing the specified method.
+        Raises ValueError if positional arguments are provided.
+        Raises TypeError if any required keyword argument is missing.
+    :rtype: Callable
+    """
+
+    if required_args is None:
+        required_args = set()
+
+    def inner(self, *args, **kwargs):
+        if args:
+            raise ValueError(
+                f"Positional arguments are not supported for "
+                f"`{type(self)}.{method_name}`. "
+                f"Use keyword arguments instead."
+            )
+
+        missing_args = required_args - set(kwargs.keys())
+        if missing_args:
+            raise ValueError(
+                f"`{type(self)}.{method_name}` is missing required argument(s): {', '.join(missing_args)}"
+            )
+
         updated_query = self._queries + [(method_name, kwargs)]
         return type(self)(updated_query)
 

--- a/docarray/index/backends/mongodb_atlas.py
+++ b/docarray/index/backends/mongodb_atlas.py
@@ -65,7 +65,6 @@ class MongoDBAtlasDocumentIndex(BaseDocIndex, Generic[TSchema]):
     def __init__(self, db_config=None, **kwargs):
         super().__init__(db_config=db_config, **kwargs)
         logger.info(f'{self.__class__.__name__} has been initialized')
-        # TODO -Allow one to specify the Collection name. This is done in DBConfig()
 
     @property
     def index_name(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,5 +165,6 @@ markers = [
     "index: marks test using a document index",
     "benchmark: marks slow benchmarking tests",
     "elasticv8: marks test that run with ElasticSearch v8",
-    "jac: need to have access to jac cloud"
+    "jac: need to have access to jac cloud",
+    "atlas: mark tests using MongoDB Atlas",
 ]

--- a/tests/index/mongo_atlas/__init__.py
+++ b/tests/index/mongo_atlas/__init__.py
@@ -26,8 +26,7 @@ class NestedDoc(BaseDoc):
 
 class FlatSchema(BaseDoc):
     embedding1: NdArray = Field(dim=N_DIM, index_name="vector_index_1")
-    # the dim and N_DIM are setted different on propouse. to check the correct handling of n_dim
-    embedding2: NdArray[50] = Field(dim=N_DIM, index_name="vector_index_2")
+    embedding2: NdArray = Field(dim=N_DIM, index_name="vector_index_2")
 
 
 def assert_when_ready(callable: Callable, tries: int = 5, interval: float = 2):
@@ -40,7 +39,7 @@ def assert_when_ready(callable: Callable, tries: int = 5, interval: float = 2):
         except AssertionError:
             tries -= 1
             if tries == 0:
-                raise
+                raise RuntimeError("Retries exhausted.")
             time.sleep(interval)
         else:
             return

--- a/tests/index/mongo_atlas/__init__.py
+++ b/tests/index/mongo_atlas/__init__.py
@@ -36,10 +36,10 @@ def assert_when_ready(callable: Callable, tries: int = 5, interval: float = 2):
     while True:
         try:
             callable()
-        except AssertionError:
+        except AssertionError as e:
             tries -= 1
             if tries == 0:
-                raise RuntimeError("Retries exhausted.")
+                raise RuntimeError("Retries exhausted.") from e
             time.sleep(interval)
         else:
             return

--- a/tests/index/mongo_atlas/conftest.py
+++ b/tests/index/mongo_atlas/conftest.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from docarray.index import MongoDBAtlasDocumentIndex
+
 from . import NestedDoc, SimpleDoc, SimpleSchema
 
 
@@ -19,7 +20,9 @@ def mongodb_index_config():
 @pytest.fixture
 def simple_index(mongodb_index_config):
 
-    index = MongoDBAtlasDocumentIndex[SimpleSchema](index_name="bespoke_name", **mongodb_index_config)
+    index = MongoDBAtlasDocumentIndex[SimpleSchema](
+        index_name="bespoke_name", **mongodb_index_config
+    )
     return index
 
 
@@ -36,7 +39,7 @@ def n_dim():
 
 @pytest.fixture(scope='module')
 def embeddings(n_dim):
-    """ A consistent, reasonable, mock of vector embeddings, in [-1, 1]."""
+    """A consistent, reasonable, mock of vector embeddings, in [-1, 1]."""
     x = np.linspace(-np.pi, np.pi, n_dim)
     y = np.arange(n_dim)
     return np.sin(x[np.newaxis, :] + y[:, np.newaxis])

--- a/tests/index/mongo_atlas/test_find.py
+++ b/tests/index/mongo_atlas/test_find.py
@@ -8,13 +8,11 @@ from docarray.typing import NdArray
 
 from . import NestedDoc, SimpleDoc, SimpleSchema, assert_when_ready
 
-N_DIM = 10
 
-
-def test_find_simple_schema(simple_index_with_docs):  # noqa: F811
+def test_find_simple_schema(simple_index_with_docs, n_dim):  # noqa: F811
 
     simple_index, random_simple_documents = simple_index_with_docs  # noqa: F811
-    query = np.ones(N_DIM)
+    query = np.ones(n_dim)
 
     # Insert one doc that identically matches query's embedding
     expected_matching_document = SimpleSchema(embedding=query, text="other", number=10)
@@ -29,8 +27,8 @@ def test_find_simple_schema(simple_index_with_docs):  # noqa: F811
     assert_when_ready(pred)
 
 
-def test_find_empty_index(simple_index):  # noqa: F811
-    query = np.random.rand(N_DIM)
+def test_find_empty_index(simple_index, n_dim):  # noqa: F811
+    query = np.random.rand(n_dim)
 
     def pred():
         docs, scores = simple_index.find(query, search_field='embedding', limit=5)
@@ -40,10 +38,10 @@ def test_find_empty_index(simple_index):  # noqa: F811
     assert_when_ready(pred)
 
 
-def test_find_limit_larger_than_index(simple_index_with_docs):  # noqa: F811
+def test_find_limit_larger_than_index(simple_index_with_docs, n_dim):  # noqa: F811
     simple_index, random_simple_documents = simple_index_with_docs  # noqa: F811
 
-    query = np.ones(N_DIM)
+    query = np.ones(n_dim)
     new_doc = SimpleSchema(embedding=query, text="other", number=10)
 
     simple_index.index(new_doc)
@@ -56,29 +54,29 @@ def test_find_limit_larger_than_index(simple_index_with_docs):  # noqa: F811
     assert_when_ready(pred)
 
 
-def test_find_flat_schema(mongodb_index_config):  # noqa: F811
+def test_find_flat_schema(mongodb_index_config, n_dim):  # noqa: F811
     class FlatSchema(BaseDoc):
-        embedding1: NdArray = Field(dim=N_DIM, index_name="vector_index_1")
-        # the dim and N_DIM are setted different on propouse. to check the correct handling of n_dim
-        embedding2: NdArray[50] = Field(dim=N_DIM, index_name="vector_index_2")
+        embedding1: NdArray = Field(dim=n_dim, index_name="vector_index_1")
+        # the dim and n_dim are setted different on propouse. to check the correct handling of n_dim
+        embedding2: NdArray[50] = Field(dim=n_dim, index_name="vector_index_2")
 
     index = MongoDBAtlasDocumentIndex[FlatSchema](**mongodb_index_config)
 
-    index._doc_collection.delete_many({})
+    index._collection.delete_many({})
 
     index_docs = [
-        FlatSchema(embedding1=np.random.rand(N_DIM), embedding2=np.random.rand(50))
+        FlatSchema(embedding1=np.random.rand(n_dim), embedding2=np.random.rand(50))
         for _ in range(10)
     ]
 
-    index_docs.append(FlatSchema(embedding1=np.zeros(N_DIM), embedding2=np.ones(50)))
-    index_docs.append(FlatSchema(embedding1=np.ones(N_DIM), embedding2=np.zeros(50)))
+    index_docs.append(FlatSchema(embedding1=np.zeros(n_dim), embedding2=np.ones(50)))
+    index_docs.append(FlatSchema(embedding1=np.ones(n_dim), embedding2=np.zeros(50)))
     index.index(index_docs)
 
     def pred1():
 
         # find on embedding1
-        query = np.ones(N_DIM)
+        query = np.ones(n_dim)
         docs, scores = index.find(query, search_field='embedding1', limit=5)
         assert len(docs) == 5
         assert len(scores) == 5
@@ -116,10 +114,10 @@ def test_find_batches(simple_index_with_docs):  # noqa: F811
     assert_when_ready(pred)
 
 
-def test_find_nested_schema(nested_index_with_docs):  # noqa: F811
+def test_find_nested_schema(nested_index_with_docs, n_dim):  # noqa: F811
     db, base_docs = nested_index_with_docs
 
-    query = NestedDoc(d=SimpleDoc(embedding=np.ones(N_DIM)), embedding=np.ones(N_DIM))
+    query = NestedDoc(d=SimpleDoc(embedding=np.ones(n_dim)), embedding=np.ones(n_dim))
 
     # find on root level
     def pred():
@@ -137,11 +135,11 @@ def test_find_nested_schema(nested_index_with_docs):  # noqa: F811
     assert_when_ready(pred)
 
 
-def test_find_schema_without_index(mongodb_index_config):  # noqa: F811
+def test_find_schema_without_index(mongodb_index_config, n_dim):  # noqa: F811
     class Schema(BaseDoc):
-        vec: NdArray = Field(dim=N_DIM)
+        vec: NdArray = Field(dim=n_dim)
 
     index = MongoDBAtlasDocumentIndex[Schema](**mongodb_index_config)
-    query = np.ones(N_DIM)
+    query = np.ones(n_dim)
     with pytest.raises(ValueError):
         index.find(query, search_field='vec', limit=2)

--- a/tests/index/mongo_atlas/test_persist_data.py
+++ b/tests/index/mongo_atlas/test_persist_data.py
@@ -5,7 +5,8 @@ from . import SimpleSchema, assert_when_ready
 
 def test_persist(mongodb_index_config, random_simple_documents):  # noqa: F811
     index = MongoDBAtlasDocumentIndex[SimpleSchema](**mongodb_index_config)
-    index._doc_collection.delete_many({})
+    index._collection.delete_many({})
+
 
     def cleaned_database():
         assert index.num_docs() == 0

--- a/tests/index/mongo_atlas/test_persist_data.py
+++ b/tests/index/mongo_atlas/test_persist_data.py
@@ -7,7 +7,6 @@ def test_persist(mongodb_index_config, random_simple_documents):  # noqa: F811
     index = MongoDBAtlasDocumentIndex[SimpleSchema](**mongodb_index_config)
     index._collection.delete_many({})
 
-
     def cleaned_database():
         assert index.num_docs() == 0
 

--- a/tests/index/mongo_atlas/test_query_builder.py
+++ b/tests/index/mongo_atlas/test_query_builder.py
@@ -1,0 +1,343 @@
+import numpy as np
+import pytest
+
+from . import assert_when_ready
+
+
+def test_missing_required_var_exceptions(simple_index):  # noqa: F811
+    """Ensure that exceptions are raised when required arguments are not provided."""
+
+    with pytest.raises(ValueError):
+        simple_index.build_query().find().build()
+
+    with pytest.raises(ValueError):
+        simple_index.build_query().text_search().build()
+
+    with pytest.raises(ValueError):
+        simple_index.build_query().filter().build()
+
+
+def test_find_uses_provided_vector(simple_index):  # noqa: F811
+    query = (
+        simple_index.build_query().find(query=np.ones(10), search_field='embedding').build(7)
+    )
+
+    query_vector = query.vector_fields.pop('embedding')
+    assert query.vector_fields == {}
+    assert np.allclose(query_vector, np.ones(10))
+    assert query.filters == []
+    assert query.limit == 7
+
+
+def test_multiple_find_returns_averaged_vector(simple_index, n_dim):  # noqa: F811
+    query = (
+        simple_index.build_query()  # type: ignore[attr-defined]
+        .find(query=np.ones(n_dim), search_field='embedding')
+        .find(query=np.zeros(n_dim), search_field='embedding')
+        .build(5)
+    )
+
+    assert len(query.vector_fields) == 1
+    query_vector = query.vector_fields.pop('embedding')
+    assert query.vector_fields == {}
+    assert np.allclose(query_vector, np.array([0.5] * n_dim))
+    assert query.filters == []
+    assert query.limit == 5
+
+
+def test_filter_passes_filter(simple_index):  # noqa: F811
+    index = simple_index
+
+    filter = {"number": {"$lt": 1}}
+    query = index.build_query().filter(query=filter).build(limit=11)  # type: ignore[attr-defined]
+
+    assert query.vector_fields == {}
+    assert query.filters == [{"query": filter}]
+    assert query.limit == 11
+
+
+def test_execute_query_find_filter(simple_index_with_docs, n_dim):  # noqa: F811
+    """Tests filters passed to vector search behave as expected"""
+    index, _ = simple_index_with_docs
+
+    find_query = np.ones(n_dim)
+    filter_query1 = {"number": {"$lt": 8}}
+    filter_query2 = {"number": {"$gt": 5}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .filter(query=filter_query1)
+        .filter(query=filter_query2)
+        .build(limit=5)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+        assert len(res.documents) == 2
+        assert set(res.documents.number) == {6, 7}
+
+    assert_when_ready(trial)
+
+
+def test_execute_only_filter(
+    simple_index_with_docs,  # noqa: F811
+):
+    index, _ = simple_index_with_docs
+
+    filter_query1 = {"number": {"$lt": 8}}
+    filter_query2 = {"number": {"$gt": 5}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .filter(query=filter_query1)
+        .filter(query=filter_query2)
+        .build(limit=5)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+
+        assert len(res.documents) == 2
+        assert set(res.documents.number) == {6, 7}
+
+    assert_when_ready(trial)
+
+
+def test_execute_text_search_with_filter(
+    simple_index_with_docs,  # noqa: F811
+):
+    """Note: Text search returns only matching _, not limit."""
+    index, _ = simple_index_with_docs
+
+    filter_query1 = {"number": {"$eq": 0}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .filter(query=filter_query1)
+        .build(limit=5)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+
+        assert len(res.documents) == 1
+        assert set(res.documents.number) == {0}
+
+    assert_when_ready(trial)
+
+
+def test_find(
+    simple_index_with_docs, n_dim,  # noqa: F811
+):
+    index, _ = simple_index_with_docs
+    limit = 3
+    # Base Case: No filters, single text search, single vector search
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=np.ones(n_dim), search_field='embedding')
+        .build(limit=limit)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+        assert len(res.documents) == limit
+        assert res.documents.number == [5, 4, 6]
+    assert_when_ready(trial)
+
+
+def test_hybrid_search(
+    simple_index_with_docs, n_dim  # noqa: F811
+):
+    find_query = np.ones(n_dim)
+    index, docs = simple_index_with_docs
+    n_docs = len(docs)
+    limit = n_docs
+
+    # Base Case: No filters, single text search, single vector search
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=limit)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+        assert len(res.documents) == limit
+        assert set(res.documents.number) == set(range(n_docs))
+    assert_when_ready(trial)
+
+    # Now that we've successfully executed a query, we know that the search indexes have been built
+    # We no longer need to sleep and retry. Re-run to keep results
+    res_base = index.execute_query(query)
+
+    # Case 2: Base plus a filter
+    filter_query1 = {"number": {"$gt": 0}}
+
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .filter(query=filter_query1)
+        .build(limit=n_docs)
+    )
+
+    res = index.execute_query(query)
+    assert len(res.documents) == 9
+    assert set(res.documents.number) == set(range(1, n_docs))
+
+    # Case 3: Base with, but matching, additional vector search component
+    # As we are using averaging to combine embedding vectors, this is a no-op
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .find(query=find_query, search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=n_docs)
+    )
+    res3 = index.execute_query(query)
+    assert res3.documents.number == res_base.documents.number
+
+    # Case 4: Base with, but perpendicular, additional vector search component
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        # .find(query=find_query, search_field='embedding')
+        .find(query=np.random.standard_normal(find_query.shape), search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=n_docs)
+    )
+    res4 = index.execute_query(query)
+    assert res4.documents.number != res_base.documents.number
+
+    # Case 5: Multiple text searches
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .text_search(query="classical music compositions", search_field='text')
+        .build(limit=n_docs)
+    )
+    res5 = index.execute_query(query)
+    assert res5.documents.number[:2] == [0, 3]
+
+    # Case 6: Multiple text search with filters
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=find_query, search_field='embedding')
+        .filter(query={"number": {"$gt": 0}})
+        .text_search(query="classical music compositions", search_field='text')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=n_docs)
+    )
+    res6 = index.execute_query(query)
+    assert res6.documents.number[0] == 3
+
+
+def test_hybrid_search_multiple_text(
+    simple_index_with_docs, n_dim  # noqa: F811
+):
+    """Tests disambiguation of scores on multiple text searches on same field."""
+
+    index, _ = simple_index_with_docs
+    limit = 10
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .text_search(query="classical music compositions", search_field='text')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .find(query=np.ones(n_dim), search_field='embedding')
+        .build(limit=limit)
+    )
+
+    def trial():
+        res = index.execute_query(query, score_breakdown=True)
+        assert len(res.documents) == limit
+        assert res.documents.number == [0, 3, 5, 4, 6, 9, 7, 1, 2, 8]
+
+    assert_when_ready(trial)
+
+
+def test_hybrid_search_only_text(
+    simple_index_with_docs  # noqa: F811
+):
+    """Query built with two text searches will be a Hybrid Search.
+
+     It will return only two results.
+     In our case, each text matches just one document, hence we will receive two results, each top ranked
+     """
+    index, _ = simple_index_with_docs
+    limit = 10
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .text_search(query="classical music compositions", search_field='text')
+        .text_search(query="Python is a valuable skill", search_field='text')
+        .build(limit=limit)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+        assert len(res.documents) != limit
+        # Instead, we find the number of documents containing one of these phrases
+        assert len(res.documents) == len(query.text_searches)
+        assert set(res.documents.number) == {0, 3}
+        assert set(res.scores) == {0.5, 0.5}
+
+    assert_when_ready(trial)
+
+
+def test_hybrid_search_only_vector(
+    simple_index_with_docs, n_dim  # noqa: F811
+):
+
+    limit = 3
+    index, _ = simple_index_with_docs
+    query = (
+        index.build_query()  # type: ignore[attr-defined]
+        .find(query=np.ones(n_dim), search_field='embedding')
+        .find(query=np.zeros(n_dim), search_field='embedding')
+        .build(limit=limit)
+    )
+
+    def trial():
+        res = index.execute_query(query)
+        assert len(res.documents) == limit
+        assert res.documents.number == [5, 4, 6]
+    assert_when_ready(trial)
+
+
+@pytest.mark.skip
+def test_hybrid_search_vectors_with_different_fields(mongodb_index_config):  # noqa: F811
+    """Hybrid Search involving queries to two different vector indexes.
+
+    # TODO - To be added in an upcoming release.
+    """
+
+    from docarray.index.backends.mongodb_atlas import MongoDBAtlasDocumentIndex
+    from tests.index.mongo_atlas import FlatSchema
+    multi_index = MongoDBAtlasDocumentIndex[FlatSchema](**mongodb_index_config)
+    multi_index._collection.delete_many({})
+
+    n_dim = 25
+    n_docs = 5
+    data = [FlatSchema(embedding1=np.random.standard_normal(n_dim),
+                       embedding2=np.random.standard_normal(n_dim)) for _ in range(n_docs)]
+    multi_index.index(data)
+    yield multi_index
+    multi_index._collection.delete_many({})
+
+
+    limit = 3
+    query = (
+        flat_multiple_index.build_query()  # type: ignore[attr-defined]
+        .find(query=np.ones(n_dim), search_field='embedding1')
+        .find(query=np.zeros(n_dim), search_field='embedding2')
+        .build(limit=limit)
+    )
+
+    with pytest.raises(NotImplementedError):
+        def trial():
+            res = multi_index.execute_query(query)
+            assert len(res.documents) == limit
+            assert res.documents.number == [5, 4, 6]
+        assert_when_ready(trial)

--- a/tests/index/mongo_atlas/test_subindex.py
+++ b/tests/index/mongo_atlas/test_subindex.py
@@ -53,7 +53,7 @@ class MyDoc(BaseDoc):
 def clean_subindex(index):
     for subindex in index._subindices.values():
         clean_subindex(subindex)
-    index._doc_collection.delete_many({})
+    index._collection.delete_many({})
 
 
 @pytest.fixture(scope='session')
@@ -262,6 +262,4 @@ def test_subindex_del(index):
 
 def test_subindex_collections(mongodb_index_config):  # noqa: F811
     doc_index = MongoDBAtlasDocumentIndex[MetaCategoryDoc](**mongodb_index_config)
-
     assert doc_index._subindices["paths"].index_name == 'metacategorydoc__paths'
-    assert doc_index._subindices["paths"]._collection == 'metacategorydoc__paths'

--- a/tests/index/mongo_atlas/test_text_search.py
+++ b/tests/index/mongo_atlas/test_text_search.py
@@ -9,7 +9,7 @@ def test_text_search(simple_index_with_docs):  # noqa: F811
 
     def pred():
         docs, scores = simple_index.text_search(
-            query=query_string, search_field='text', limit=1
+            query=query_string, search_field='text', limit=10
         )
         assert len(docs) == 1
         assert docs[0].text == expected_text


### PR DESCRIPTION
## Description
This pull request adds `QueryBuilder` functionality to the existing  `MongoDBAtlasDocumentIndex`.

## Example Usage

```python
from docarray.index import MongoAtlasDocumentIndex
import numpy as np

NDIM = 10

class MyDoc(BaseDoc):
    text: str
    embedding: NdArray[NDIM]
    number: int

docs = [MyDoc(text=f'text {i}', embedding=np.random.randn(NDIM), number=i) for i in range(5)]
index = MongoAtlasDocumentIndex[MyDoc](mongo_connection_uri='localhost')
index.index(docs)
    query = (
        index.build_query()
        .find(query=np.ones(NDIM), search_field='embedding')
        .filter(query={"number": {"$gt": 0}})
        .text_search(query="text 3", search_field='text')
        .build(limit=n_docs)
```

## Supported Functionality
Atlas offers full-text, vector, and hybrid search. 
For documentation, see the following.
* Text Search: https://www.mongodb.com/docs/atlas/atlas-search/atlas-search-overview/
* Vector Search: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/
* Hybrid Search: https://www.mongodb.com/docs/atlas/atlas-vector-search/tutorials/reciprocal-rank-fusion/

## Integration Tests and documentation
- `tests/index/mongo_atlas` 
- `docs/API_reference/doc_index/backends/mongodb.md`