### PR TITLE
Fix scalar coercion (#1914)

### DIFF
--- a/docarray/typing/tensor/jaxarray.py
+++ b/docarray/typing/tensor/jaxarray.py
@@ -142,7 +142,10 @@ class JaxArray(AbstractTensor, Generic[ShapeT], metaclass=metaJax):
                 pass  # handled below
         elif isinstance(value, str):
             value = orjson.loads(value)
-
+        # Handle scalar values (int, float, etc.) - wrap in 1D array
+        elif isinstance(value, (int, float, complex, bool, np.number)):
+            arr_from_scalar: jnp.ndarray = jnp.array([value])
+            return cls._docarray_from_native(arr_from_scalar)
         try:
             arr: jnp.ndarray = jnp.ndarray(value)
             return cls._docarray_from_native(arr)

--- a/docarray/typing/tensor/ndarray.py
+++ b/docarray/typing/tensor/ndarray.py
@@ -137,6 +137,10 @@ class NdArray(np.ndarray, AbstractTensor, Generic[ShapeT]):
                 return cls._docarray_from_native(arr_from_list)
             except Exception:
                 pass  # handled below
+        # Handle scalar values (int, float, etc.) - wrap in 1D array
+        elif isinstance(value, (int, float, complex, bool, np.number)):
+            arr_from_scalar: np.ndarray = np.array([value])
+            return cls._docarray_from_native(arr_from_scalar)
         try:
             arr: np.ndarray = np.ndarray(value)
             return cls._docarray_from_native(arr)

--- a/tests/units/typing/tensor/test_ndarray.py
+++ b/tests/units/typing/tensor/test_ndarray.py
@@ -31,7 +31,7 @@ def test_from_list():
 def test_from_scalar_int():
     """Test that scalar integers are properly converted to 1-dimensional arrays"""
     tensor = parse_obj_as(NdArray, 10)
-    
+
     assert isinstance(tensor, NdArray)
     assert isinstance(tensor, np.ndarray)
     # Scalar should be wrapped in 1-dimensional array
@@ -43,7 +43,7 @@ def test_from_scalar_int():
 def test_from_scalar_float():
     """Test that scalar floats are properly converted to 1-dimensional arrays"""
     tensor = parse_obj_as(NdArray, 10.5)
-    
+
     assert isinstance(tensor, NdArray)
     assert isinstance(tensor, np.ndarray)
     # Scalar should be wrapped in 1-dimensional array
@@ -54,20 +54,20 @@ def test_from_scalar_float():
 
 def test_from_scalar_complex():
     """Test that scalar complex numbers are properly converted to 1-dimensional arrays"""
-    tensor = parse_obj_as(NdArray, 3+4j)
-    
+    tensor = parse_obj_as(NdArray, 3 + 4j)
+
     assert isinstance(tensor, NdArray)
     assert isinstance(tensor, np.ndarray)
     # Scalar should be wrapped in 1-dimensional array
     assert tensor.shape == (1,)
-    assert tensor[0] == 3+4j
+    assert tensor[0] == 3 + 4j
     assert np.iscomplexobj(tensor)
 
 
 def test_from_scalar_bool():
     """Test that scalar booleans are properly converted to 1-dimensional arrays"""
     tensor = parse_obj_as(NdArray, True)
-    
+
     assert isinstance(tensor, NdArray)
     assert isinstance(tensor, np.ndarray)
     # Scalar should be wrapped in 1-dimensional array
@@ -78,14 +78,15 @@ def test_from_scalar_bool():
 
 def test_from_scalar_in_document():
     """Test that scalar values work correctly when used in a Document"""
+
     class MyDoc(BaseDoc):
         arr: NdArray
-    
+
     # Test with integer
     doc_int = MyDoc(arr=42)
     assert doc_int.arr.shape == (1,)
     assert doc_int.arr[0] == 42
-    
+
     # Test with float
     doc_float = MyDoc(arr=3.14)
     assert doc_float.arr.shape == (1,)

--- a/tests/units/typing/tensor/test_ndarray.py
+++ b/tests/units/typing/tensor/test_ndarray.py
@@ -28,6 +28,70 @@ def test_from_list():
     assert (tensor == np.zeros((2, 2))).all()
 
 
+def test_from_scalar_int():
+    """Test that scalar integers are properly converted to 1-dimensional arrays"""
+    tensor = parse_obj_as(NdArray, 10)
+    
+    assert isinstance(tensor, NdArray)
+    assert isinstance(tensor, np.ndarray)
+    # Scalar should be wrapped in 1-dimensional array
+    assert tensor.shape == (1,)
+    assert tensor[0] == 10
+    assert tensor.dtype in [np.int32, np.int64]  # Platform dependent
+
+
+def test_from_scalar_float():
+    """Test that scalar floats are properly converted to 1-dimensional arrays"""
+    tensor = parse_obj_as(NdArray, 10.5)
+    
+    assert isinstance(tensor, NdArray)
+    assert isinstance(tensor, np.ndarray)
+    # Scalar should be wrapped in 1-dimensional array
+    assert tensor.shape == (1,)
+    assert tensor[0] == 10.5
+    assert tensor.dtype in [np.float32, np.float64]
+
+
+def test_from_scalar_complex():
+    """Test that scalar complex numbers are properly converted to 1-dimensional arrays"""
+    tensor = parse_obj_as(NdArray, 3+4j)
+    
+    assert isinstance(tensor, NdArray)
+    assert isinstance(tensor, np.ndarray)
+    # Scalar should be wrapped in 1-dimensional array
+    assert tensor.shape == (1,)
+    assert tensor[0] == 3+4j
+    assert np.iscomplexobj(tensor)
+
+
+def test_from_scalar_bool():
+    """Test that scalar booleans are properly converted to 1-dimensional arrays"""
+    tensor = parse_obj_as(NdArray, True)
+    
+    assert isinstance(tensor, NdArray)
+    assert isinstance(tensor, np.ndarray)
+    # Scalar should be wrapped in 1-dimensional array
+    assert tensor.shape == (1,)
+    assert tensor[0] == True
+    assert tensor.dtype == np.bool_
+
+
+def test_from_scalar_in_document():
+    """Test that scalar values work correctly when used in a Document"""
+    class MyDoc(BaseDoc):
+        arr: NdArray
+    
+    # Test with integer
+    doc_int = MyDoc(arr=42)
+    assert doc_int.arr.shape == (1,)
+    assert doc_int.arr[0] == 42
+    
+    # Test with float
+    doc_float = MyDoc(arr=3.14)
+    assert doc_float.arr.shape == (1,)
+    assert doc_float.arr[0] == 3.14
+
+
 def test_json_schema():
     schema_json_of(NdArray)
 


### PR DESCRIPTION
This PR fixes Issue #1914, where scalar values (int, float, complex, bool, np.number) were not correctly coerced into NdArray or JaxArray. PR adds a complete test suite ensuring correct behavior for all scalar types

### Root Cause: 
np.ndarray(value) and jnp.ndarray(value) interpret numeric values as shapes, not as data. This resulted in:
-uninitialized arrays when value was an integer
-validation errors when value was a float
-no coercion for complex or boolean scalars

### 1. Updated NdArray validator
```
elif isinstance(value, (int, float, complex, bool, np.number)):
    arr_from_scalar = np.array([value])
    return cls._docarray_from_native(arr_from_scalar)

```
### 2. Updated JaxArray validator
```
elif isinstance(value, (int, float, complex, bool, np.number)):
    arr_from_scalar = jnp.array([value])
    return cls._docarray_from_native(arr_from_scalar)

```
### 3. New Tests added in test_ndarray.py
test_from_scalar_int
test_from_scalar_float
test_from_scalar_complex
test_from_scalar_bool
test_from_scalar_in_document

These tests confirm:
Scalars convert to (1,) shape, Values are preserved correctly , Dtypes are correct (int32/int64, float32/float64, complex, bool) ,Scalars work correctly when assigned as Document fields
