### PR TITLE
replace usage of `issubclass` with `safe_issubclass` in `BaseDocWitho…

### DIFF
--- a/docarray/base_doc/doc.py
+++ b/docarray/base_doc/doc.py
@@ -326,7 +326,7 @@ class BaseDocWithoutId(BaseModel, IOMixin, UpdateMixin, BaseNode):
             from docarray.array.any_array import AnyDocArray
 
             type_ = self._get_field_annotation(field)
-            if isinstance(type_, type) and issubclass(type_, AnyDocArray):
+            if isinstance(type_, type) and safe_issubclass(type_, AnyDocArray):
                 doclist_exclude_fields.append(field)
 
         original_exclude = exclude

--- a/docarray/index/backends/milvus.py
+++ b/docarray/index/backends/milvus.py
@@ -192,7 +192,7 @@ class MilvusDocumentIndex(BaseDocIndex, Generic[TSchema]):
             AbstractTensor: DataType.FLOAT_VECTOR,
         }
 
-        if issubclass(python_type, ID):
+        if safe_issubclass(python_type, ID):
             return DataType.VARCHAR
 
         for py_type, db_type in type_map.items():
@@ -665,7 +665,7 @@ class MilvusDocumentIndex(BaseDocIndex, Generic[TSchema]):
         if search_field:
             if '__' in search_field:
                 fields = search_field.split('__')
-                if issubclass(self._schema._get_field_annotation(fields[0]), AnyDocArray):  # type: ignore
+                if safe_issubclass(self._schema._get_field_annotation(fields[0]), AnyDocArray):  # type: ignore
                     return self._subindices[fields[0]].find_batched(
                         queries,
                         search_field='__'.join(fields[1:]),


### PR DESCRIPTION
- replaces usage of `issubclass` with `safe_issubclass` in `BaseDocWithoutID` and `MilvusDocumentIndex`
- remaining usage of `issubclass` are in `safe_issubclass` function and tests only

Fixes #1903