### PR TITLE
Make docstring a raw string to avoid `SyntaxWarning`

### DIFF
--- a/docarray/helper.py
+++ b/docarray/helper.py
@@ -221,7 +221,7 @@ def get_paths(
     size: Optional[int] = None,
     exclude_regex: Optional[str] = None,
 ) -> Generator[str, None, None]:
-    """
+    r"""
     Yield file paths described by `patterns`.
 
     ---


### PR DESCRIPTION
Currently, running `docarray/helper.py` will emit a `SyntaxWarning` due to invalid escape sequences in the docstring for `get_paths`. Making it a raw-string is a simple fix to this.